### PR TITLE
Fix external PiHole proxy configuration

### DIFF
--- a/kubernetes/clusters/homelab/apps/external-proxy/pihole.yaml
+++ b/kubernetes/clusters/homelab/apps/external-proxy/pihole.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: external-proxy
 spec:
   ports:
-    - name: http
-      port: 80
-      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443
 ---
 apiVersion: v1
 kind: Endpoints
@@ -19,8 +19,8 @@ subsets:
   - addresses:
       - ip: 192.168.10.2
     ports:
-      - name: http
-        port: 80
+      - name: https
+        port: 443
         protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1
@@ -34,19 +34,20 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-lan-allowlist@kubernetescrd
+    traefik.ingress.kubernetes.io/service.serverstransports: traefik-lan-https-insecure@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:
     - host: pihole.lan.${DOMAIN_NAME}
       http:
         paths:
-          - path: /
+          - path: /admin/
             pathType: Prefix
             backend:
               service:
                 name: pihole
                 port:
-                  name: http
+                  name: https
   tls:
     - hosts:
         - pihole.lan.${DOMAIN_NAME}


### PR DESCRIPTION
## Summary
- Correct PiHole service port from 80 to 443 (PiHole only serves HTTPS)
- Update Endpoints to target port 443 instead of 80
- Add serversTransport annotation to skip TLS verification for self-signed certificates
- Change ingress path from "/" to "/admin/" (PiHole returns 403 on root path)
- Fix serversTransport reference to use traefik namespace prefix

This resolves the "bad gateway" error when proxying external PiHole through cluster Traefik.