### PR TITLE
Fix pihole cross-namespace middleware and serversTransport references

### DIFF
--- a/kubernetes/clusters/homelab/apps/external-proxy/pihole.yaml
+++ b/kubernetes/clusters/homelab/apps/external-proxy/pihole.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: external-proxy
 spec:
   ports:
-    - name: http
-      port: 80
-      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443
 ---
 apiVersion: v1
 kind: Endpoints
@@ -19,8 +19,8 @@ subsets:
   - addresses:
       - ip: 192.168.10.2
     ports:
-      - name: http
-        port: 80
+      - name: https
+        port: 443
         protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1
@@ -34,19 +34,20 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-lan-allowlist@kubernetescrd
+    traefik.ingress.kubernetes.io/service.serverstransports: traefik-lan-https-insecure@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:
     - host: pihole.lan.${DOMAIN_NAME}
       http:
         paths:
-          - path: /
+          - path: /admin/
             pathType: Prefix
             backend:
               service:
                 name: pihole
                 port:
-                  name: http
+                  name: https
   tls:
     - hosts:
         - pihole.lan.${DOMAIN_NAME}

--- a/kubernetes/clusters/homelab/apps/external-proxy/pihole.yaml
+++ b/kubernetes/clusters/homelab/apps/external-proxy/pihole.yaml
@@ -4,6 +4,9 @@ kind: Service
 metadata:
   name: pihole
   namespace: external-proxy
+  annotations:
+    traefik.ingress.kubernetes.io/service.serversscheme: https
+    traefik.ingress.kubernetes.io/service.serverstransport: traefik-lan-https-insecure@kubernetescrd
 spec:
   ports:
     - name: https
@@ -34,7 +37,6 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-lan-allowlist@kubernetescrd
-    traefik.ingress.kubernetes.io/service.serverstransports: traefik-lan-https-insecure@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:


### PR DESCRIPTION
## Summary
- Move serversTransport annotation from Ingress to Service (correct placement per Traefik docs)
- Fix serversTransport annotation key from `service.serverstransports` to `service.serverstransport`  
- Add `service.serversscheme` annotation to specify HTTPS backend protocol
- Middleware reference format is correct: `traefik-lan-allowlist@kubernetescrd` (namespace-name@kubernetescrd)

This resolves the 500 error and TLS verification failures when proxying external PiHole through cluster Traefik.