### PR TITLE
Fix Grafana dashboards by enabling dashboard sidecar

### DIFF
--- a/kubernetes/clusters/homelab/infrastructure/observability/grafana/install/helmrelease.yaml
+++ b/kubernetes/clusters/homelab/infrastructure/observability/grafana/install/helmrelease.yaml
@@ -124,6 +124,7 @@ spec:
       dashboards:
         enabled: true
         SCProvider: true
+        folder: /var/lib/grafana/dashboards/default
 
     resources:
       requests:

--- a/kubernetes/clusters/homelab/infrastructure/observability/grafana/install/helmrelease.yaml
+++ b/kubernetes/clusters/homelab/infrastructure/observability/grafana/install/helmrelease.yaml
@@ -119,16 +119,11 @@ spec:
           gnetId: 20417
           datasource: Prometheus
 
-    dashboardProviders:
-      providers:
-        - name: 'default'
-          orgId: 1
-          folder: ''
-          type: file
-          disableDeletion: false
-          editable: false
-          options:
-            path: /var/lib/grafana/dashboards/default
+    # Enable dashboard sidecar to manage dashboard providers
+    sidecar:
+      dashboards:
+        enabled: true
+        SCProvider: true
 
     resources:
       requests:


### PR DESCRIPTION
- Remove incorrect dashboardProviders direct configuration
- Enable sidecar.dashboards sidecar with SCProvider enabled
- Allows Grafana to discover dashboard JSON files in PVC
- Fixes dashboards not showing in Grafana UI