### PR TITLE
feat(authentik): add outpost tls certificate

### DIFF
--- a/kubernetes/clusters/homelab/infrastructure/authentik/config/kustomization.yaml
+++ b/kubernetes/clusters/homelab/infrastructure/authentik/config/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - postgres-cluster.yaml
   - ingress.yaml
+  - outpost-certificate.yaml
   - authentik-podmonitor.yaml

--- a/kubernetes/clusters/homelab/infrastructure/authentik/config/outpost-certificate.yaml
+++ b/kubernetes/clusters/homelab/infrastructure/authentik/config/outpost-certificate.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: authentik-outpost-tls
+  namespace: authentik
+spec:
+  secretName: authentik-outpost-tls
+  duration: 2160h
+  renewBefore: 720h
+  dnsNames:
+    - "${DOMAIN_NAME}"
+    - "*.${DOMAIN_NAME}"
+    - "*.lan.${DOMAIN_NAME}"
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer


### PR DESCRIPTION
## Summary
- Added `outpost-certificate.yaml` to request a TLS certificate named `authentik-outpost-tls` for the Authentik Outpost.
- Updated `kustomization.yaml` to include the new certificate resource.

## Reasoning
The Authentik Outpost Ingress was failing to configure TLS because it expects a secret named `authentik-outpost-tls` to exist in the `authentik` namespace. This change ensures the certificate is automatically provisioned using cert-manager, resolving the Traefik error logs.