### PR TITLE
feat(kubernetes): add Gitea with Traefik TCP routing for SSH

### DIFF
--- a/kubernetes/apps/apps/development/gitea/helmrelease.yaml
+++ b/kubernetes/apps/apps/development/gitea/helmrelease.yaml
@@ -1,0 +1,68 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gitea
+  namespace: development
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    controllers:
+      main:
+        pod:
+          securityContext:
+            runAsUser: 99
+            runAsGroup: 100
+            fsGroup: 100
+            fsGroupChangePolicy: "OnRootMismatch"
+        containers:
+          main:
+            image:
+              repository: docker.gitea.com/gitea
+              tag: 1.25.3
+            env:
+              USER_UID: "99"
+              USER_GID: "100"
+            ports:
+              - name: http
+                containerPort: 3000
+              - name: ssh
+                containerPort: 22
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 3000
+            targetPort: 3000
+          ssh:
+            port: 22
+            targetPort: 22
+    ingress:
+      main:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: git.${CLUSTER_DOMAIN}
+        hosts:
+          - host: git.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        storageClass: longhorn-r2
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/apps/development/gitea/helmrelease.yaml
+++ b/kubernetes/apps/apps/development/gitea/helmrelease.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       chart: app-template
   values:
+    fullnameOverride: gitea
     controllers:
       main:
         pod:
@@ -22,8 +23,8 @@ spec:
               repository: docker.gitea.com/gitea
               tag: 1.25.3
             env:
-              USER_UID: "99"
-              USER_GID: "100"
+              USER_UID: 99
+              USER_GID: 100
             ports:
               - name: http
                 containerPort: 3000

--- a/kubernetes/apps/apps/development/gitea/ingressroutetcp.yaml
+++ b/kubernetes/apps/apps/development/gitea/ingressroutetcp.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: gitea-ssh
+  namespace: development
+spec:
+  entryPoints:
+    - ssh
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: gitea
+          namespace: development
+          port: 22

--- a/kubernetes/apps/apps/development/gitea/kustomization.yaml
+++ b/kubernetes/apps/apps/development/gitea/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+  - ../../../../components/common-env
+  - ../../../../components/ingress/traefik-base
+  - ../../../../components/storage/backup-policy
+resources:
+  - helmrelease.yaml
+  - ingressroutetcp.yaml

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ../apps/external-proxy
   - ../apps/automation/n8n
   - ../apps/media/audiobookshelf
+  - ../apps/development/gitea

--- a/kubernetes/infrastructure/config/namespaces.yaml
+++ b/kubernetes/infrastructure/config/namespaces.yaml
@@ -77,3 +77,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: automation
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: development

--- a/kubernetes/infrastructure/networking/traefik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/networking/traefik/install/helmrelease.yaml
@@ -42,6 +42,11 @@ spec:
       websecure:
         tls:
           enabled: true
+      ssh:
+        port: 22
+        expose:
+          default: true
+        protocol: TCP
       metrics:
         port: 9100
         expose:


### PR DESCRIPTION
## Summary
- Add Gitea self-hosted Git service to the development namespace
- Configure Traefik TCP routing to handle SSH on port 22
- Set up persistent storage with Longhorn (2Gi, 2 replicas) and automatic backups

## Key Features
- **Image**: docker.gitea.com/gitea:1.25.3
- **Storage**: 2Gi Longhorn volume with 2 replicas (longhorn-r2)
- **Security**: Runs as UID 99/GID 100 (Unraid-compatible)
- **Access**: Single domain for both HTTP and SSH via Traefik
- **Backups**: Automatic daily/weekly backups via backup-policy component

## Access URLs
- **Web UI**: `https://git.${CLUSTER_DOMAIN}`
- **Git Clone**: `git clone git@git.${CLUSTER_DOMAIN}:repo.git`

## Infrastructure Changes
- Added SSH entryPoint (port 22) to Traefik HelmRelease
- Created `development` namespace
- Added Gitea to production deployment pipeline

## Test plan
- [ ] Flux reconciles Gitea deployment successfully
- [ ] Web UI accessible at `https://git.${CLUSTER_DOMAIN}`
- [ ] Git clone/push works via SSH on port 22
- [ ] Longhorn volume provisioned with 2 replicas
- [ ] Backup labels applied to PVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)