### PR TITLE
fix(crowdsec): enable TLS for agent authentication

### DIFF
--- a/kubernetes/infrastructure/security/crowdsec/config/bouncer-middleware.yaml
+++ b/kubernetes/infrastructure/security/crowdsec/config/bouncer-middleware.yaml
@@ -8,7 +8,9 @@ spec:
     crowdsec-bouncer-traefik-plugin:
       enabled: true
       crowdsecMode: stream
+      crowdsecLapiScheme: https
       crowdsecLapiHost: crowdsec-service.crowdsec.svc.cluster.local:8080
+      crowdsecLapiTlsInsecure: true
       crowdsecLapiKeyFile: /etc/traefik/crowdsec-bouncer-api-key
       updateIntervalSeconds: 60
       logLevel: INFO

--- a/kubernetes/infrastructure/security/crowdsec/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/crowdsec/install/helmrelease.yaml
@@ -20,6 +20,18 @@ spec:
   values:
     container_runtime: containerd
 
+    # --- TLS Configuration ---
+    # Enables TLS for internal communication between LAPI and agents.
+    # Uses cert-manager to auto-generate a self-signed CA (no external validation needed).
+    # Agents authenticate via TLS client certs instead of registration tokens,
+    # eliminating "user already exists" errors on pod restarts.
+    tls:
+      enabled: true
+      certManager:
+        enabled: true
+      agent:
+        tlsClientAuth: true
+
     # --- LAPI Configuration ---
     lapi:
       replicas: 1
@@ -43,6 +55,7 @@ spec:
         httpGet:
           path: /health
           port: lapi
+          scheme: HTTPS
         failureThreshold: 6
         periodSeconds: 5
         timeoutSeconds: 3
@@ -52,6 +65,7 @@ spec:
         httpGet:
           path: /health
           port: lapi
+          scheme: HTTPS
         failureThreshold: 3
         periodSeconds: 10
         timeoutSeconds: 3


### PR DESCRIPTION
## Summary
- Fixes CrowdSec agent pods crashing with `user already exists` error on restart
- Enables TLS with cert-manager auto-generated self-signed CA for internal communication
- Agents authenticate via TLS client certificates instead of registration tokens

## Problem
The CrowdSec agent DaemonSet uses the pod name (`metadata.name`) as the machine username for LAPI registration. When pods restart (not recreate):
1. The `emptyDir` volume holding credentials is cleared
2. Init container tries to re-register with the same username
3. LAPI returns `403 Forbidden: user already exists`
4. Init container fails → CrashLoopBackOff

## Solution
Enable TLS with cert-manager auto-generated self-signed CA. When `tls.agent.tlsClientAuth: true`:
- Init container only waits for LAPI (no registration step)
- Agents authenticate via TLS certificates managed by cert-manager
- No "user exists" conflict since there's no username-based registration

## Changes
- `helmrelease.yaml`: Add TLS config with cert-manager self-signed CA
- `helmrelease.yaml`: Update LAPI probes to use HTTPS scheme
- `bouncer-middleware.yaml`: Add `crowdsecLapiScheme: https` and `crowdsecLapiTlsInsecure: true`

## Testing
After merge, verify:
1. CrowdSec LAPI pod restarts with TLS enabled
2. Agent pods no longer crash on restart
3. Traefik bouncer connects via HTTPS

## Notes
- Brief downtime expected during LAPI restart
- Bouncer API key authentication unchanged (only transport encrypted)
- Self-signed CA is generated in-cluster, never leaves the cluster