### PR TITLE
feat(authentik): add OpenClaw gateway password header

### DIFF
--- a/kubernetes/infrastructure/security/authentik/config/middleware-openclaw.yaml
+++ b/kubernetes/infrastructure/security/authentik/config/middleware-openclaw.yaml
@@ -11,3 +11,4 @@ spec:
     authResponseHeaders:
       - X-authentik-username
       - X-authentik-email
+      - X-Gateway-Password

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -851,6 +851,28 @@ data:
           users:
             - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
 
+      - model: authentik_providers_oauth2.scopemapping
+        state: present
+        id: openclaw-gateway-password-mapping
+        identifiers:
+          name: "OpenClaw Gateway Password Mapping"
+        attrs:
+          scope_name: openclaw-gateway-password
+          description: "Injects the OpenClaw gateway password header"
+          expression: |
+            import os
+            gateway_password = os.environ.get("OPENCLAW_GATEWAY_PASSWORD", "")
+            headers = {}
+            if gateway_password:
+                headers["X-Gateway-Password"] = gateway_password
+            return {
+                "ak_proxy": {
+                    "user_attributes": {
+                        "additionalHeaders": headers
+                    }
+                }
+            }
+
       - model: authentik_providers_proxy.proxyprovider
         id: openclaw-provider
         identifiers:
@@ -864,6 +886,7 @@ data:
           refresh_token_validity: "days=30"
           property_mappings:
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "ak-proxy"]]
+            - !KeyOf openclaw-gateway-password-mapping
 
       - model: authentik_core.application
         identifiers:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -141,6 +141,11 @@ spec:
             secretKeyRef:
               name: frigate-proxy-secret
               key: FRIGATE_PROXY_SECRET
+        - name: OPENCLAW_GATEWAY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: openclaw-gateway-secret
+              key: OPENCLAW_GATEWAY_PASSWORD
 
         # Blueprint variables
         - name: AK_BLUEPRINT_USER

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml
   - frigate-proxy-secret.sops.yaml
+  - openclaw-gateway-secret.sops.yaml

--- a/kubernetes/infrastructure/security/authentik/install/openclaw-gateway-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/openclaw-gateway-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: openclaw-gateway-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    OPENCLAW_GATEWAY_PASSWORD: ENC[AES256_GCM,data:8GbUx1oZPaqFOjBcSsPLiyJ7TFA/d66wJSO73XdpC+5RBzGyNZlzGdknMIIWQrHT,iv:tApuAW+8q5ASRkzFE3BRPhfWvFfjaL+oe06rGtqZbco=,tag:SaajeKg5QfmZ+aj0vM3+Lw==,type:str]
+sops:
+    age:
+        - recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHbmhQRUU0eE93S2V5aEJG
+            THZSTnVNcG5UOWFnQ1Rwb3ZQbFRuWW04V1FvCm4rSW1mVGtaRSs3TlJYU2luZFpB
+            WVdJejFVQ3pNa1dMWFU4M0M2eTM2NGcKLS0tIFlLMmNyTmd3R1lGMFhSSEJ6UHND
+            OVZqVjlBTi9wUEV6bW15Q2M5czlONzAKpdiyRkQsDZkFPGmPZPVh2GbBJ95rQVdh
+            NRrNDJw2+SHU1WN925+rb/GzCcT4Ohim2VvC488pBnG7HyOJF+Rujw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-21T17:12:29Z"
+    mac: ENC[AES256_GCM,data:i/c2/xRzp/wP20egLiOS5Om5tqGwuXE8CUhVupkBFc/I6J5dbYgdyOEi/9+pTxkfoVPtJTDfBPZt9Ttke6qFTywfGHodjyWf3ibFfm6JBtBHeeQxkioq+oWRNDKoM0Lz4cpOQ0YTdco4gazFA1vCnEpZHYnvDo8BYPHjuxZeT0k=,iv:Nvipaj4aRdFCFsfxtJVM/q1pa+tqbfjroLocFUGmlUQ=,tag:Kaht27BR7qrjxzp8L0KbHA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2


### PR DESCRIPTION
## Summary
- add a dedicated SOPS secret and Authentik env wiring for `OPENCLAW_GATEWAY_PASSWORD`
- attach an OpenClaw-specific Authentik proxy mapping that injects `X-Gateway-Password`
- forward `X-Gateway-Password` through the OpenClaw Traefik forwardAuth middleware

## Validation
- `pre-commit run --all-files`
- `kubectl kustomize kubernetes/infrastructure/security/authentik/install >/dev/null`
- `kubectl kustomize kubernetes/infrastructure/security/authentik/config >/dev/null`