### PR TITLE
feat(ansible): add public VPS inventory overlay pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ venv/
 .ansible
 ansible-facts/
 ansible_collections/
+ansible/inventories/*.local.yml
 
 # Terraform / Packer / Kube
 .terraform/

--- a/ansible/inventories/public-vps.yml
+++ b/ansible/inventories/public-vps.yml
@@ -1,0 +1,22 @@
+---
+# Tracked public VPS inventory structure.
+#
+# Keep real public IPs and any sensitive connection details in the local-only
+# overlay file `ansible/inventories/public-vps.local.yml`, which is ignored by git.
+#
+# Example local overlay:
+# all:
+#   children:
+#     public_vps:
+#       hosts:
+#         vps-app-01:
+#           ansible_host: 203.0.113.10
+#           ansible_user: ubuntu
+#         vps-app-02:
+#           ansible_host: 203.0.113.11
+#           ansible_user: ubuntu
+
+all:
+  children:
+    public_vps:
+      hosts: {}

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -140,6 +140,38 @@ ansible-playbook playbooks/k3s_cluster.yml --check
 ansible-playbook playbooks/k3s_cluster.yml
 ```
 
+### Optional: Local-only public VPS inventory overlay
+
+If you want to manage internet-facing VPS without committing their public IPs,
+keep the tracked group definition in `ansible/inventories/public-vps.yml` and
+create a local-only overlay file at `ansible/inventories/public-vps.local.yml`.
+
+That overlay is ignored by git and loaded automatically because
+`ansible/ansible.cfg` points Ansible at the full `ansible/inventories/`
+directory.
+
+Example local overlay:
+
+```yaml
+all:
+  children:
+    public_vps:
+      hosts:
+        vps-app-01:
+          ansible_host: 203.0.113.10
+          ansible_user: ubuntu
+        vps-app-02:
+          ansible_host: 203.0.113.11
+          ansible_user: ubuntu
+```
+
+You can validate the combined inventory with:
+
+```bash
+cd ansible
+ansible-inventory --list
+```
+
 ### Step 4: Verify Kubernetes Cluster
 
 ```bash


### PR DESCRIPTION
## Summary
- add a tracked `public_vps` inventory scaffold without committing any real public host addresses
- ignore `ansible/inventories/*.local.yml` so a local `public-vps.local.yml` overlay can hold real `ansible_host` values safely outside git
- document the local overlay workflow in `docs/GETTING_STARTED.md`, including an example file and an `ansible-inventory --list` validation step

## Validation
- `ansible-inventory --list`
- YAML diagnostics for `ansible/inventories/public-vps.yml`
- direct inspection of `.gitignore` and `docs/GETTING_STARTED.md` (no LSP configured here for gitignore or Markdown at the time of implementation)