### PR TITLE
feat(ansible): add public VPS baseline playbook

### DIFF
--- a/ansible/inventories/group_vars/public_vps.yml
+++ b/ansible/inventories/group_vars/public_vps.yml
@@ -1,0 +1,14 @@
+---
+# Baseline hardening for internet-facing Ubuntu VPS.
+
+ssh_hardening_sshd_settings:
+  PermitRootLogin: "no"
+  PasswordAuthentication: "no"
+  ChallengeResponseAuthentication: "no"
+
+ufw_install_enabled: true
+ufw_enabled: true
+ufw_default_incoming_policy: deny
+ufw_default_outgoing_policy: allow
+ufw_allow_ssh: true
+ufw_inbound_rules: []

--- a/ansible/inventories/group_vars/public_vps.yml
+++ b/ansible/inventories/group_vars/public_vps.yml
@@ -1,6 +1,8 @@
 ---
 # Baseline hardening for internet-facing Ubuntu VPS.
 
+common_user: "{{ ansible_user | default('ubuntu') }}"
+
 ssh_hardening_sshd_settings:
   PermitRootLogin: "no"
   PasswordAuthentication: "no"

--- a/ansible/playbooks/public_vps.yml
+++ b/ansible/playbooks/public_vps.yml
@@ -1,0 +1,8 @@
+---
+- name: Provision public VPS hosts
+  hosts: public_vps
+  become: true
+  roles:
+    - common
+    - ssh_hardening
+    - ufw


### PR DESCRIPTION
## Summary
- add `ansible/inventories/group_vars/public_vps.yml` with the first internet-facing host baseline: strict SSH settings plus UFW default deny inbound and SSH allowed
- add `ansible/playbooks/public_vps.yml` composing `common`, `ssh_hardening`, and `ufw` in the same order used by the existing host provisioning flows
- keep the baseline minimal so per-host port rules can be added later through `ufw_inbound_rules` without reworking the group policy

## Validation
- `ansible-inventory --list`
- `ansible-lint playbooks roles`
- `ansible-playbook --syntax-check playbooks/public_vps.yml`
- YAML diagnostics for `ansible/inventories/group_vars/public_vps.yml`
- YAML diagnostics for `ansible/playbooks/public_vps.yml`