### PR TITLE
feat(ansible): add fail2ban SSH protection for public VPS

### DIFF
--- a/ansible/inventories/group_vars/public_vps.yml
+++ b/ansible/inventories/group_vars/public_vps.yml
@@ -14,3 +14,6 @@ ufw_default_incoming_policy: deny
 ufw_default_outgoing_policy: allow
 ufw_allow_ssh: true
 ufw_inbound_rules: []
+
+fail2ban_install_enabled: true
+fail2ban_enabled: true

--- a/ansible/playbooks/public_vps.yml
+++ b/ansible/playbooks/public_vps.yml
@@ -5,4 +5,5 @@
   roles:
     - common
     - ssh_hardening
+    - fail2ban
     - ufw

--- a/ansible/roles/fail2ban/defaults/main.yml
+++ b/ansible/roles/fail2ban/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# Toggle fail2ban package installation.
+fail2ban_install_enabled: true
+
+# Final fail2ban service state.
+fail2ban_enabled: false
+
+# SSH jail defaults for internet-facing hosts.
+fail2ban_sshd_enabled: true
+fail2ban_sshd_backend: systemd
+fail2ban_sshd_port: ssh
+fail2ban_sshd_maxretry: 5
+fail2ban_sshd_findtime: 10m
+fail2ban_sshd_bantime: 1h

--- a/ansible/roles/fail2ban/handlers/main.yml
+++ b/ansible/roles/fail2ban/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart fail2ban
+  ansible.builtin.service:
+    name: fail2ban
+    state: restarted

--- a/ansible/roles/fail2ban/handlers/main.yml
+++ b/ansible/roles/fail2ban/handlers/main.yml
@@ -3,3 +3,4 @@
   ansible.builtin.service:
     name: fail2ban
     state: restarted
+  when: fail2ban_enabled | bool

--- a/ansible/roles/fail2ban/tasks/main.yml
+++ b/ansible/roles/fail2ban/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+- name: Ensure fail2ban supports this OS family
+  ansible.builtin.assert:
+    that:
+      - ansible_os_family == 'Debian'
+    fail_msg: "fail2ban role currently supports only Debian-family hosts"
+    quiet: true
+
+- name: Install fail2ban packages
+  ansible.builtin.apt:
+    name:
+      - fail2ban
+      - python3-systemd
+    state: present
+    update_cache: true
+  when: fail2ban_install_enabled | bool
+
+- name: Ensure fail2ban jail.d directory exists
+  ansible.builtin.file:
+    path: /etc/fail2ban/jail.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: fail2ban_install_enabled | bool
+
+- name: Configure fail2ban SSH jail
+  ansible.builtin.template:
+    src: sshd.conf.j2
+    dest: /etc/fail2ban/jail.d/10-sshd.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: fail2ban_install_enabled | bool
+  notify: Restart fail2ban
+
+- name: Enable fail2ban service
+  ansible.builtin.service:
+    name: fail2ban
+    enabled: true
+    state: started
+  when:
+    - fail2ban_install_enabled | bool
+    - fail2ban_enabled | bool
+    - not ansible_check_mode
+
+- name: Disable fail2ban service
+  ansible.builtin.service:
+    name: fail2ban
+    enabled: false
+    state: stopped
+  when:
+    - fail2ban_install_enabled | bool
+    - not fail2ban_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/fail2ban/templates/sshd.conf.j2
+++ b/ansible/roles/fail2ban/templates/sshd.conf.j2
@@ -1,0 +1,7 @@
+[sshd]
+enabled = {{ fail2ban_sshd_enabled | ternary('true', 'false') }}
+port = {{ fail2ban_sshd_port }}
+backend = {{ fail2ban_sshd_backend }}
+maxretry = {{ fail2ban_sshd_maxretry }}
+findtime = {{ fail2ban_sshd_findtime }}
+bantime = {{ fail2ban_sshd_bantime }}


### PR DESCRIPTION
## Summary
- add a Debian-focused `fail2ban` role that installs and manages fail2ban with a single SSH jail drop-in under `/etc/fail2ban/jail.d/10-sshd.conf`
- configure the SSH jail to protect against brute-force attempts by default using the systemd backend with conservative defaults (`maxretry=5`, `findtime=10m`, `bantime=1h`)
- enable the new role for `public_vps` and keep the baseline playbook order as `common -> ssh_hardening -> fail2ban -> ufw`

## Validation
- `ansible-inventory --list`
- `ansible-lint playbooks roles`
- `ansible-playbook --syntax-check playbooks/public_vps.yml`
- YAML diagnostics for:
  - `ansible/roles/fail2ban/defaults/main.yml`
  - `ansible/roles/fail2ban/tasks/main.yml`
  - `ansible/roles/fail2ban/handlers/main.yml`
  - `ansible/inventories/group_vars/public_vps.yml`
  - `ansible/playbooks/public_vps.yml`