### PR TITLE
fix safe pvc failover recovery after node loss

### DIFF
--- a/kubernetes/apps/apps/media/audiobookshelf/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/audiobookshelf/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/bazarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/bazarr/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
             value: "1"
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/komga/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/komga/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
         fsGroup: 100
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/lidarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/lidarr/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/lidatube/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/lidatube/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/plextraktsync/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/plextraktsync/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        strategy: Recreate
         initContainers:
           copy-trakt-config:
             image:

--- a/kubernetes/apps/apps/media/prowlarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/prowlarr/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/radarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/radarr/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/sabnzbd/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/sabnzbd/helmrelease.yaml
@@ -11,6 +11,7 @@ spec:
     fullnameOverride: sabnzbd
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/seerr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/seerr/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
         fsGroup: 100
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/sonarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/sonarr/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/tautulli/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/tautulli/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/media/tidarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/tidarr/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        strategy: Recreate
         containers:
           main:
             image:

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/install/helmrelease.yaml
@@ -21,6 +21,8 @@ spec:
   values:
     grafana:
       enabled: true
+      deploymentStrategy:
+        type: Recreate
       env:
         # SERVER SETTINGS - THIS FIXES THE REDIRECT MISMATCH
         GF_SERVER_ROOT_URL: "https://grafana.lan.${CLUSTER_DOMAIN}"

--- a/kubernetes/infrastructure/security/crowdsec/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/crowdsec/install/helmrelease.yaml
@@ -32,6 +32,8 @@ spec:
 
     lapi:
       replicas: 1
+      strategy:
+        type: Recreate
       service:
         annotations:
           traefik.ingress.kubernetes.io/service.serversscheme: https

--- a/kubernetes/infrastructure/storage/longhorn/config/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/longhorn/config/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - storageclass-longhorn-r1.yaml
   - storageclass-longhorn-r2.yaml
   - storageclass-local-path.yaml
+  - settings-failover.yaml
   - ingress-longhorn-ui.yaml
   - longhorn-backup-secret.sops.yaml
   - recurring-backup-jobs.yaml

--- a/kubernetes/infrastructure/storage/longhorn/config/settings-failover.yaml
+++ b/kubernetes/infrastructure/storage/longhorn/config/settings-failover.yaml
@@ -1,0 +1,6 @@
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: node-down-pod-deletion-policy
+  namespace: longhorn-system
+value: delete-both-statefulset-and-deployment-pod


### PR DESCRIPTION
## Summary
- add a Longhorn node-down pod deletion policy so PVC-backed workloads can be rescheduled instead of staying attached to dead-node pods
- switch the affected PVC-backed media workloads plus Grafana and CrowdSec LAPI to Recreate so rollouts do not overlap a single RWO volume
- keep the scope safety-first by leaving replica counts, PVC definitions, and force-detach workflows unchanged