### PR TITLE
chore(git): enforce commit message policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,11 @@ Use conventional commits format:
 [optional body]
 ```
 
+Scope is optional, so `<type>: <description>` is also valid.
+If present, scope should stay lowercase and can represent a single area like `ansible`, a composite area like `ansible+terraform`, or a path-like area like `apps/item`.
+
+Commit message validation is enforced by the repository hook and CI. Git-generated subjects such as `Merge ...`, `Revert "..."`, `fixup! ...`, `squash! ...`, and `amend! ...` are allowed as exceptions.
+
 **Types:**
 - `feat` - New feature
 - `fix` - Bug fix

--- a/scripts/forbid-commit-attribution-trailers.sh
+++ b/scripts/forbid-commit-attribution-trailers.sh
@@ -17,24 +17,64 @@ if [ ! -f "$message_file" ]; then
 fi
 
 python3 - "$message_file" <<'PY'
+import subprocess
 import pathlib
 import re
 import sys
 
 message_path = pathlib.Path(sys.argv[1])
+allowed_subject = re.compile(
+    r"^(feat|fix|docs|refactor|chore)(\([a-z0-9][a-z0-9+._/-]*\))?: \S.*$"
+)
+git_generated_subjects = [
+    re.compile(r"^Merge\b"),
+    re.compile(r'^Revert ".+"$'),
+    re.compile(r"^(fixup|squash|amend)! "),
+]
 forbidden = [
     re.compile(r"^Co-authored-by:\s*Sisyphus\b", re.IGNORECASE),
     re.compile(r"^Ultraworked with\b", re.IGNORECASE),
-    re.compile(r"clio-agent@sisyphuslabs\.ai", re.IGNORECASE),
+    re.compile(r"^Co-authored-by:.*clio-agent@sisyphuslabs\.ai\b", re.IGNORECASE),
 ]
+
+
+def get_comment_prefix() -> str:
+    for key in ("core.commentString", "core.commentChar"):
+        try:
+            value = subprocess.check_output(
+                ["git", "config", "--get", key],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+        if value and value != "auto":
+            return value
+    return "#"
+
+
+comment_prefix = get_comment_prefix()
+subject_line = None
 
 violations = []
 for line_number, raw_line in enumerate(message_path.read_text().splitlines(), start=1):
     line = raw_line.rstrip("\r")
-    if line.startswith("#"):
+    if line.startswith(comment_prefix):
         continue
+    if subject_line is None and line.strip():
+        subject_line = line
     if any(pattern.search(line) for pattern in forbidden):
         violations.append((line_number, line))
+
+if subject_line and not any(pattern.search(subject_line) for pattern in git_generated_subjects):
+    if not allowed_subject.fullmatch(subject_line):
+        print("ERROR: commit message subject must match '<type>(<scope>): <description>' or '<type>: <description>'.", file=sys.stderr)
+        print("Allowed types: feat, fix, docs, refactor, chore.", file=sys.stderr)
+        print("Examples: 'chore(ansible): install packages', 'refactor(helm): simplify values', 'docs: update guide'.", file=sys.stderr)
+        print("Allowed Git-generated subjects: Merge ..., Revert \"...\", fixup! ..., squash! ..., amend! ...", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(f"subject: {subject_line}", file=sys.stderr)
+        sys.exit(1)
 
 if violations:
     print("ERROR: commit message contains forbidden Sisyphus attribution text.", file=sys.stderr)


### PR DESCRIPTION
## Summary
- enforce conventional commit subjects in the existing commit-msg validator while preserving Git-generated subjects like merge, revert, and autosquash messages
- keep blocking the Sisyphus attribution trailers, but narrow the email check to co-author trailer usage to avoid false positives in normal prose
- document the enforced commit message shape and accepted scope patterns in CONTRIBUTING.md so local hooks, CI, and docs stay aligned