### PR TITLE
fix(authentik): add cnpg backup and wal settings

### DIFF
--- a/kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
@@ -18,9 +18,50 @@ spec:
     size: 2Gi
     storageClass: longhorn-r2
 
+  postgresql:
+    parameters:
+      wal_level: "logical"
+      archive_timeout: "5min"
+      archive_mode: "on"
+
+  backup:
+    barmanObjectStore:
+      wal:
+        compression: gzip
+        encryption: AES256
+      data:
+        compression: gzip
+        encryption: AES256
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-backup-s3
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-backup-s3
+          key: ACCESS_SECRET_KEY
+        region:
+          name: cnpg-backup-s3
+          key: AWS_DEFAULT_REGION
+      destinationPath: "s3://cloudnative-pg/authentik"
+      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
+      serverName: "authentik-pg-v1"
+    retentionPolicy: "14d"
+
   bootstrap:
     initdb:
       database: authentik
       owner: authentik
       secret:
         name: authentik-db-secrets
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: authentik-pg-backup
+  namespace: authentik
+spec:
+  schedule: "0 0 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: authentik-pg
+  method: barmanObjectStore


### PR DESCRIPTION
## Summary
- restore CNPG object-store backups for authentik with WAL and base-backup encryption
- add a ScheduledBackup and codify authentik's WAL/archive settings in Git to match the live-safe configuration used after the missing-WAL recovery incident
- keep the change scoped to authentik and validate it with pre-commit plus kubectl client-side dry-run