### PR TITLE
fix(paperless): remove backup readiness gate

### DIFF
--- a/kubernetes/apps/apps/paperless/backup-job.yaml
+++ b/kubernetes/apps/apps/paperless/backup-job.yaml
@@ -63,8 +63,7 @@ spec:
                     echo "ERROR: No paperless pod found with selector: $SELECTOR" >&2
                     exit 1
                   fi
-                  echo "Found pod: $POD, waiting for it to be ready..."
-                  kubectl -n "$NS" wait --for=condition=Ready "pod/$POD" --timeout=120s
+                  echo "Found pod: $POD, starting backup..."
                   echo "Running paperless document export and backup..."
                   kubectl -n "$NS" exec "$POD" -c main -- /bin/sh -c '
                     set -euo pipefail


### PR DESCRIPTION
## Summary
- remove the Paperless backup CronJob's `kubectl wait --for=condition=Ready` step
- let the job proceed directly to `kubectl exec` and the built-in Paperless export flow
- avoid blocking backups on the pod's NFS-backed readiness probe, which is unrelated to whether the export path works

## Risk
- if Paperless is genuinely unavailable for reasons beyond the readiness probe, the backup job will now fail later in the export commands instead of at the readiness gate