### PR TITLE
feat(terraform): support Netbird UFW rules in Hetzner VMs

### DIFF
--- a/terraform/cloud/hetzner/firewall/firewall_definition.tf
+++ b/terraform/cloud/hetzner/firewall/firewall_definition.tf
@@ -20,6 +20,51 @@ locals {
             description = "Allow SSH from trusted admin networks"
           },
         ]
+      },
+      http = {
+        name = "http"
+        labels = {
+          role = "ingress"
+        }
+        rules = [
+          {
+            direction   = "in"
+            protocol    = "tcp"
+            port        = "80"
+            source_ips  = ["0.0.0.0/0", "::/0"]
+            description = "Allow HTTP"
+          },
+        ]
+      },
+      https = {
+        name = "https"
+        labels = {
+          role = "ingress"
+        }
+        rules = [
+          {
+            direction   = "in"
+            protocol    = "tcp"
+            port        = "443"
+            source_ips  = ["0.0.0.0/0", "::/0"]
+            description = "Allow HTTPS"
+          },
+        ]
+      },
+      netbird-udp = {
+        name = "netbird-udp"
+        labels = {
+          role = "netbird"
+        }
+        rules = [
+          {
+            direction   = "in"
+            protocol    = "udp"
+            port        = "3478"
+            source_ips  = ["0.0.0.0/0", "::/0"]
+            description = "Allow UDP port for Netbird"
+          },
+        ]
       }
     }
   }

--- a/terraform/cloud/hetzner/servers/netbird/main.tf
+++ b/terraform/cloud/hetzner/servers/netbird/main.tf
@@ -18,5 +18,5 @@ module "vm" {
 
   default_labels     = local.default_labels
   default_cloud_init = local.default_cloud_init
-  vms                = [local.netbird_vm]
+  vms                = [local.vm]
 }

--- a/terraform/cloud/hetzner/servers/netbird/server_definition.tf
+++ b/terraform/cloud/hetzner/servers/netbird/server_definition.tf
@@ -10,11 +10,11 @@ locals {
     managed_by = "terraform"
   }
 
-  netbird_firewall_ids = [
+  firewall_ids = [
     for firewall_key in ["ssh", "http", "https", "netbird-udp"] : data.terraform_remote_state.firewall.outputs.firewall_ids[firewall_key]
   ]
 
-  netbird_ufw_rules = [
+  additional_ufw_rules = [
     for rule in flatten([
       for firewall_key in ["http", "https", "netbird-udp"] : data.terraform_remote_state.firewall.outputs.firewalls[firewall_key].rules
       ]) : {
@@ -40,7 +40,7 @@ locals {
     extra_packages      = []
   }
 
-  netbird_vm = {
+  vm = {
     name         = "netbird"
     ansible_user = local.default_ansible_connection.user
     ansible_port = local.default_ansible_connection.port
@@ -50,9 +50,9 @@ locals {
     # Per-VM cloud_init is merged with local.default_cloud_init by the Hetzner VM
     # module; here it only adds NetBird-specific UFW rules.
     cloud_init = {
-      ufw_rules = local.netbird_ufw_rules
+      ufw_rules = local.additional_ufw_rules
     }
-    firewall_ids = local.netbird_firewall_ids
+    firewall_ids = local.firewall_ids
     labels = {
       os          = "ubuntu"
       environment = "production"
@@ -64,9 +64,9 @@ locals {
   }
 
   ansible_inventory_connection_by_vm_name = {
-    (local.netbird_vm.name) = {
-      ansible_user = try(local.netbird_vm.user_data, null) != null ? try(local.netbird_vm.ansible_user, null) : coalesce(try(local.netbird_vm.ansible_user, null), try(local.netbird_vm.cloud_init.username, null), local.default_cloud_init.username)
-      ansible_port = try(local.netbird_vm.user_data, null) != null ? try(local.netbird_vm.ansible_port, null) : coalesce(try(local.netbird_vm.ansible_port, null), try(local.netbird_vm.cloud_init.ssh_port, null), local.default_cloud_init.ssh_port)
+    (local.vm.name) = {
+      ansible_user = try(local.vm.user_data, null) != null ? try(local.vm.ansible_user, null) : coalesce(try(local.vm.ansible_user, null), try(local.vm.cloud_init.username, null), local.default_cloud_init.username)
+      ansible_port = try(local.vm.user_data, null) != null ? try(local.vm.ansible_port, null) : coalesce(try(local.vm.ansible_port, null), try(local.vm.cloud_init.ssh_port, null), local.default_cloud_init.ssh_port)
     }
   }
 }

--- a/terraform/cloud/hetzner/servers/netbird/server_definition.tf
+++ b/terraform/cloud/hetzner/servers/netbird/server_definition.tf
@@ -10,6 +10,20 @@ locals {
     managed_by = "terraform"
   }
 
+  netbird_firewall_ids = [
+    for firewall_key in ["ssh", "http", "https", "netbird-udp"] : data.terraform_remote_state.firewall.outputs.firewall_ids[firewall_key]
+  ]
+
+  netbird_ufw_rules = [
+    for rule in flatten([
+      for firewall_key in ["netbird-udp"] : data.terraform_remote_state.firewall.outputs.firewalls[firewall_key].rules
+      ]) : {
+      port     = rule.port
+      protocol = rule.protocol
+    }
+    if rule.direction == "in" && contains(["tcp", "udp"], rule.protocol) && try(rule.port, null) != null && rule.port != "any"
+  ]
+
   ssh_public_keys = compact([
     for line in split(
       "\n",
@@ -17,6 +31,8 @@ locals {
     ) : nonsensitive(trimspace(line))
   ])
 
+  # Module-level baseline for generated cloud-init. Individual VM definitions can
+  # still add or override fields via vm.cloud_init.
   default_cloud_init = {
     username            = local.default_ansible_connection.user
     ssh_authorized_keys = local.ssh_public_keys
@@ -31,9 +47,12 @@ locals {
     server_type  = "cx23"
     image        = "ubuntu-24.04"
     location     = "fsn1"
-    firewall_ids = [
-      for firewall_key in ["ssh"] : data.terraform_remote_state.firewall.outputs.firewall_ids[firewall_key]
-    ]
+    # Per-VM cloud_init is merged with local.default_cloud_init by the Hetzner VM
+    # module; here it only adds NetBird-specific UFW rules.
+    cloud_init = {
+      ufw_rules = local.netbird_ufw_rules
+    }
+    firewall_ids = local.netbird_firewall_ids
     labels = {
       os          = "ubuntu"
       environment = "production"

--- a/terraform/cloud/hetzner/servers/netbird/server_definition.tf
+++ b/terraform/cloud/hetzner/servers/netbird/server_definition.tf
@@ -16,7 +16,7 @@ locals {
 
   netbird_ufw_rules = [
     for rule in flatten([
-      for firewall_key in ["netbird-udp"] : data.terraform_remote_state.firewall.outputs.firewalls[firewall_key].rules
+      for firewall_key in ["http", "https", "netbird-udp"] : data.terraform_remote_state.firewall.outputs.firewalls[firewall_key].rules
       ]) : {
       port     = rule.port
       protocol = rule.protocol

--- a/terraform/modules/hetzner/README.md
+++ b/terraform/modules/hetzner/README.md
@@ -86,6 +86,13 @@ module "vm" {
     environment = "production"
   }
 
+  default_cloud_init = {
+    username            = "ubuntu"
+    ssh_authorized_keys = [file("~/.ssh/id_ed25519.pub")]
+    ssh_port            = 22
+    extra_packages      = ["jq"]
+  }
+
   vms = [
     {
       name        = "public-vps-01"
@@ -98,6 +105,15 @@ module "vm" {
 
       labels = {
         role = "edge"
+      }
+
+      cloud_init = {
+        ufw_rules = [
+          {
+            port     = "443"
+            protocol = "tcp"
+          }
+        ]
       }
 
       private_network = {
@@ -146,9 +162,16 @@ Outputs:
 Inputs:
 - `vms` — list of VM definitions
 - `default_labels`
+- `default_cloud_init` — optional module-wide baseline for generated cloud-init
 
 Outputs:
 - `vms` — map keyed by VM name, including server metadata and attached volume metadata
+
+Cloud-init merge behavior:
+- If `user_data` is set on a VM, the module uses it directly and does not generate cloud-init for that VM.
+- `username`, `ssh_authorized_keys`, and `ssh_port` use the per-VM `cloud_init` value when present; otherwise they fall back to `default_cloud_init`.
+- `extra_packages` combines the default and per-VM lists, then de-duplicates them.
+- `ufw_rules` combines the default and per-VM lists in order.
 
 ## Notes
 

--- a/terraform/modules/hetzner/firewall/outputs.tf
+++ b/terraform/modules/hetzner/firewall/outputs.tf
@@ -10,6 +10,7 @@ output "firewalls" {
       id     = firewall.id
       name   = firewall.name
       labels = firewall.labels
+      rules  = var.firewalls[key].rules
     }
   }
 }

--- a/terraform/modules/hetzner/vm/cloud_init.tf
+++ b/terraform/modules/hetzner/vm/cloud_init.tf
@@ -6,6 +6,7 @@ locals {
     ssh_authorized_keys = var.default_cloud_init.ssh_authorized_keys
     ssh_port            = coalesce(try(var.default_cloud_init.ssh_port, null), 22)
     extra_packages      = coalesce(try(var.default_cloud_init.extra_packages, null), [])
+    ufw_rules           = coalesce(try(var.default_cloud_init.ufw_rules, null), [])
   }
 
   cloud_init_by_vm_name = {
@@ -29,6 +30,10 @@ locals {
         try(local.normalized_default_cloud_init.extra_packages, []),
         coalesce(try(vm.cloud_init.extra_packages, null), [])
       ))
+      ufw_rules = concat(
+        try(local.normalized_default_cloud_init.ufw_rules, []),
+        coalesce(try(vm.cloud_init.ufw_rules, null), [])
+      )
     })
   }
 
@@ -67,13 +72,20 @@ locals {
               "",
             ])
           }]
-          runcmd = [
-            format("printf '[sshd]\\nenabled = true\\nport = ssh, %d\\nbanaction = iptables-multiport' > /etc/fail2ban/jail.local", local.cloud_init_by_vm_name[vm.name].ssh_port),
-            "systemctl enable fail2ban",
-            format("ufw allow %d", local.cloud_init_by_vm_name[vm.name].ssh_port),
-            "ufw --force enable",
-            "systemctl restart ssh",
-          ]
+          runcmd = concat(
+            [
+              format("printf '[sshd]\\nenabled = true\\nport = ssh, %d\\nbanaction = iptables-multiport' > /etc/fail2ban/jail.local", local.cloud_init_by_vm_name[vm.name].ssh_port),
+              "systemctl enable fail2ban",
+              format("ufw allow %d", local.cloud_init_by_vm_name[vm.name].ssh_port),
+            ],
+            [
+              for rule in local.cloud_init_by_vm_name[vm.name].ufw_rules : format("ufw allow %s/%s", rule.port, rule.protocol)
+            ],
+            [
+              "ufw --force enable",
+              "systemctl restart ssh",
+            ]
+          )
         })
       ])
     ))

--- a/terraform/modules/hetzner/vm/variables.tf
+++ b/terraform/modules/hetzner/vm/variables.tf
@@ -1,15 +1,19 @@
 variable "vms" {
   type = list(object({
-    name               = string
-    server_type        = string
-    image              = string
-    location           = string
-    ssh_key_ids        = optional(list(number), [])
+    name        = string
+    server_type = string
+    image       = string
+    location    = string
+    ssh_key_ids = optional(list(number), [])
     cloud_init = optional(object({
       username            = optional(string)
       ssh_authorized_keys = optional(list(string))
       ssh_port            = optional(number)
       extra_packages      = optional(list(string), [])
+      ufw_rules = optional(list(object({
+        port     = string
+        protocol = optional(string, "tcp")
+      })), [])
     }), null)
     firewall_ids       = optional(list(number), [])
     placement_group_id = optional(number, null)
@@ -46,6 +50,24 @@ variable "vms" {
     ])
     error_message = "Volume names must be unique within each VM definition."
   }
+
+  validation {
+    condition = alltrue(flatten([
+      for vm in var.vms : [
+        for rule in coalesce(try(vm.cloud_init.ufw_rules, null), []) : contains(["tcp", "udp"], rule.protocol)
+      ]
+    ]))
+    error_message = "Each cloud_init.ufw_rules protocol must be either 'tcp' or 'udp'."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for vm in var.vms : [
+        for rule in coalesce(try(vm.cloud_init.ufw_rules, null), []) : length(trimspace(rule.port)) > 0 && trimspace(rule.port) != "any"
+      ]
+    ]))
+    error_message = "Each cloud_init.ufw_rules port must be a non-empty explicit port value, not 'any'."
+  }
 }
 
 variable "default_labels" {
@@ -60,7 +82,25 @@ variable "default_cloud_init" {
     ssh_authorized_keys = list(string)
     ssh_port            = optional(number, 22)
     extra_packages      = optional(list(string), [])
+    ufw_rules = optional(list(object({
+      port     = string
+      protocol = optional(string, "tcp")
+    })), [])
   })
   description = "Default generated cloud-init settings applied to VMs unless overridden per VM"
   default     = null
+
+  validation {
+    condition = var.default_cloud_init == null ? true : alltrue([
+      for rule in var.default_cloud_init.ufw_rules : contains(["tcp", "udp"], rule.protocol)
+    ])
+    error_message = "Each default_cloud_init.ufw_rules protocol must be either 'tcp' or 'udp'."
+  }
+
+  validation {
+    condition = var.default_cloud_init == null ? true : alltrue([
+      for rule in var.default_cloud_init.ufw_rules : length(trimspace(rule.port)) > 0 && trimspace(rule.port) != "any"
+    ])
+    error_message = "Each default_cloud_init.ufw_rules port must be a non-empty explicit port value, not 'any'."
+  }
 }


### PR DESCRIPTION
## Summary
- add shared Hetzner firewall definitions and expose firewall rules so callers can derive VM-local UFW entries from remote state
- extend the Hetzner VM module and the Netbird server root to merge per-VM UFW rules into generated cloud-init
- document how `default_cloud_init` and per-VM `cloud_init` are merged in the Hetzner VM module