### PR TITLE
Enable Docker and jq for the Netbird VPS

### DIFF
--- a/ansible/inventories/host_vars/netbird.yml
+++ b/ansible/inventories/host_vars/netbird.yml
@@ -1,0 +1,3 @@
+---
+# Enable Docker only for the Netbird public VPS.
+docker_install_enabled: true

--- a/ansible/playbooks/public_vps.yml
+++ b/ansible/playbooks/public_vps.yml
@@ -6,3 +6,4 @@
     # Bootstrap SSH/UFW/fail2ban hardening is owned by Terraform cloud-init:
     # terraform/modules/hetzner/vm/cloud_init.tf
     - common
+    - docker

--- a/terraform/cloud/hetzner/servers/netbird/server_definition.tf
+++ b/terraform/cloud/hetzner/servers/netbird/server_definition.tf
@@ -37,7 +37,7 @@ locals {
     username            = local.default_ansible_connection.user
     ssh_authorized_keys = local.ssh_public_keys
     ssh_port            = local.default_ansible_connection.port
-    extra_packages      = []
+    extra_packages      = ["jq"]
   }
 
   vm = {


### PR DESCRIPTION
## Summary
- add the existing Ansible docker role to the public VPS playbook and enable it only for the Netbird host via host vars
- add `jq` to the Netbird Hetzner cloud-init extra packages so the VPS boots with that utility installed