### PR TITLE
docs: refresh agent and contributor guidance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nreymundo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,66 +1,26 @@
-# PROJECT KNOWLEDGE BASE
+# Repo-Wide Agent Rules
 
-**Generated:** 2026-03-28
-**Commit:** cad43be
-**Branch:** master
+This file defines durable repo-wide behavior. Read the nearest subtree `AGENTS.md` before making changes in a specific area, and use `CONTRIBUTING.md` for contributor workflow, examples, and command details.
 
-## CONVENTIONS
-- GitOps-first. If a Kubernetes change can live in git, make it in git and let Flux reconcile.
-- Root Kubernetes flow is `kubernetes/clusters/production/kustomization.yaml` → `flux-system/` + `ks/`.
-- App layout is stable: `kubernetes/apps/apps/<category>/<app>/`.
-- Standard app components recur: `bjw-s-defaults`, `ingress/traefik-base`, and `storage/backup-policy`.
-- Internal hostnames follow `*.lan.${CLUSTER_DOMAIN}`.
-- Infrastructure secrets use Bitwarden; Kubernetes secrets are committed only as `*.sops.yaml`.
-- Terraform is upstream of Ansible here: `terraform/instances/k3s_nodes` writes `ansible/inventories/k3s-nodes.yml` and `terraform/instances/openclaw` writes `ansible/inventories/openclaw.yml`.
+## Commit Messages
+- Follow the commit message format defined in `CONTRIBUTING.md`.
+- Keep the commit subject limited to the requested change summary.
+- Do not add attribution to a person, tool, or AI assistant unless explicitly instructed.
 
-## ANTI-PATTERNS (THIS PROJECT)
-- Never patch, apply, edit, scale, or restart Kubernetes resources directly when the repo can express the change.
-- Never treat `kubernetes/clusters/production/flux-system/gotk-*.yaml` as normal edit targets.
+## What To Do
+- Prefer changing source-of-truth files over mutating live systems or generated artifacts.
+- Use the repo's GitOps workflow when a Kubernetes change can be expressed in git.
+- Keep changes narrowly scoped to the user's request.
+- Validate changes with the most direct evidence available for the kind of change you made.
+
+## What Not To Do
+- Do not patch, apply, edit, scale, or restart Kubernetes resources directly when the repo can express the change.
+- Do not edit generated artifacts as if they were normal source files.
 - Never commit plaintext secrets, private keys, or unencrypted Kubernetes Secret manifests.
-- Do not edit root `README.md`.
-- Do not attribute commits to any person or tool unless explicitly instructed to do so.
-- Do not add anything to commit messages beyond the requested change summary unless explicitly instructed to do so.
-- Never broaden a narrowly requested fix beyond the files needed for that exact change.
-- Do not use docs or generated manifests as evidence that a subtree needs its own AGENTS file.
+- Do not broaden a narrowly requested fix into adjacent cleanup.
 
-## DEBUGGING / INCIDENT VALIDATION
-- Do not assume a root cause from config review, static reasoning, or pattern matching alone when live evidence is available.
-- Before claiming a fix, identify the actual root cause using the most direct evidence available in the current environment: real logs, live cluster state, runtime behavior, failing requests, rendered config, or other production-facing signals.
-- If live validation is possible from the current environment, do it before proposing or applying a fix. Do not stop at a plausible theory.
-- If live validation is not possible, say so explicitly, state that the diagnosis is provisional, and do not present the fix as confirmed.
-- After applying a fix for a runtime issue, validate the live result against the original failure mode whenever access permits. Do not declare success based only on linting, dry-run validation, or code inspection.
-
-## UNIQUE STYLES
-- Repo guidance is intentionally operational: commands, boundaries, and “where to edit” matter more than prose style.
-- Validation is centralized through pre-commit plus domain-specific CLI checks, not a large traditional CI test suite.
-- `CLAUDE.md` currently mirrors root guidance; treat `AGENTS.md` as the canonical source when extending hierarchy.
-
-## COMMANDS
-```bash
-pre-commit install
-pre-commit run --all-files
-
-# Kubernetes / Flux
-kubectl apply --dry-run=client -f <path>
-flux get all -A
-flux reconcile kustomization flux-system --with-source
-
-# Terraform
-terraform -chdir=terraform/instances/k3s_nodes validate
-terraform -chdir=terraform/instances/k3s_nodes plan
-terraform -chdir=terraform/instances/openclaw validate
-terraform -chdir=terraform/instances/openclaw plan
-
-# Ansible
-ansible-lint ansible/playbooks/ ansible/roles/
-ansible-playbook ansible/playbooks/k3s_cluster.yml --check
-
-# Packer
-packer validate packer/ubuntu-24.04-base
-packer validate packer/fedora-43-server
-```
-
-## NOTES
-- Highest-signal generated noise: `kubernetes/clusters/production/flux-system/gotk-components.yaml` and `gotk-sync.yaml`.
-- `docs/` is useful for orientation, but AGENTS placement should follow maintained runtime boundaries first.
-- Start with the domain AGENTS nearest the change; parent files give shared rules, child files give edit targets and local gotchas.
+## Validation And Evidence
+- Do not present a config-only theory as a confirmed root cause when live evidence is available.
+- Before claiming a fix, use the most direct evidence available in the current environment.
+- If live validation is not possible, say so explicitly and describe the result as provisional.
+- After a runtime fix, validate against the original failure mode whenever current access allows it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ git push origin feature/my-change
 - Review requests are automatically handled through `CODEOWNERS`.
 - All PRs request review from `@nreymundo` by default.
 - If a PR is opened from a bot or machine account, this ensures the main account is still pulled in for review.
+- Pull request titles should follow the same conventional format as commit subjects.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,11 @@ Guidelines for contributing to the home-lab-iac repository.
 git clone https://github.com/<user>/home-lab-iac.git
 cd home-lab-iac
 
+# Check required host tools
+scripts/bootstrap-host-tools.sh --check
+
 # Install pre-commit hooks
 pre-commit install
-
-# Set up environment variables (see docs/GETTING_STARTED.md)
 ```
 
 ### 2. Make Changes
@@ -32,6 +33,12 @@ git commit -m "feat: descriptive commit message"
 git push origin feature/my-change
 ```
 
+### 4. Pull Request Review
+
+- Review requests are automatically handled through `CODEOWNERS`.
+- All PRs request review from `@nreymundo` by default.
+- If a PR is opened from a bot or machine account, this ensures the main account is still pulled in for review.
+
 ---
 
 ## Pre-commit Hooks
@@ -42,11 +49,17 @@ The repository uses pre-commit to enforce code quality:
 |------|---------|
 | `trailing-whitespace` | Remove trailing whitespace |
 | `end-of-file-fixer` | Ensure files end with newline |
+| `mixed-line-ending` | Normalize mixed line endings |
+| `check-added-large-files` | Block accidentally committed large files |
 | `check-yaml` | Validate YAML syntax |
 | `yamllint` | Lint YAML files |
 | `ansible-lint` | Lint Ansible playbooks and roles |
 | `packer-fmt` | Format Packer HCL files |
 | `terraform-fmt` | Format Terraform files |
+| `forbid-sensitive-files` | Block committing private key material |
+| `prevent-plaintext-k8s-secrets` | Block unencrypted Kubernetes Secret manifests |
+| `sops-auto-encrypt` | Auto-encrypt `*.sops.yaml` files when needed |
+| `forbid-commit-attribution` | Enforce commit subject policy and block forbidden attribution trailers |
 
 ### Running Hooks
 
@@ -61,6 +74,8 @@ pre-commit run terraform-fmt --all-files
 # Update hooks to latest versions
 pre-commit autoupdate
 ```
+
+The `forbid-commit-attribution` hook runs during `git commit` as a `commit-msg` hook rather than through the normal file-based pre-commit scan.
 
 ---
 
@@ -115,25 +130,24 @@ pre-commit autoupdate
 ### Packer
 
 ```bash
-cd packer/<template>
-packer validate .
-./build.sh  # Full build
+packer validate packer/ubuntu-24.04-base
+packer validate packer/fedora-43-server
 ```
 
 ### Terraform
 
 ```bash
-cd terraform/instances/k3s_nodes
-terraform validate
-terraform plan
+terraform -chdir=terraform/instances/k3s_nodes validate
+terraform -chdir=terraform/instances/k3s_nodes plan
+terraform -chdir=terraform/instances/openclaw validate
+terraform -chdir=terraform/instances/openclaw plan
 ```
 
 ### Ansible
 
 ```bash
-cd ansible
-ansible-lint playbooks/ roles/
-ansible-playbook playbooks/<playbook>.yml --check
+ansible-lint ansible/playbooks/ ansible/roles/
+ansible-playbook ansible/playbooks/<playbook>.yml --check
 ```
 
 ### Kubernetes
@@ -174,7 +188,7 @@ Commit message validation is enforced by the repository hook and CI. Git-generat
 ```
 feat(kubernetes): add audiobookshelf deployment
 fix(ansible): correct network interface detection
-docs: update getting started guide
+docs(project): update getting started guide
 chore(deps): update helm chart versions
 ```
 

--- a/ansible/AGENTS.md
+++ b/ansible/AGENTS.md
@@ -1,30 +1,28 @@
-# ANSIBLE KNOWLEDGE BASE
+# Ansible Agent Notes
 
-## OVERVIEW
-`ansible/` configures hosts and the K3s cluster after Terraform creates the VMs.
+Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers Ansible-local editing rules.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Main cluster playbook | `playbooks/k3s_cluster.yml` | Applies `common`, `secondary_disk`, and `k3s` roles |
-| Other entry playbooks | `playbooks/*.yml` | Proxmox, VMs, upgrades, distro-specific flows |
-| Role resolution | `ansible.cfg` | `roles_path = ./roles:./roles/vms` |
-| Generated inventory | `inventories/k3s-nodes.yml` | Written by Terraform; not hand-maintained |
+## What This Subtree Owns
+- `ansible/` is responsible for host and cluster configuration after Terraform has provisioned infrastructure.
+- Roles are the durable unit of reuse; playbooks should stay thin and primarily compose roles.
+- `ansible.cfg` is part of the execution contract because it defines role paths, inventory defaults, and command expectations.
 
-## CONVENTIONS
-- Inventory defaults live in `ansible.cfg`; run commands from the `ansible/` root or respect that config.
-- Generated inventory clearly says it is Terraform-owned.
-- Roles are the stable unit of reuse; playbooks stay thin and mostly compose roles.
+## Source Of Truth Boundaries
+- Treat generated inventory such as `ansible/inventories/k3s-nodes.yml` as Terraform-owned output.
+- Treat role defaults, vars, handlers, and tasks as the source of truth instead of scattering one-off playbook logic.
+- If Terraform changes node labels, hostnames, or users, verify Ansible assumptions before changing the playbooks to compensate.
 
-## ANTI-PATTERNS
-- Do not hand-edit `inventories/k3s-nodes.yml`; Terraform overwrites it.
-- Do not bypass roles with ad hoc playbook logic when an existing role already owns that concern.
+## Local Anti-Patterns
+- Do not hand-edit Terraform-generated inventory.
+- Do not bypass an existing role with ad hoc playbook logic when that concern already has a stable owner.
+- Do not assume commands run the same way outside the `ansible/` root unless you preserve the `ansible.cfg` context explicitly.
+- Do not encode infrastructure-topology fixes in Ansible when the real source of truth lives upstream in Terraform.
 
-## COMMANDS
+## Validation
 ```bash
 ansible-lint ansible/playbooks/ ansible/roles/
 ansible-playbook ansible/playbooks/k3s_cluster.yml --check
 ```
 
-## NOTES
-- Terraform and Ansible are coupled here: node topology and labels originate upstream in `terraform/instances/k3s_nodes`.
+- Treat the playbook command above as a representative example; for subtree-local validation, run the specific playbook(s) you modified with `--check` when possible.
+- After Terraform-driven inventory or topology changes, re-check host grouping, labels, and any role assumptions before treating Ansible failures as purely local bugs.

--- a/kubernetes/AGENTS.md
+++ b/kubernetes/AGENTS.md
@@ -1,28 +1,23 @@
-# KUBERNETES KNOWLEDGE BASE
+# Kubernetes Agent Notes
 
-## OVERVIEW
-Everything under `kubernetes/` is desired cluster state reconciled by Flux.
+Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers Kubernetes-wide rules that apply across the subtree.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Production bootstrap | `clusters/production/` | Top-level entry for this cluster |
-| Shared infra services | `infrastructure/` | Sources + service install/config trees |
-| Workload apps | `apps/` | Production overlay plus app and storage trees |
-| Reusable components | `components/` | Shared Kustomize components referenced by apps |
+## What This Subtree Owns
+- Everything under `kubernetes/` is desired cluster state reconciled by Flux.
+- Child AGENTS files under `clusters/production/`, `infrastructure/`, `apps/`, and `components/` own the more specific local editing rules.
 
-## CONVENTIONS
+## Source Of Truth Boundaries
 - Edit hand-authored manifests, not generated Flux bootstrap output.
-- Kustomize boundaries matter: parent `kustomization.yaml` files are the authoritative inclusion points.
-- Shared provider/chart sources live in `infrastructure/sources/`, not ad hoc beside every service.
-- App manifests commonly rely on `app-template` through `bjw-s-defaults`.
-- `*.sops.yaml` is the normal form for committed Kubernetes secrets.
+- Parent `kustomization.yaml` files are authoritative inclusion boundaries; file presence alone does not make an object active.
+- Shared Helm/OCI source definitions belong in `kubernetes/infrastructure/sources/` unless a child subtree documents a real exception.
+- `*.sops.yaml` is the normal committed form for Kubernetes secrets in this repo.
 
-## ANTI-PATTERNS
-- Do not validate by applying live changes when `kubectl --dry-run=client`, `flux get`, or `flux reconcile` will answer the question.
-- Do not scatter new Helm/OCI source definitions outside `infrastructure/sources/` without a strong reason.
+## Kubernetes-Wide Anti-Patterns
+- Do not validate by applying live changes when `kubectl --dry-run=client`, `flux get`, or `flux reconcile` will answer the question safely.
+- Do not hand-edit generated `flux-system` bootstrap output during routine changes.
+- Do not scatter new source definitions, secrets, or app wiring outside the subtree that already owns them.
 
-## COMMANDS
+## Validation
 ```bash
 kubectl apply --dry-run=client -f <path>
 flux get all -A
@@ -30,5 +25,4 @@ flux get helmreleases -A
 flux reconcile kustomization flux-system --with-source
 ```
 
-## NOTES
-- Read the closer child AGENTS before editing `clusters/production`, `infrastructure`, `apps`, or `components`; each subtree has materially different rules.
+- Read the closer child AGENTS before editing `clusters/production`, `infrastructure`, `apps`, or `components`; those files should answer the subtree-local gotchas this parent file intentionally omits.

--- a/kubernetes/apps/AGENTS.md
+++ b/kubernetes/apps/AGENTS.md
@@ -1,23 +1,22 @@
-# APPS KNOWLEDGE BASE
+# Kubernetes Apps Agent Notes
 
-## OVERVIEW
-`kubernetes/apps/` is the workload layer: production overlays, deployable apps, and storage/PVC definitions that support those apps.
+Read the repo root `AGENTS.md` and `kubernetes/AGENTS.md` first. This file only covers workload-layer composition rules.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Production workload overlay | `production/kustomization.yaml` | Aggregates app deployments |
-| Deployable applications | `apps/` | HelmRelease-driven services |
-| PVCs and storage overlays | `storage/` | Mostly PVC catalogs and storage-scoped kustomizations |
+## What This Subtree Owns
+- `kubernetes/apps/` owns workload overlays, deployable applications, and storage manifests that support those workloads.
+- The subtree is intentionally split between `apps/apps/` for workload manifests and `apps/storage/` for PVC and storage-state concerns.
 
-## CONVENTIONS
-- Workload membership is controlled by the production kustomizations, not by file presence alone.
-- App deploy logic and app storage are intentionally split across `apps/` and `storage/`.
-- Most app-level secrets are SOPS files colocated with the app or related storage object.
+## Source Of Truth Boundaries
+- Workload membership is controlled by the relevant parent `kustomization.yaml`, not by file presence alone.
+- App deploy logic and app persistence are intentionally split across the two child subtrees; changing one often requires checking the other.
+- Most app-level secrets should stay SOPS-encrypted and colocated with the app or storage object that consumes them.
+- `kubernetes/apps/storage/` owns PVC and persistence state, while `kubernetes/apps/apps/storage/` is just a workload category; do not confuse the two because they have different contracts.
 
-## ANTI-PATTERNS
+## Local Anti-Patterns
 - Do not add an app directory without wiring it into the relevant parent `kustomization.yaml`.
-- Do not put PVC catalogs beside the workload manifests when an existing storage subtree already owns them.
+- Do not put PVC catalogs beside workload manifests when `apps/storage/` already owns that persistence layer.
+- Do not treat this file as the detailed editing guide; use `apps/apps/AGENTS.md` for workload-shape rules and `apps/storage/AGENTS.md` for persistence-specific rules.
 
-## NOTES
-- Use the nearer child AGENTS in `apps/apps/` or `apps/storage/` for the actual local editing rules.
+## Validation
+- For workload-tree changes, dry-run the smallest affected subtree rather than the whole cluster.
+- For app changes that depend on persistence, verify both the workload manifest path and the storage inclusion path before claiming the change is complete.

--- a/kubernetes/apps/apps/AGENTS.md
+++ b/kubernetes/apps/apps/AGENTS.md
@@ -1,33 +1,26 @@
-# APPLICATION DEPLOYMENTS KNOWLEDGE BASE
+# Kubernetes Workload Apps Agent Notes
 
-## OVERVIEW
-`kubernetes/apps/apps/` contains deployable workloads, mostly category-grouped folders plus a few standalone app roots such as `immich/`, `nextcloud/`, and `paperless/`.
+Read the repo root `AGENTS.md`, `kubernetes/AGENTS.md`, and `kubernetes/apps/AGENTS.md` first. This file only covers deployable workload rules.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Standard app deployment | `<category>/<app>/helmrelease.yaml` | Main workload definition |
-| App composition | `<category>/<app>/kustomization.yaml` | Pulls in components and local resources |
-| DB-backed apps | `*/cnpg-cluster.yaml` | Per-app CloudNativePG clusters |
-| Special high-variance subtree | `external-proxy/` | Many small service YAMLs under one umbrella |
+## What This Subtree Owns
+- `kubernetes/apps/apps/` owns deployable workloads and their workload-local resources.
+- The common workload shape is `helmrelease.yaml` + `kustomization.yaml` plus optional secrets and extra resources such as DB clusters, backup jobs, or sidecar HelmReleases.
 
-## CONVENTIONS
-- Common shape: `helmrelease.yaml` + `kustomization.yaml` + optional `*.sops.yaml` and extra resources.
-- Standard components often include `../../../components/bjw-s-defaults` and `.../ingress/traefik-base`.
-- Hostnames and ingress rules usually follow `*.lan.${CLUSTER_DOMAIN}`.
-- Some apps bundle related satellites in the same folder, e.g. Paperless variants or Discord Presence main/alternate trees.
+## Source Of Truth Boundaries
+- Workload-local resources that directly travel with an app stay here.
+- PVC catalogs and persistent storage ownership stay in `kubernetes/apps/storage/` unless a nearer child file explicitly documents an exception.
+- Shared defaults and shared ingress behavior often come from `kubernetes/components/`, so local app edits may have shared-component dependencies.
 
-## ANTI-PATTERNS
-- Do not invent a different app scaffold when the existing category already shows a stable pattern.
-- Do not put PVC definitions here when the persistent storage belongs in `kubernetes/apps/storage/`.
-- Do not overlook sibling resources like `cnpg-cluster.yaml`, backup jobs, or extra HelmReleases in multi-part apps.
+## Local Anti-Patterns
+- Do not invent a new app scaffold when the existing category already shows a stable pattern.
+- Do not put PVC definitions here when the persistence belongs in `kubernetes/apps/storage/`.
+- Do not overlook sibling resources such as `cnpg-cluster.yaml`, backup jobs, extra HelmReleases, or app variants in the same folder.
+- Do not assume `external-proxy/` follows the normal HelmRelease-heavy pattern; it is intentionally higher-variance and more direct-YAML-oriented.
 
-## COMMANDS
+## Validation
 ```bash
 kubectl apply --dry-run=client -f kubernetes/apps/apps/<category>/<app>
 flux get helmreleases -A
 ```
 
-## NOTES
-- `external-proxy/` is intentionally different: many direct service YAMLs, minimal HelmRelease pattern.
-- Check parent production kustomizations whenever adding or removing apps.
+- Check parent production kustomizations whenever adding or removing apps, and check storage wiring whenever persistence is part of the change.

--- a/kubernetes/apps/storage/AGENTS.md
+++ b/kubernetes/apps/storage/AGENTS.md
@@ -1,31 +1,26 @@
-# APP STORAGE KNOWLEDGE BASE
+# Kubernetes App Storage Agent Notes
 
-## OVERVIEW
-`kubernetes/apps/storage/` holds workload storage state, mostly PVC catalogs grouped by workload domain, plus storage-scoped overlays like `production/`.
+Read the repo root `AGENTS.md`, `kubernetes/AGENTS.md`, and `kubernetes/apps/AGENTS.md` first. This file only covers workload-persistence rules.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| PVC groups | `pvcs/` | Domain folders like `media/`, `ai/`, `security/`, `utils/` |
-| Storage overlay | `production/kustomization.yaml` | Inclusion point for storage resources |
-| Per-domain grouping | `pvcs/<domain>/kustomization.yaml` | Parent include for each PVC set |
+## What This Subtree Owns
+- `kubernetes/apps/storage/` owns workload PVC catalogs and storage overlays.
+- PVCs are grouped by workload domain rather than copied into every app directory.
 
-## CONVENTIONS
-- PVC manifests are grouped by workload domain rather than colocated with every app.
-- File naming is explicit and workload-specific: `<app>-pvc.yaml`.
-- Shared multi-instance apps may have multiple PVCs in the same domain folder, e.g. Discord Presence main/alternate.
+## Source Of Truth Boundaries
+- File naming should stay explicit and workload-tied, typically `<app>-pvc.yaml`.
+- Persistence ownership stays here even when the consuming workload manifest lives under `kubernetes/apps/apps/`.
+- `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` is a special create-only or migration-oriented contract, not a normal default for new PVCs.
 
-## ANTI-PATTERNS
-- Do not create opaque PVC names; keep them tied to the consuming workload.
+## Local Anti-Patterns
+- Do not create opaque PVC names that hide the consuming workload.
 - Do not scatter storage manifests across app folders when an existing PVC domain already owns them.
+- Do not assume Flux will reconcile field changes on a PVC that already uses `ssa: IfNotPresent`.
+- Do not add `ssa: IfNotPresent` to new PVCs unless you intentionally want create-only behavior for an existing-data or migration scenario.
 
-## COMMANDS
+## Validation
 ```bash
 kubectl apply --dry-run=client -f kubernetes/apps/storage
 ```
 
-## NOTES
-- When changing app persistence, inspect both this subtree and the app deployment subtree; they are intentionally split.
-- `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` is mainly for migrated, pre-existing, or retained PVCs that Flux should create when absent but not keep mutating after they already exist.
-- New PVCs usually should not need `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent`; only add it when you intentionally want create-only behavior for an existing-data or migration scenario.
-- When changing a PVC that already has `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent`, do not assume Flux will apply the update. Call this out to the user and prompt for the required manual live change instead (for example, PVC size expansion).
+- When changing app persistence, inspect both this subtree and the workload subtree; they are intentionally split.
+- When changing a PVC that already has `ssa: IfNotPresent`, call out any required manual live step explicitly instead of presenting the Git change as self-sufficient.

--- a/kubernetes/clusters/production/AGENTS.md
+++ b/kubernetes/clusters/production/AGENTS.md
@@ -1,33 +1,27 @@
-# PRODUCTION CLUSTER KNOWLEDGE BASE
+# Production Cluster Agent Notes
 
-## OVERVIEW
-`clusters/production/` defines Flux bootstrap wiring and the ordered cluster bring-up manifests for the production cluster.
+Read the repo root `AGENTS.md` and `kubernetes/AGENTS.md` first. This file only covers the production cluster ordering and bootstrap layer.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Overall cluster entry | `kustomization.yaml` | Includes `flux-system` then `ks` |
-| Ordered cluster resources | `ks/kustomization.yaml` | Numbered sequence is intentional |
-| Generated Flux bootstrap | `flux-system/` | Bootstrap output, not routine edit surface |
+## What This Subtree Owns
+- `kubernetes/clusters/production/` owns the top-level cluster aggregation, Flux bootstrap wiring, and ordered reconciliation entrypoints.
+- `ks/` is the hand-maintained ordering layer.
+- `flux-system/` is generated bootstrap output and is not the routine edit surface.
 
-## CONVENTIONS
-- `kustomization.yaml` at this level is the top-level aggregator for the cluster subtree.
-- `ks/` is hand-maintained and authoritative for cluster resource ordering.
-- Number prefixes in `ks/*.yaml` communicate dependency order; keep the order meaningful.
-- Install and config pairs often come as adjacent numbers: e.g. `20-*-install`, `21-*-config`.
+## Source Of Truth Boundaries
+- `ks/kustomization.yaml` and the numbered `ks/*.yaml` files communicate dependency order and are part of the production bring-up contract.
+- Install/config pairs often appear as adjacent numbers; preserve that ordering intent unless the dependency model itself is changing.
+- Service-specific implementation details should stay in `kubernetes/infrastructure/` or `kubernetes/apps/`; this subtree should mostly wire ordering and inclusion.
 
-## ANTI-PATTERNS
-- Never hand-edit `flux-system/gotk-components.yaml` or `flux-system/gotk-sync.yaml`.
-- Do not reorder `ks/kustomization.yaml` casually; bootstrapping dependencies depend on the sequence.
-- Do not put service-specific detail here when the real source belongs in `kubernetes/infrastructure/` or `kubernetes/apps/`.
+## Local Anti-Patterns
+- Never hand-edit `flux-system/gotk-components.yaml` or `flux-system/gotk-sync.yaml` during routine changes.
+- Do not reorder `ks/kustomization.yaml` casually; bootstrap and reconciliation dependencies rely on that sequence.
+- Do not solve local service problems by stuffing service-specific config into the cluster ordering layer.
 
-## COMMANDS
+## Validation
 ```bash
 kubectl apply --dry-run=client -f kubernetes/clusters/production/ks
 flux get kustomizations
 flux reconcile kustomization flux-system --with-source
 ```
 
-## NOTES
-- Contributor-relevant files are almost always `ks/*.yaml` and `ks/kustomization.yaml`.
-- Treat `flux-system/` as generated bootstrap state unless you are intentionally re-bootstrapping Flux.
+- Most routine edits here should answer one of three questions: are you changing ordering, changing inclusion, or intentionally re-bootstrapping Flux?

--- a/kubernetes/components/AGENTS.md
+++ b/kubernetes/components/AGENTS.md
@@ -1,24 +1,24 @@
-# KUBERNETES COMPONENTS KNOWLEDGE BASE
+# Kubernetes Components Agent Notes
 
-## OVERVIEW
-`kubernetes/components/` contains reusable Kustomize building blocks shared by multiple apps or infrastructure manifests.
+Read the repo root `AGENTS.md` and `kubernetes/AGENTS.md` first. This file only covers shared-component rules.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Base app-template defaults | `bjw-s-defaults/` | Shared defaults for many app HelmReleases |
-| Shared ingress snippets | `ingress/` | Reusable ingress / Traefik bases |
-| Shared storage snippets | `storage/` | Backup-policy and related shared storage pieces |
-| Shared scripts/config | `arr-custom-scripts/` | Reusable script payloads for consumers |
+## What This Subtree Owns
+- `kubernetes/components/` holds reusable Kustomize building blocks shared by multiple workloads or infrastructure manifests.
+- Components are shared inputs, not complete applications or service roots.
 
-## CONVENTIONS
-- Components are shared inputs, not full applications.
-- Keep component scope narrow and reusable across multiple consumers.
-- When changing a component, inspect downstream references before assuming the blast radius is local.
+## Source Of Truth Boundaries
+- A component should own only the reusable fragment it was created for: defaults, shared ingress, shared storage policy, or shared scripts/config.
+- Relative component paths are part of the contract because many consumers reference them directly.
 
-## ANTI-PATTERNS
+## Local Anti-Patterns
 - Do not add app-specific business logic to a shared component.
-- Do not rename or restructure shared component paths casually; many kustomizations reference them relatively.
+- Do not rename or restructure component paths casually; many downstream kustomizations depend on those relative references.
+- Do not assume a component change is local just because only one file changed; inspect downstream consumers first.
+- Do not hide breaking changes inside a shared default layer without calling out the blast radius explicitly.
 
-## NOTES
-- Typical consumers live under `kubernetes/apps/apps/`, but infrastructure manifests may also depend on shared components.
+## Validation
+- Before editing a shared component, inspect its downstream references in workload and infrastructure manifests.
+- Use `kubectl apply --dry-run=client -f <consumer-path>` on one or more representative consumers when the change affects rendered manifests.
+
+## Notes
+- Most consumers live under `kubernetes/apps/apps/`, but infrastructure manifests can depend on shared components too.

--- a/kubernetes/infrastructure/AGENTS.md
+++ b/kubernetes/infrastructure/AGENTS.md
@@ -1,40 +1,28 @@
-# INFRASTRUCTURE KNOWLEDGE BASE
+# Kubernetes Infrastructure Agent Notes
 
-## OVERVIEW
-`kubernetes/infrastructure/` holds shared cluster services: sources, namespaces/config, and domain services such as networking, security, storage, observability, automation, GPU, and database operators.
+Read the repo root `AGENTS.md` and `kubernetes/AGENTS.md` first. This file only covers shared infrastructure-service rules.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Shared chart/source defs | `sources/` | Centralized HelmRepository / source catalog |
-| Shared namespaces/config | `config/` | Global infrastructure wiring |
-| Networking services | `networking/` | Traefik, external-dns, cloudflared, MetalLB |
-| Security services | `security/` | Authentik, CrowdSec, cert-manager, kube-replicator |
-| Storage services | `storage/` | Longhorn and related config |
-| Observability stack | `observability/` | Prometheus, Loki, Alloy, metrics-server |
-| Automation services | `automation/` | Renovate and related scheduled automation |
-| Database operators | `database/` | CloudNativePG and related secrets/backups |
-| GPU services | `gpu/` | Intel device plugins and GPU operator pieces |
-| Node discovery | `node-feature-discovery/` | Hardware labeling and discovery rules |
+## What This Subtree Owns
+- `kubernetes/infrastructure/` owns shared cluster services and the sources, install manifests, config overlays, and secrets they depend on.
+- A common pattern is `install/` for deploy-time objects and `config/` for runtime policy or overlays.
 
-## CONVENTIONS
-- Common pattern: `install/` for deploy-time objects, `config/` for runtime policies and overlays.
-- Source definitions belong in `sources/`; service directories reference them.
-- Secrets next to services are usually SOPS-encrypted and service-scoped.
-- Service roots often expose one install Kustomization plus one config Kustomization.
+## Source Of Truth Boundaries
+- Shared HelmRepository and source definitions belong in `sources/`; service directories should reference that catalog rather than duplicating it.
+- Service-scoped secrets belong beside the service and are usually committed as SOPS-encrypted manifests.
+- Treat generated or vendor-like chart content as external input; this repo should keep manifests, values, and wiring, not vendored chart payloads.
+- `kubernetes/infrastructure/kustomization.yaml` is not the full service aggregation layer; most service reconciliation is wired through `kubernetes/clusters/production/ks/*.yaml`, so ordering and inclusion changes often need edits there too.
 
-## ANTI-PATTERNS
-- Do not create duplicate source definitions inside service folders when `sources/` is the shared catalog.
-- Do not mix long-lived runtime config into `install/` when an existing `config/` split is already in use.
-- Do not treat generated or vendor-like chart content as if it belongs in this repo; keep repo state to manifests and values.
+## Local Anti-Patterns
+- Do not duplicate shared source definitions inside service folders when `sources/` already owns them.
+- Do not mix long-lived runtime config into `install/` when an existing `config/` split already communicates the boundary.
+- Do not assume install-only changes are isolated; many infrastructure services also have config overlays, ingress, or policy objects nearby.
+- Do not change service wiring or inclusion assumptions without checking whether the production cluster ordering layer also needs an update.
 
-## COMMANDS
+## Validation
 ```bash
 kubectl apply --dry-run=client -f kubernetes/infrastructure
 flux get helmreleases -A
 pre-commit run --all-files
 ```
 
-## NOTES
-- Security and storage subtrees carry the most local nuance because they mix install objects, policies, ingress, and secrets.
-- If a change affects ordering, the corresponding `clusters/production/ks/*.yaml` entry is often the other place to inspect.
+- Security and storage subtrees usually have the most local nuance because they mix install objects, policies, ingress, and secrets in the same service tree.

--- a/packer/AGENTS.md
+++ b/packer/AGENTS.md
@@ -1,30 +1,29 @@
-# PACKER KNOWLEDGE BASE
+# Packer Agent Notes
 
-## OVERVIEW
-`packer/` builds Proxmox VM templates that Terraform later clones for K3s nodes and other hosts.
+Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers Packer-local editing rules.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Ubuntu base template | `ubuntu-24.04-base/` | Current K3s node template default |
-| Fedora template | `fedora-43-server/` | Separate template root |
-| Main build config | `<template>/*.pkr.hcl` | Source blocks, build steps, variables |
-| Helper scripts | `<template>/build.sh`, `scripts/` | Build wrapper and SSH/autoinstall generation |
+## What This Subtree Owns
+- Each template directory is a self-contained build root with its own Packer config, variables, and helper entrypoints.
+- `packer/scripts/` owns shared helper logic used by one or more templates.
+- The output of this subtree is reusable VM templates that Terraform later clones.
 
-## CONVENTIONS
-- Validate inside the template directory before running the wrapper build script.
-- Templates use Bitwarden-backed SSH key injection and generated autoinstall data.
-- Template roots are self-contained: variables, main config, scripts, and build entrypoint live together.
+## Source Of Truth Boundaries
+- Hand-authored template definitions live in each template root; generated autoinstall or helper-produced inputs are workflow artifacts, not ad hoc edit targets.
+- If a template-local `build.sh` prepares generated inputs first, treat that wrapper as part of the intended source-of-truth workflow rather than an optional convenience script.
+- Secrets and SSH material belong in environment variables, Bitwarden-backed flows, or helper scripts, not inline Packer config.
 
-## ANTI-PATTERNS
-- Do not skip template-local `build.sh` when comments say it prepares generated inputs first.
-- Do not hardcode secrets into Packer files; this repo expects environment variables and helper scripts.
+## Local Anti-Patterns
+- Do not hardcode secrets, tokens, or private keys into template files.
+- Do not skip template-local wrapper scripts when they prepare generated inputs required for a correct build.
+- Do not document or depend on a brittle list of current template names when the subtree is meant to support additional template roots over time.
+- Do not change a base template casually without checking the downstream Terraform consumers that clone it.
 
-## COMMANDS
+## Validation
 ```bash
 packer validate packer/ubuntu-24.04-base
+packer validate packer/ubuntu-26.04-base
 packer validate packer/fedora-43-server
 ```
 
-## NOTES
-- The default Terraform template name is `ubuntu-24.04-base`, so changes there have downstream impact on node provisioning.
+- Treat those commands as representative examples of validating template roots; keep this file aligned when new template directories are added.
+- After changing a base template used by Terraform, call out the downstream impact on cloned node builds and any image compatibility assumptions.

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -1,27 +1,24 @@
-# TERRAFORM KNOWLEDGE BASE
+# Terraform Agent Notes
 
-## OVERVIEW
-`terraform/` is split between reusable modules in `modules/` and concrete instance roots in `instances/`.
+Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers Terraform-local editing rules.
 
-## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Shared VM module | `modules/proxmox_vms/` | Reusable Proxmox VM provisioning logic |
-| K3s instance root | `instances/k3s_nodes/` | K3s VM definitions, providers, and Ansible inventory generation |
-| OpenClaw instance root | `instances/openclaw/` | Single-VM instance root using the shared module |
+## What This Subtree Owns
+- `terraform/modules/` holds reusable infrastructure building blocks.
+- Concrete root modules live under both `terraform/instances/` and `terraform/cloud/`; those roots are allowed to produce downstream artifacts such as Ansible inventory or cloud-specific infrastructure state.
+- Secrets belong in Bitwarden-backed flows, not inline Terraform values or plaintext files.
 
-## CONVENTIONS
-- `instances/k3s_nodes/vm_definition.tf` is the scaling/config surface for K3s nodes.
-- Secrets come from Bitwarden, not inline Terraform values.
-- Instance roots write generated inventories into `ansible/inventories/`; those artifacts are part of the intended workflow.
-- Terraform Cloud workspace metadata lives in each instance root's `providers.tf` and is part of the root-module contract.
+## Source Of Truth Boundaries
+- Treat instance roots as the source of truth for generated inventory under `ansible/inventories/`.
+- Treat Terraform Cloud workspace settings in each root module's `providers.tf` as part of the root-module contract.
+- For the K3s node fleet, prefer the current `local.k3s.nodes`-driven topology instead of reintroducing older count-based patterns.
 
-## ANTI-PATTERNS
-- Do not hand-edit the generated Ansible inventory.
-- Do not reintroduce `node_count`-driven logic when `length(local.k3s.nodes)` is the current source of truth.
-- Do not move secrets into tfvars or plaintext files when the module already uses Bitwarden.
+## Local Anti-Patterns
+- Do not hand-edit Terraform-generated Ansible inventory.
+- Do not move secrets into `tfvars`, plaintext files, or ad hoc environment handling when the existing module already uses Bitwarden.
+- Do not treat module internals as a safe place for per-instance overrides when the root module already owns that concern.
+- Do not change root-module outputs or inventory shape without checking downstream Ansible impact.
 
-## COMMANDS
+## Validation
 ```bash
 terraform -chdir=terraform/instances/k3s_nodes fmt
 terraform -chdir=terraform/instances/k3s_nodes validate
@@ -31,5 +28,5 @@ terraform -chdir=terraform/instances/openclaw validate
 terraform -chdir=terraform/instances/openclaw plan
 ```
 
-## NOTES
-- Changes here often require checking the downstream Ansible impact, especially inventory shape, host labels, and users.
+- Treat those commands as representative root-module examples, not an exhaustive list of every Terraform root in the repo.
+- After changing Terraform that feeds Ansible, inspect the generated inventory diff and any host labels, users, or topology assumptions consumed downstream.


### PR DESCRIPTION
## Summary
- slim the root `AGENTS.md` down to durable repo-wide policy and refresh `CONTRIBUTING.md` with current workflow, review, and PR title guidance
- add `.github/CODEOWNERS` so `@nreymundo` is automatically requested for review on PRs
- refactor nested `AGENTS.md` files to emphasize subtree ownership, source-of-truth boundaries, local anti-patterns, and safe validation