### PR TITLE
feat(media): bump *arr app PVCs from 1Gi to 3Gi

### DIFF
--- a/kubernetes/apps/storage/pvcs/media/bazarr-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/media/bazarr-pvc.yaml
@@ -16,4 +16,4 @@ spec:
   storageClassName: longhorn-r2
   resources:
     requests:
-      storage: 1Gi
+      storage: 3Gi

--- a/kubernetes/apps/storage/pvcs/media/lidarr-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/media/lidarr-pvc.yaml
@@ -16,4 +16,4 @@ spec:
   storageClassName: longhorn-r2
   resources:
     requests:
-      storage: 1Gi
+      storage: 3Gi

--- a/kubernetes/apps/storage/pvcs/media/prowlarr-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/media/prowlarr-pvc.yaml
@@ -16,4 +16,4 @@ spec:
   storageClassName: longhorn-r2
   resources:
     requests:
-      storage: 1Gi
+      storage: 3Gi

--- a/kubernetes/apps/storage/pvcs/media/radarr-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/media/radarr-pvc.yaml
@@ -16,4 +16,4 @@ spec:
   storageClassName: longhorn-r2
   resources:
     requests:
-      storage: 1Gi
+      storage: 3Gi

--- a/kubernetes/apps/storage/pvcs/media/sonarr-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/media/sonarr-pvc.yaml
@@ -16,4 +16,4 @@ spec:
   storageClassName: longhorn-r2
   resources:
     requests:
-      storage: 1Gi
+      storage: 3Gi


### PR DESCRIPTION
## Summary

Bumps PVC storage for all \*arr apps from 1Gi to 3Gi, addressing the Lidarr PVC full issue that caused SQLite I/O errors.

## Changes

| App | Before | After |
|-----|--------|-------|
| lidarr | 1Gi | 3Gi |
| sonarr | 1Gi | 3Gi |
| radarr | 1Gi | 3Gi |
| bazarr | 1Gi | 3Gi |
| prowlarr | 1Gi | 3Gi |
| tidarr | 5Gi | 5Gi (unchanged — already above threshold) |

## Context

Lidarr's 1Gi PVC hit 100% capacity, causing SQLite disk I/O errors and pod crashes. All \*arr apps were running the same 1Gi PVC size and are likely to hit the same issue as libraries grow.

Longhorn-r2 storage class supports online expansion — no pod restart required after merge.

Closes #400