### PR TITLE
feat(terraform): add WireGuard firewall rule for netbird instance

### DIFF
--- a/terraform/cloud/hetzner/firewall/firewall_definition.tf
+++ b/terraform/cloud/hetzner/firewall/firewall_definition.tf
@@ -65,6 +65,21 @@ locals {
             description = "Allow UDP port for Netbird"
           },
         ]
+      },
+      wireguard = {
+        name = "wireguard"
+        labels = {
+          role = "vpn"
+        }
+        rules = [
+          {
+            direction   = "in"
+            protocol    = "udp"
+            port        = "51820"
+            source_ips  = ["0.0.0.0/0", "::/0"]
+            description = "Allow WireGuard VPN"
+          },
+        ]
       }
     }
   }

--- a/terraform/cloud/hetzner/servers/netbird/server_definition.tf
+++ b/terraform/cloud/hetzner/servers/netbird/server_definition.tf
@@ -11,12 +11,12 @@ locals {
   }
 
   firewall_ids = [
-    for firewall_key in ["ssh", "http", "https", "netbird-udp"] : data.terraform_remote_state.firewall.outputs.firewall_ids[firewall_key]
+    for firewall_key in ["ssh", "http", "https", "netbird-udp", "wireguard"] : data.terraform_remote_state.firewall.outputs.firewall_ids[firewall_key]
   ]
 
   additional_ufw_rules = [
     for rule in flatten([
-      for firewall_key in ["http", "https", "netbird-udp"] : data.terraform_remote_state.firewall.outputs.firewalls[firewall_key].rules
+      for firewall_key in ["http", "https", "netbird-udp", "wireguard"] : data.terraform_remote_state.firewall.outputs.firewalls[firewall_key].rules
       ]) : {
       port     = rule.port
       protocol = rule.protocol


### PR DESCRIPTION
## Summary

Add a new WireGuard firewall rule to allow VPN connections on UDP port 51820 to the NetBird instance.

### Changes

- **Firewall Definition**: Add new `wireguard` firewall entry in `hetzner/firewall/firewall_definition.tf`:
  - direction: "in"
  - protocol: "udp"
  - port: "51820"
  - source_ips: ["0.0.0.0/0", "::/0"]
  - description: "Allow WireGuard VPN"

- **NetBird Server**: Attach the new firewall to the netbird instance:
  - Add "wireguard" to `firewall_ids` list
  - Add "wireguard" to `additional_ufw_rules` loop for cloud-init UFW rule generation