### PR TITLE
fix: add recursive DNS nameservers for cert-manager DNS-01 challenges

### DIFF
--- a/kubernetes/infrastructure/security/cert-manager/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/cert-manager/install/helmrelease.yaml
@@ -20,6 +20,9 @@ spec:
       interval: 1h
   values:
     installCRDs: true
+    extraArgs:
+      - --dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53
+      - --dns01-recursive-nameservers-only=true
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
## Problem

cert-manager cannot renew the wildcard TLS certificate for `${CLUSTER_DOMAIN}` because Cloudflare DNS returns empty NS records, preventing cert-manager from determining authoritative nameservers for DNS-01 challenge propagation checks.

## Solution

Add two controller args to the cert-manager HelmRelease:

- `--dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53` - use Cloudflare and Google public resolvers instead of NS lookup
- `--dns01-recursive-nameservers-only=true` - skip authoritative NS discovery entirely

These flags tell cert-manager to check DNS-01 challenge propagation against well-known public resolvers, bypassing the empty NS record issue with Cloudflare.

## Changes

- `kubernetes/infrastructure/security/cert-manager/install/helmrelease.yaml` - added `extraArgs` under `spec.values`