### PR TITLE
fix(ansible+terraform): harden public VPS password-based access

### DIFF
--- a/ansible/inventories/group_vars/public_vps.yml
+++ b/ansible/inventories/group_vars/public_vps.yml
@@ -2,6 +2,7 @@
 # Baseline hardening for internet-facing Ubuntu VPS.
 
 common_user: "{{ ansible_user | default('ubuntu') }}"
+common_lock_root_password: true
 
 ssh_hardening_sshd_settings:
   PermitRootLogin: "no"

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -4,6 +4,7 @@ common_enable_unattended_upgrades: true
 common_unattended_upgrades_auto_reboot: false
 common_unattended_upgrades_reboot_time: "06:00"
 common_run_upgrade: true
+common_lock_root_password: false
 
 # Scheduled fstrim for Linux guests (ignored if discard unsupported).
 common_enable_fstrim: true

--- a/ansible/roles/common/tasks/identity.yml
+++ b/ansible/roles/common/tasks/identity.yml
@@ -33,6 +33,12 @@
   when:
     - common_cloud_cfg_dir.stat.isdir | default(false)
 
+- name: Ensure root account password is locked
+  ansible.builtin.user:
+    name: root
+    password_lock: true
+  when: common_lock_root_password | bool
+
 - name: Ensure timezone is set
   ansible.builtin.command: timedatectl set-timezone {{ common_timezone }}
   when:

--- a/terraform/modules/hetzner/vm/cloud_init.tf
+++ b/terraform/modules/hetzner/vm/cloud_init.tf
@@ -55,6 +55,7 @@ locals {
           ))
           package_update  = true
           package_upgrade = true
+          ssh_pwauth      = false
           write_files = [{
             path = "/etc/ssh/sshd_config.d/ssh-hardening.conf"
             content = join("\n", [


### PR DESCRIPTION
## Summary
- disable SSH password authentication in the Hetzner VM cloud-init so the generated host no longer re-enables password logins
- add a guarded Ansible control to lock the root account password and enable it for `public_vps` hosts
- keep the public VPS inventory workflow unchanged by preserving the Terraform-generated `public-vps.local.yml` overlay pattern

## Validation
- `terraform -chdir=terraform/cloud/hetzner/servers/netbird validate`
- `ansible-lint playbooks/public_vps.yml roles/common`
- live VPS verification after apply confirmed `sshd -T` reports `passwordauthentication no`, `root` is locked, and only SSH is listening publicly