### PR TITLE
fix(apps): split storage readiness from liveness probes

### DIFF
--- a/kubernetes/apps/apps/immich/helmrelease.yaml
+++ b/kubernetes/apps/apps/immich/helmrelease.yaml
@@ -45,11 +45,9 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  exec:
-                    command:
-                      - /bin/sh
-                      - -c
-                      - immich-healthcheck && ls /data >/dev/null
+                  httpGet:
+                    path: /api/server/ping
+                    port: 2283
                   initialDelaySeconds: 30
                   periodSeconds: 10
                   timeoutSeconds: 5

--- a/kubernetes/apps/apps/paperless/helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/helmrelease.yaml
@@ -83,11 +83,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  exec:
-                    command:
-                      - /bin/sh
-                      - -c
-                      - ls /usr/src/paperless/media >/dev/null
+                  tcpSocket:
+                    port: 8000
                   initialDelaySeconds: 120
                   periodSeconds: 30
                   timeoutSeconds: 5


### PR DESCRIPTION
## Summary
- make Immich liveness app-only by switching it to the existing `/api/server/ping` health endpoint while leaving readiness storage-aware
- make Paperless liveness app-only with a TCP check on port 8000 while leaving readiness storage-aware on the NFS-backed media path
- keep all NFS paths, exports, `subPath` settings, and probe timing thresholds unchanged

## Validation
- `kubectl apply --dry-run=client -f kubernetes/apps/apps/immich/helmrelease.yaml`
- `kubectl apply --dry-run=client -f kubernetes/apps/apps/paperless/helmrelease.yaml`