### PR TITLE
fix(apps/discord-presence): restore Discord IPC publishing

### DIFF
--- a/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           kasmcord:
             image:
               repository: kasmweb/discord
-              tag: 1.14.0
+              tag: 1.18.0
             env:
               TZ: Europe/Berlin
               VNC_PW:

--- a/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           kasmcord:
             image:
               repository: kasmweb/discord
-              tag: 1.14.0
+              tag: 1.18.0
             env:
               TZ: Europe/Berlin
               VNC_PW:


### PR DESCRIPTION
## Summary
- bump `kasmweb/discord` from `1.14.0` to `1.18.0` for both Discord presence HelmReleases
- restore the Discord IPC socket contract after validating that `1.14.0` no longer creates `discord-ipc-0` in this environment while `1.18.0` does

## Validation
- `pre-commit run --files kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml`
- `kubectl kustomize kubernetes/apps/apps/utils/discord-presence/main >/dev/null`
- `kubectl kustomize kubernetes/apps/apps/utils/discord-presence/alternate >/dev/null`
- isolated pod tests with `kasmweb/discord:1.14.0` and `kasmweb/discord:1.18.0`