### PR TITLE
fix(apps/discord-presence): persist Discord host update skip

### DIFF
--- a/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
@@ -42,7 +42,9 @@ spec:
                 import os
 
                 path = "/home/kasm-user/.config/discord/settings.json"
-                os.makedirs(os.path.dirname(path), exist_ok=True)
+                dirpath = os.path.dirname(path)
+                os.makedirs(dirpath, exist_ok=True)
+                os.chown(dirpath, 1000, 1000)
 
                 data = {}
                 if os.path.exists(path):

--- a/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
@@ -37,6 +37,30 @@ spec:
                 mkdir -p /run/user/1000
                 chown -R 1000:1000 /run/user/1000
                 chmod 700 /run/user/1000
+                python3 - <<'PY'
+                import json
+                import os
+
+                path = "/home/kasm-user/.config/discord/settings.json"
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+
+                data = {}
+                if os.path.exists(path):
+                    try:
+                        with open(path) as f:
+                            data = json.load(f)
+                    except Exception:
+                        data = {}
+
+                data["SKIP_HOST_UPDATE"] = True
+
+                with open(path, "w") as f:
+                    json.dump(data, f, indent=2)
+                    f.write("\n")
+
+                os.chown(path, 1000, 1000)
+                os.chmod(path, 0o644)
+                PY
                 export XDG_RUNTIME_DIR=/run/user/1000
                 exec /usr/bin/setpriv --reuid=1000 --regid=1000 --clear-groups \
                   /dockerstartup/kasm_default_profile.sh \

--- a/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
@@ -42,7 +42,9 @@ spec:
                 import os
 
                 path = "/home/kasm-user/.config/discord/settings.json"
-                os.makedirs(os.path.dirname(path), exist_ok=True)
+                dirpath = os.path.dirname(path)
+                os.makedirs(dirpath, exist_ok=True)
+                os.chown(dirpath, 1000, 1000)
 
                 data = {}
                 if os.path.exists(path):

--- a/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
@@ -37,6 +37,30 @@ spec:
                 mkdir -p /run/user/1000
                 chown -R 1000:1000 /run/user/1000
                 chmod 700 /run/user/1000
+                python3 - <<'PY'
+                import json
+                import os
+
+                path = "/home/kasm-user/.config/discord/settings.json"
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+
+                data = {}
+                if os.path.exists(path):
+                    try:
+                        with open(path) as f:
+                            data = json.load(f)
+                    except Exception:
+                        data = {}
+
+                data["SKIP_HOST_UPDATE"] = True
+
+                with open(path, "w") as f:
+                    json.dump(data, f, indent=2)
+                    f.write("\n")
+
+                os.chown(path, 1000, 1000)
+                os.chmod(path, 0o644)
+                PY
                 export XDG_RUNTIME_DIR=/run/user/1000
                 exec /usr/bin/setpriv --reuid=1000 --regid=1000 --clear-groups \
                   /dockerstartup/kasm_default_profile.sh \


### PR DESCRIPTION
## Summary
- write `SKIP_HOST_UPDATE: true` into Discord settings during startup for both Discord presence variants
- preserve any existing Discord settings while ensuring PVC-backed homes can still install `discord_rpc` and publish `discord-ipc-0` after restarts

## Validation
- `pre-commit run --files kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml`
- `kubectl kustomize kubernetes/apps/apps/utils/discord-presence/main >/dev/null`
- `kubectl kustomize kubernetes/apps/apps/utils/discord-presence/alternate >/dev/null`
- live recovery validation on both Discord pods after adding `SKIP_HOST_UPDATE` to the persisted settings