### PR TITLE
fix(kubernetes): reduce cluster alert noise

### DIFF
--- a/kubernetes/apps/apps/ai/openwebui/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/openwebui/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        replicas: 0
         containers:
           main:
             image:

--- a/kubernetes/infrastructure/networking/cloudflared/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/networking/cloudflared/install/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchLabels:
-                    app.kubernetes.io/name: cloudflared
+                    app.kubernetes.io/name: cloudflared-cloudflared
                 topologyKey: kubernetes.io/hostname
 
     controllers:

--- a/kubernetes/infrastructure/networking/cloudflared/install/pdb.yaml
+++ b/kubernetes/infrastructure/networking/cloudflared/install/pdb.yaml
@@ -7,4 +7,4 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: cloudflared
+      app.kubernetes.io/name: cloudflared-cloudflared

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/install/helmrelease.yaml
@@ -19,6 +19,15 @@ spec:
         namespace: flux-system
       interval: 12h
   values:
+    kubeControllerManager:
+      enabled: false
+
+    kubeScheduler:
+      enabled: false
+
+    kubeProxy:
+      enabled: false
+
     grafana:
       enabled: true
       deploymentStrategy:

--- a/kubernetes/infrastructure/security/crowdsec/config/networkpolicy-lapi.yaml
+++ b/kubernetes/infrastructure/security/crowdsec/config/networkpolicy-lapi.yaml
@@ -23,3 +23,10 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - protocol: TCP
+          port: 6060


### PR DESCRIPTION
## Summary
- pin OpenWebUI to `replicas: 0` so Flux preserves the intended scale-down state
- allow Prometheus scrapes to CrowdSec LAPI metrics, align cloudflared selectors with rendered pod labels, and disable unsupported k3s control-plane monitors in kube-prometheus-stack
- follow up the direct in-cluster stale Job cleanup with durable GitOps changes that reduce recurring alert noise without masking new failures