### PR TITLE
fix(kubernetes): tune CPU reservations and limits

### DIFF
--- a/kubernetes/apps/apps/external-observability/omada-exporter/helmrelease.yaml
+++ b/kubernetes/apps/apps/external-observability/omada-exporter/helmrelease.yaml
@@ -65,7 +65,7 @@ spec:
                 cpu: 50m
                 memory: 64Mi
               limits:
-                cpu: 200m
+                cpu: 500m
                 memory: 128Mi
     service:
       main:

--- a/kubernetes/infrastructure/storage/longhorn/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/storage/longhorn/install/helmrelease.yaml
@@ -51,6 +51,7 @@ spec:
 
     defaultSettings:
       allowRecurringJobWhileVolumeDetached: true
+      guaranteedInstanceManagerCPU: '{"v1":"8","v2":"8"}'
     persistence:
       defaultClass: false # we will create our own StorageClass + mark it default
     # S3 Backup Target (Garage)


### PR DESCRIPTION
## Summary
- reduce Longhorn instance-manager guaranteed CPU reservation from the chart default by setting `guaranteedInstanceManagerCPU` to 8% for both v1 and v2
- raise the omada-exporter CPU limit to reduce observed throttling without increasing its reserved CPU request
- keep the changes narrowly scoped to the two highest-value follow-up tuning items identified from live cluster signals