### PR TITLE
fix(renovate): remove broken GHCR host rules

### DIFF
--- a/kubernetes/infrastructure/automation/renovate/secret.sops.yaml
+++ b/kubernetes/infrastructure/automation/renovate/secret.sops.yaml
@@ -10,7 +10,6 @@ stringData:
     RENOVATE_PLATFORM: ENC[AES256_GCM,data:f0nJqaVi,iv:i0mzhb9dZsRJN1Cc8lex7TyjqxEu+ErOjko9sISRC+U=,tag:5ycZiRAO8gFq+Os/hh2vFA==,type:str]
     RENOVATE_ENDPOINT: ENC[AES256_GCM,data:Q+Ux1lnykgoXiZWQ/jZ7MyhlxbiCfA==,iv:2Ru05WTbNiyr6RCFof5il9LhMm/Jz2gHZw68xB2p67E=,tag:aieKodVT+Y6Ew7KZC+6e3w==,type:str]
     RENOVATE_GIT_AUTHOR: ENC[AES256_GCM,data:aiPqfI6bXWkl7bjazFAaNSU39UohzoruVQS7HgnvpwSgpZs=,iv:tf/8ab2L4OP3yKDiP0aBKDYfXsmwCDleyXyj0RaxtFU=,tag:gBcHnGkU+aPQBlXhgDnzZQ==,type:str]
-    RENOVATE_HOST_RULES: ENC[AES256_GCM,data:V+EDspB26GoYpoargClTcMN+/DSHm+rTelHIofbmUKyJWHOWOSIZOd0qrg9yATNu7ji4T/pc1+D7X2Bun6uoRhDQoxHJm8jv2GbYsEhMQL9UjR6LoWSnzjd4IPx6M2kvW3TjK0+CecGUvdTBlKJL0h06iPfywJtA7C8=,iv:S4oUP2NguWcBcKZWX197iV4lkOwN9tiuWxMewquFUxY=,tag:s1zK5XpMIPW+IhQkGhr3zA==,type:str]
 sops:
     age:
         - recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
@@ -22,7 +21,7 @@ sops:
             b2VvMXhEaXdEa3BiT1dHRW1lY0JBelkKId1C6ZY2nxqzH5hey8NlSobXZAA9oOdS
             yn0yfDMQ/sTkIZ+tNypRKQjDKCjRmxDaYsfbFBl061A3lcDNRgfvyg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-21T20:33:37Z"
-    mac: ENC[AES256_GCM,data:nI6UwFmZrNincJQL7Zjuvco8J515rwoqb6sMacGJvbAA5awpUofrsEUJWeiz8zSSU0kty8nqNXJ68kG4mQMeyAy33IvihAmmF5kY2v9JzHGGQzBqsEP0DeqhyeqrfNdfVgsvchvZi1A6A9oA8E5uYxxHHwnohhAjx7c/4LuaSoM=,iv:sdyT7zknowXav0HNG2KbQ8ZF33H3bnTS8Xe59M+kv0E=,tag:tmt19Ep9jalcfNyAW1QM1g==,type:str]
+    lastmodified: "2026-05-08T17:24:34Z"
+    mac: ENC[AES256_GCM,data:SbGvbrO+VaMZBc3/MDOcMkLH/jC/Ew4pFFcQDNtjFU6BfRd1gbnrHenU4l8n9LS0rHAWs6UVmnVloHykqGGgDIPMZ15YNkFPCE8NQf8q6MDwnwvF5mDZvTqRUbjs/ihOuFGz7A5Boywmm8r1asp6jp7mEZ+ObJKadU3Q6jbcTFc=,iv:krGTzeJuQdt80GCR+kWTnNekPWB1e7jDQlKEROMMS4w=,tag:bsUemueENKqJKkqUJTczaA==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.0


### PR DESCRIPTION
## Summary
- Remove the encrypted `RENOVATE_HOST_RULES` entry that forced Renovate to authenticate to GHCR with bad credentials.
- Let Renovate resolve public GHCR Docker images anonymously again, including `seerr-team/seerr`.

## Validation
- `sops decrypt kubernetes/infrastructure/automation/renovate/secret.sops.yaml >/dev/null`
- `kubectl apply --dry-run=client -f kubernetes/infrastructure/automation/renovate/secret.sops.yaml`
- `npx --yes renovate@39.4.0 --dry-run=full` with no `RENOVATE_HOST_RULES`, confirming `seerr-team/seerr` resolves to `v3.2.0`