### PR TITLE
fix(renovate): use GitHub native automerge checks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,7 +64,6 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
       "platformAutomerge": true,
-      "ignoreTests": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "automergeSchedule": ["at any time"]


### PR DESCRIPTION
## Summary
- Remove `ignoreTests` from the Kubernetes immediate automerge package rule.
- Keep Renovate configured for PR automerge through GitHub native auto-merge with `platformAutomerge: true` and `automergeType: "pr"`.
- This makes GitHub's required `commit-message-policy` check gate automerge instead of Renovate treating branches as immediately green.

## Verification
- `python3 -m json.tool renovate.json >/dev/null`
- `npx --yes --package renovate renovate-config-validator renovate.json`
- `RENOVATE_LOG_LEVEL=debug RENOVATE_DRY_RUN=full npx --yes --package renovate renovate --platform=local`
  - Local dry-run exited 0
  - Seerr update detected
  - `ignoreTests occurrences: 0`
- `pre-commit run --files renovate.json`
- GitHub repo/ruleset checked:
  - `autoMergeAllowed: true`
  - squash merge enabled
  - default-branch ruleset requires PRs and `commit-message-policy`

## Note
The Renovate token exposed earlier must still be rotated separately.