### PR TITLE
fix(ai): downscale AI workloads for Framework maintenance

### DIFF
--- a/kubernetes/apps/apps/ai/kokoro/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/kokoro/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        replicas: 0
         pod:
           nodeSelector:
             topology.kubernetes.io/zone: "framework"

--- a/kubernetes/apps/apps/ai/llama-swap/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/llama-swap/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        replicas: 0
         pod:
           nodeSelector:
             topology.kubernetes.io/zone: "framework"

--- a/kubernetes/apps/apps/ai/sillytavern/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/sillytavern/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        replicas: 0
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/ai/vane/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/vane/helmrelease.yaml
@@ -14,6 +14,7 @@ spec:
 
     controllers:
       main:
+        replicas: 0
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/ai/whisper/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/whisper/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     controllers:
       main:
+        replicas: 0
         pod:
           nodeSelector:
             topology.kubernetes.io/zone: "framework"


### PR DESCRIPTION
## Summary
- Downscale Framework-pinned AI workloads (`kokoro`, `llama-swap`, `whisper`) to zero replicas.
- Downscale remaining active AI workloads (`sillytavern`, `vane`) to zero replicas.
- Leave `openwebui` unchanged because it was already at zero replicas.

## Validation
- `kubectl apply --dry-run=client -f` against the changed HelmRelease files
- `flux get helmreleases -A` reviewed; existing unrelated failures remain in `media/seerr`, `paperless/paperless`, and `utils/homepage`
- Pre-commit hooks passed for both commits