### PR TITLE
fix(ai): restore AI workloads

### DIFF
--- a/kubernetes/apps/apps/ai/kokoro/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/kokoro/helmrelease.yaml
@@ -10,7 +10,6 @@ spec:
   values:
     controllers:
       main:
-        replicas: 0
         pod:
           nodeSelector:
             topology.kubernetes.io/zone: "framework"

--- a/kubernetes/apps/apps/ai/llama-swap/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/llama-swap/helmrelease.yaml
@@ -10,7 +10,6 @@ spec:
   values:
     controllers:
       main:
-        replicas: 0
         pod:
           nodeSelector:
             topology.kubernetes.io/zone: "framework"

--- a/kubernetes/apps/apps/ai/sillytavern/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/sillytavern/helmrelease.yaml
@@ -10,7 +10,6 @@ spec:
   values:
     controllers:
       main:
-        replicas: 0
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/ai/vane/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/vane/helmrelease.yaml
@@ -14,7 +14,6 @@ spec:
 
     controllers:
       main:
-        replicas: 0
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/ai/whisper/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/whisper/helmrelease.yaml
@@ -10,7 +10,6 @@ spec:
   values:
     controllers:
       main:
-        replicas: 0
         pod:
           nodeSelector:
             topology.kubernetes.io/zone: "framework"


### PR DESCRIPTION
## Summary
- Restore the AI workloads downscaled in #448 by removing the forced `replicas: 0` overrides.
- Scope is limited to Kokoro, Llama Swap, Whisper, SillyTavern, and Vane HelmReleases.

## Validation
- `kubectl apply --dry-run=client -f` against the five changed HelmRelease files
- pre-commit hooks: check yaml, yamllint, secret checks