### PR TITLE
chore(cnpg): reduce nextcloud and authentik to one instance

### DIFF
--- a/kubernetes/apps/apps/nextcloud/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/nextcloud/cnpg-cluster.yaml
@@ -11,7 +11,7 @@ spec:
       recurring-job.longhorn.io/source: enabled
       recurring-job.longhorn.io/backup-daily: enabled
       recurring-job.longhorn.io/backup-weekly: enabled
-  instances: 2
+  instances: 1
   monitoring:
     enablePodMonitor: true
   storage:

--- a/kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
@@ -11,7 +11,7 @@ spec:
       recurring-job.longhorn.io/source: enabled
       recurring-job.longhorn.io/backup-daily: enabled
       recurring-job.longhorn.io/backup-weekly: enabled
-  instances: 2
+  instances: 1
   monitoring:
     enablePodMonitor: false
   storage:


### PR DESCRIPTION
## Summary
- reduce the Nextcloud CNPG cluster from two instances to one
- reduce the Authentik CNPG cluster from two instances to one
- align desired state with the single-instance, backup-first topology already used for the other app database clusters

## Validation
- kubectl apply --dry-run=client -f kubernetes/apps/apps/nextcloud/cnpg-cluster.yaml
- kubectl apply --dry-run=client -f kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
- pre-commit run check-yaml --files kubernetes/apps/apps/nextcloud/cnpg-cluster.yaml kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
- pre-commit run yamllint --files kubernetes/apps/apps/nextcloud/cnpg-cluster.yaml kubernetes/infrastructure/security/authentik/install/authentik-db.yaml