### PR TITLE
chore(homepage): regroup local and Kubernetes services

### DIFF
--- a/kubernetes/apps/apps/ai/kokoro/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/kokoro/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: kokoro.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Kokoro
           gethomepage.dev/description: Text-to-speech API
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: kokoro-web.png
           gethomepage.dev/enabled: "true"
           gethomepage.dev/pod-selector: app.kubernetes.io/name=kokoro,app.kubernetes.io/instance=kokoro

--- a/kubernetes/apps/apps/ai/llama-swap/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/llama-swap/helmrelease.yaml
@@ -53,7 +53,7 @@ spec:
           gethomepage.dev/name: Llama Swap
           gethomepage.dev/icon: ollama.png
           gethomepage.dev/description: LLM model hot-swapping proxy
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/enabled: "true"
           gethomepage.dev/pod-selector: app.kubernetes.io/name=llama-swap,app.kubernetes.io/instance=llama-swap
         hosts:

--- a/kubernetes/apps/apps/ai/sillytavern/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/sillytavern/helmrelease.yaml
@@ -44,7 +44,7 @@ spec:
           gethomepage.dev/name: SillyTavern
           gethomepage.dev/description: Chat interface for LLM roleplay
           gethomepage.dev/icon: "https://upload.wikimedia.org/wikipedia/commons/6/6b/SillyTavern_logo_%28dark_background%29.png"
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/enabled: "true"
         hosts:
           - host: tavern.lan.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/apps/ai/vane/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/vane/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           gethomepage.dev/name: Vane
           gethomepage.dev/description: AI search assistant
           gethomepage.dev/icon: "https://i.imgur.com/9E2W5BY.png"
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
         hosts:
           - host: vane.lan.${CLUSTER_DOMAIN}
             paths:

--- a/kubernetes/apps/apps/automation/n8n/helmrelease.yaml
+++ b/kubernetes/apps/apps/automation/n8n/helmrelease.yaml
@@ -196,7 +196,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: n8n.${CLUSTER_DOMAIN}
           gethomepage.dev/name: n8n
           gethomepage.dev/description: Workflow automation
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: n8n.png
           gethomepage.dev/enabled: "true"
         hosts:

--- a/kubernetes/apps/apps/development/gitea/helmrelease.yaml
+++ b/kubernetes/apps/apps/development/gitea/helmrelease.yaml
@@ -126,7 +126,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: git.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Gitea
           gethomepage.dev/description: Git service
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: gitea.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "gitea"

--- a/kubernetes/apps/apps/immich/helmrelease.yaml
+++ b/kubernetes/apps/apps/immich/helmrelease.yaml
@@ -210,7 +210,7 @@ spec:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: Immich
           gethomepage.dev/description: Photo management and backup
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: immich.png
         hosts:
           - host: photos.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/apps/media/audiobookshelf/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/audiobookshelf/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: audiobooks.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Audiobookshelf
           gethomepage.dev/description: Audiobook server
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: audiobookshelf.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "audiobookshelf"

--- a/kubernetes/apps/apps/media/bazarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/bazarr/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: bazarr.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Bazarr
           gethomepage.dev/description: Subtitle management
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: bazarr.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "bazarr"

--- a/kubernetes/apps/apps/media/jellyfin/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/helmrelease.yaml
@@ -86,7 +86,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: jellyfin.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Jellyfin
           gethomepage.dev/description: Media server
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: jellyfin.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "jellyfin"

--- a/kubernetes/apps/apps/media/komga/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/komga/helmrelease.yaml
@@ -76,7 +76,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: comics.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Komga
           gethomepage.dev/description: Comics library
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: komga.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "komga"

--- a/kubernetes/apps/apps/media/lidarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/lidarr/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: lidarr.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Lidarr
           gethomepage.dev/description: Music automation
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: lidarr.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "lidarr"

--- a/kubernetes/apps/apps/media/lidatube/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/lidatube/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: lidatube.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Lidatube
           gethomepage.dev/description: Lidarr YouTube downloader
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: "https://i.imgur.com/WLHbWAK.png"
           gethomepage.dev/enabled: "true"
         hosts:

--- a/kubernetes/apps/apps/media/plex/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/plex/helmrelease.yaml
@@ -84,7 +84,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: plex.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Plex
           gethomepage.dev/description: Media server
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: plex.png
           gethomepage.dev/enabled: "true"
         hosts:

--- a/kubernetes/apps/apps/media/prowlarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/prowlarr/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: prowlarr.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Prowlarr
           gethomepage.dev/description: Indexer manager
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: prowlarr.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "prowlarr"

--- a/kubernetes/apps/apps/media/radarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/radarr/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: radarr.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Radarr
           gethomepage.dev/description: Movie automation
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: radarr.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "radarr"

--- a/kubernetes/apps/apps/media/sabnzbd/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/sabnzbd/helmrelease.yaml
@@ -79,7 +79,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: sabnzbd.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: SABnzbd
           gethomepage.dev/description: Usenet downloader
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: sabnzbd.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "sabnzbd"

--- a/kubernetes/apps/apps/media/seerr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/seerr/helmrelease.yaml
@@ -82,7 +82,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: seerr.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Seerr
           gethomepage.dev/description: Media request manager
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: seerr.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "seerr"

--- a/kubernetes/apps/apps/media/sonarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/sonarr/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: sonarr.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Sonarr
           gethomepage.dev/description: TV automation
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: sonarr.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: "sonarr"

--- a/kubernetes/apps/apps/media/tautulli/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/tautulli/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: tautulli.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Tautulli
           gethomepage.dev/description: Plex monitoring
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: tautulli.png
           gethomepage.dev/enabled: "true"
           gethomepage.dev/pod-selector: app.kubernetes.io/name=tautulli,app.kubernetes.io/instance=tautulli

--- a/kubernetes/apps/apps/media/tidarr/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/tidarr/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: tidarr.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Tidarr
           gethomepage.dev/description: Tidal music downloader
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: tidal.png
           gethomepage.dev/enabled: "true"
         hosts:

--- a/kubernetes/apps/apps/nextcloud/helmrelease.yaml
+++ b/kubernetes/apps/apps/nextcloud/helmrelease.yaml
@@ -144,7 +144,7 @@ spec:
           traefik.ingress.kubernetes.io/router.middlewares: traefik-nextcloud-office-chain@kubernetescrd
           gethomepage.dev/name: Nextcloud
           gethomepage.dev/description: File sync and share
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: nextcloud.png
           gethomepage.dev/enabled: "true"
           gethomepage.dev/pod-selector: "app.kubernetes.io/name=nextcloud,app.kubernetes.io/instance=nextcloud,app.kubernetes.io/controller=main"

--- a/kubernetes/apps/apps/paperless/helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/helmrelease.yaml
@@ -178,7 +178,7 @@ spec:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: Paperless
           gethomepage.dev/description: Document management
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: paperless-ngx.png
         hosts:
           - host: docs.lan.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/apps/paperless/paperless-ai-helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/paperless-ai-helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: Paperless AI
           gethomepage.dev/description: AI assistant for Paperless
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: https://i.imgur.com/vFbypY5.png
         hosts:
           - host: paperless-ai.lan.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/apps/paperless/paperless-gpt-helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/paperless-gpt-helmrelease.yaml
@@ -92,7 +92,7 @@ spec:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: Paperless GPT
           gethomepage.dev/description: AI tagging and OCR assistant
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: https://i.imgur.com/mowFxHj.png
         hosts:
           - host: paperless-gpt.lan.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/apps/security/frigate/helmrelease.yaml
+++ b/kubernetes/apps/apps/security/frigate/helmrelease.yaml
@@ -182,7 +182,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: frigate.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Frigate
           gethomepage.dev/description: NVR with AI detection
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: frigate.png
           gethomepage.dev/enabled: "true"
           # gethomepage.dev/widget.type: frigate

--- a/kubernetes/apps/apps/storage/garage-webui/helmrelease.yaml
+++ b/kubernetes/apps/apps/storage/garage-webui/helmrelease.yaml
@@ -53,7 +53,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: garage.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Garage
           gethomepage.dev/description: Object store admin UI
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: garage.png
           gethomepage.dev/enabled: "true"
         hosts:

--- a/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
@@ -188,7 +188,7 @@ spec:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: Discord - Alternate
           gethomepage.dev/description: Web instance for Discord with Steam and Plex rich presence
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: discord.png
         className: traefik
         hosts:

--- a/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
@@ -188,7 +188,7 @@ spec:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: Discord - Main
           gethomepage.dev/description: Web instance for Discord with Steam and Plex rich presence
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: discord.png
         className: traefik
         hosts:

--- a/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
@@ -162,7 +162,7 @@ spec:
                   href: https://www.linkedin.com/
 
       services:
-        - Apps/Services:
+        - Local Services:
             - Proxmox:
                 icon: proxmox.png
                 description: "Proxmox Virtual Environment"
@@ -307,7 +307,7 @@ spec:
             url: http://longhorn-frontend.longhorn-system.svc.cluster.local
 
         layout:
-          Apps/Services:
+          Local Services:
             style: row
             columns: 5
 

--- a/kubernetes/apps/apps/utils/it-tools/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/it-tools/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: IT-Tools
           gethomepage.dev/description: Handy tools for developers
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: it-tools.png
         hosts:
           - host: tools.lan.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/apps/utils/searxng/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/searxng/helmrelease.yaml
@@ -82,7 +82,7 @@ spec:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: SearXNG
           gethomepage.dev/description: Privacy-focused meta search
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: searxng.png
         hosts:
           - host: search.lan.${CLUSTER_DOMAIN}

--- a/kubernetes/infrastructure/networking/traefik/config/dashboard/ingressroute-dashboard.yaml
+++ b/kubernetes/infrastructure/networking/traefik/config/dashboard/ingressroute-dashboard.yaml
@@ -9,7 +9,7 @@ metadata:
     gethomepage.dev/href: https://traefik.lan.${CLUSTER_DOMAIN}/dashboard/
     gethomepage.dev/name: Traefik
     gethomepage.dev/description: Ingress controller
-    gethomepage.dev/group: "Apps/Services"
+    gethomepage.dev/group: "Kubernetes"
     gethomepage.dev/icon: traefik.png
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: app.kubernetes.io/name=traefik,app.kubernetes.io/instance=traefik-traefik-traefik

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/install/helmrelease.yaml
@@ -100,7 +100,7 @@ spec:
           traefik.ingress.kubernetes.io/router.middlewares: traefik-default-chain@kubernetescrd
           gethomepage.dev/name: Grafana
           gethomepage.dev/description: Dashboards
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: grafana.png
           gethomepage.dev/enabled: "true"
           gethomepage.dev/pod-selector: app.kubernetes.io/name=grafana,app.kubernetes.io/instance=observability-kube-prometheus-stack
@@ -117,7 +117,7 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: prometheus.lan.${CLUSTER_DOMAIN}
           gethomepage.dev/name: Prometheus
           gethomepage.dev/description: Metrics
-          gethomepage.dev/group: "Apps/Services"
+          gethomepage.dev/group: "Kubernetes"
           gethomepage.dev/icon: prometheus.png
           gethomepage.dev/enabled: "true"
           gethomepage.dev/pod-selector: app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=observability-kube-prometh-prometheus

--- a/kubernetes/infrastructure/security/authentik/config/ingress.yaml
+++ b/kubernetes/infrastructure/security/authentik/config/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: sso.${CLUSTER_DOMAIN}
     gethomepage.dev/name: Authentik
     gethomepage.dev/description: SSO
-    gethomepage.dev/group: "Apps/Services"
+    gethomepage.dev/group: "Kubernetes"
     gethomepage.dev/icon: authentik.png
     gethomepage.dev/enabled: "true"
 spec:

--- a/kubernetes/infrastructure/storage/longhorn/config/ingress-longhorn-ui.yaml
+++ b/kubernetes/infrastructure/storage/longhorn/config/ingress-longhorn-ui.yaml
@@ -11,7 +11,7 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: longhorn.lan.${CLUSTER_DOMAIN}
     gethomepage.dev/name: Longhorn
     gethomepage.dev/description: Storage management
-    gethomepage.dev/group: "Apps/Services"
+    gethomepage.dev/group: "Kubernetes"
     gethomepage.dev/icon: longhorn.png
     gethomepage.dev/enabled: "true"
     gethomepage.dev/pod-selector: app=longhorn-ui


### PR DESCRIPTION
## Summary
- rename in-cluster Homepage annotations from `Apps/Services` to `Kubernetes` across app and infrastructure manifests
- move the manual Homepage services section for `external-proxy` backed endpoints from `Apps/Services` to `Local Services`
- keep the Homepage layout in sync with the manual group rename and validate the YAML changes with pre-commit, `kubectl --dry-run=client`, and review checks