### PR TITLE
fix(kubernetes): tune memory requests for busy workloads

### DIFF
--- a/kubernetes/apps/apps/nextcloud/helmrelease.yaml
+++ b/kubernetes/apps/apps/nextcloud/helmrelease.yaml
@@ -98,7 +98,7 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 512Mi
+                memory: 768Mi
               limits:
                 cpu: 1000m
                 memory: 2Gi

--- a/kubernetes/apps/apps/paperless/helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/helmrelease.yaml
@@ -92,7 +92,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 256Mi
+                memory: 640Mi
               limits:
                 cpu: 2000m
                 memory: 2Gi

--- a/kubernetes/apps/apps/paperless/paperless-ai-helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/paperless-ai-helmrelease.yaml
@@ -16,6 +16,10 @@ spec:
               # renovate: datasource=docker depName=clusterzx/paperless-ai registryUrl=https://docker.io
               repository: docker.io/clusterzx/paperless-ai
               tag: 3.0.9
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
             ports:
               - name: http
                 containerPort: 3000

--- a/kubernetes/apps/apps/security/frigate/helmrelease.yaml
+++ b/kubernetes/apps/apps/security/frigate/helmrelease.yaml
@@ -136,7 +136,7 @@ spec:
               requests:
                 gpu.intel.com/i915: 1
                 cpu: 500m
-                memory: 1Gi
+                memory: 1536Mi
               limits:
                 gpu.intel.com/i915: 1
                 cpu: 4

--- a/kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
@@ -12,6 +12,10 @@ spec:
       recurring-job.longhorn.io/backup-daily: enabled
       recurring-job.longhorn.io/backup-weekly: enabled
   instances: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 384Mi
   monitoring:
     enablePodMonitor: false
   storage:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -181,7 +181,7 @@ spec:
       resources:
         requests:
           cpu: 100m
-          memory: 384Mi
+          memory: 768Mi
         limits:
           cpu: 500m
           memory: 1536Mi


### PR DESCRIPTION
## Summary
- raise under-sized memory requests for frigate, nextcloud clamav, paperless, and authentik based on current usage on k3s-node-01 and k3s-node-02
- add missing requests for paperless-ai and the authentik CloudNativePG cluster so scheduling reflects real memory demand
- keep the changes narrow and conservative, including a staged frigate bump to avoid overcommitting k3s-node-02

## Validation
- kubectl apply --dry-run=client on all changed manifests
- yamllint and check-yaml pre-commit hooks
- post-change review pass for goal fit, QA, code quality, security, and context mining