### PR TITLE
fix(renovate): run the cronjob every 6 hours

### DIFF
--- a/kubernetes/infrastructure/automation/renovate/cronjob.yaml
+++ b/kubernetes/infrastructure/automation/renovate/cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: renovate
   namespace: renovate
 spec:
-  schedule: "0 0 * * *"
+  schedule: "0 */6 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary
- run the Renovate CronJob every 6 hours instead of once per day
- keep the change scoped to the Kubernetes manifest for the shared Renovate automation job

## Validation
- kubectl apply --dry-run=client -f kubernetes/infrastructure/automation/renovate/cronjob.yaml