### PR TITLE
feat(terraform): add pve3 k3s node

### DIFF
--- a/ansible/inventories/group_vars/openclaw_vms.yml
+++ b/ansible/inventories/group_vars/openclaw_vms.yml
@@ -18,3 +18,7 @@ ufw_inbound_rules:
     proto: tcp
     from_ip: 192.168.10.51
     comment: Allow OpenClaw dashboard from k3s-node-02 Traefik source
+  - port: 18789
+    proto: tcp
+    from_ip: 192.168.10.52
+    comment: Allow OpenClaw dashboard from k3s-node-03 Traefik source

--- a/ansible/inventories/group_vars/openclaw_vms.yml
+++ b/ansible/inventories/group_vars/openclaw_vms.yml
@@ -8,10 +8,6 @@ ufw_allow_ssh: true
 ufw_inbound_rules:
   - port: 18789
     proto: tcp
-    from_ip: 192.168.10.6
-    comment: Allow OpenClaw dashboard from framework Traefik source
-  - port: 18789
-    proto: tcp
     from_ip: 192.168.10.50
     comment: Allow OpenClaw dashboard from k3s-node-01 Traefik source
   - port: 18789

--- a/ansible/inventories/k3s-nodes.yml
+++ b/ansible/inventories/k3s-nodes.yml
@@ -32,3 +32,15 @@ all:
             homelab.lan/role: "general"
             homelab.lan/runtime: "vm"
             topology.kubernetes.io/zone: "pve2"
+        k3s-node-03:
+          ansible_host: 192.168.10.52
+          ansible_user: "ubuntu"
+          ansible_port: 22
+          node_os: "ubuntu"
+          k3s_node_labels:
+            homelab.lan/cpu-vendor: "intel"
+            homelab.lan/gpu: "none"
+            homelab.lan/hypervisor: "proxmox"
+            homelab.lan/role: "general"
+            homelab.lan/runtime: "vm"
+            topology.kubernetes.io/zone: "pve3"

--- a/ansible/inventories/k3s-nodes.yml
+++ b/ansible/inventories/k3s-nodes.yml
@@ -38,7 +38,7 @@ all:
           ansible_port: 22
           node_os: "ubuntu"
           k3s_node_labels:
-            homelab.lan/cpu-vendor: "intel"
+            homelab.lan/cpu-vendor: "amd"
             homelab.lan/gpu: "none"
             homelab.lan/hypervisor: "proxmox"
             homelab.lan/role: "general"

--- a/terraform/instances/k3s_nodes/vm_definition.tf
+++ b/terraform/instances/k3s_nodes/vm_definition.tf
@@ -35,6 +35,9 @@ locals {
       {
         ci_user     = "ubuntu"
         target_node = "pve3"
+        labels = {
+          "homelab.lan/cpu-vendor" = "amd"
+        }
       }
     ]
   }

--- a/terraform/instances/k3s_nodes/vm_definition.tf
+++ b/terraform/instances/k3s_nodes/vm_definition.tf
@@ -10,7 +10,7 @@ locals {
     vm_disk_size_gb        = 128
     secondary_disk_enabled = true
     secondary_disk_size_gb = 600
-    proxmox_nodes          = ["pve1", "pve2"]
+    proxmox_nodes          = ["pve1", "pve2", "pve3"]
     nodes = [
       {
         ci_user     = "ubuntu"
@@ -31,6 +31,10 @@ locals {
             id = "intel-igpu"
           }
         ]
+      },
+      {
+        ci_user     = "ubuntu"
+        target_node = "pve3"
       }
     ]
   }

--- a/terraform/modules/proxmox_vms/main.tf
+++ b/terraform/modules/proxmox_vms/main.tf
@@ -64,7 +64,6 @@ resource "proxmox_vm_qemu" "this" {
         disk {
           storage    = local.normalized_vms[count.index].storage_pool
           size       = local.normalized_vms[count.index].vm_disk_size_gb
-          cache      = "writeback"
           iothread   = true
           discard    = true
           emulatessd = true
@@ -77,7 +76,6 @@ resource "proxmox_vm_qemu" "this" {
           disk {
             storage    = local.normalized_vms[count.index].secondary_disk_storage_pool
             size       = "${local.normalized_vms[count.index].secondary_disk_size_gb}G"
-            cache      = "writeback"
             iothread   = true
             discard    = true
             emulatessd = true


### PR DESCRIPTION
## Summary
- add k3s-node-03 on pve3 with IP 192.168.10.52 on VLAN 10
- generate the corresponding Ansible inventory entry
- stop forcing writeback cache on Proxmox VM disks

## Validation
- terraform -chdir=terraform/instances/k3s_nodes fmt
- terraform -chdir=terraform/instances/k3s_nodes validate
- terraform -chdir=terraform/instances/k3s_nodes plan
- pre-commit hooks during git commit

## Plan result
- Terraform plan reports no changes against the current live state after these updates.