### PR TITLE
fix(ansible): refresh apt cache for unattended deps

### DIFF
--- a/ansible/roles/common/tasks/os-debian.yml
+++ b/ansible/roles/common/tasks/os-debian.yml
@@ -73,6 +73,8 @@
       - unattended-upgrades
       - apt-listchanges
     state: present
+    update_cache: true
+    cache_valid_time: 3600
   when: common_enable_unattended_upgrades | bool
 
 - name: Configure unattended-upgrades origins and blacklist


### PR DESCRIPTION
## Summary
- refresh apt cache when installing unattended-upgrades dependencies
- fixes fresh Ubuntu VMs missing apt package lists before apt-listchanges install

## Validation
- ansible-playbook ansible/playbooks/ubuntu_vms.yml --limit k3s-node-03 --check
- pre-commit hooks during git commit