### PR TITLE
refactor(ansible): improve proxmox role maintainability

### DIFF
--- a/ansible/inventories/group_vars/proxmox.yml
+++ b/ansible/inventories/group_vars/proxmox.yml
@@ -9,6 +9,8 @@ common_run_upgrade: true
 # Disable fstrim timer on Proxmox hosts (storage-specific).
 common_enable_fstrim: false
 
+proxmox_zfs_thin_enforce: true
+
 common_packages:
   - htop
   - iftop
@@ -18,7 +20,6 @@ common_packages:
   - starship
   - vim
   - git
-  - linux-cpupower
   - powertop
 
 # Allow root login with keys for Proxmox, but disable passwords.

--- a/ansible/inventories/group_vars/proxmox.yml
+++ b/ansible/inventories/group_vars/proxmox.yml
@@ -20,6 +20,7 @@ common_packages:
   - starship
   - vim
   - git
+  - linux-cpupower
   - powertop
 
 # Allow root login with keys for Proxmox, but disable passwords.

--- a/ansible/inventories/host_vars/pve1.yml
+++ b/ansible/inventories/host_vars/pve1.yml
@@ -1,9 +1,4 @@
 ---
-# Override ZFS pools managed by thin provisioning for this Proxmox host.
-# By default, proxmox role audits and fixes ['ssd-zfs'].
-proxmox_zfs_thin_pools:
-  - ssd-zfs
-
 proxmox_kernel_params_add:
   - "intel_idle.max_cstate=10"
   - "processor.max_cstate=10"
@@ -13,6 +8,15 @@ proxmox_kernel_params_add:
   - "video=vesafb:off"
 proxmox_kernel_params_remove:
   - "i915.enable_gvt=1"
+
+proxmox_power_tuning_enabled: true
+proxmox_power_cpu_governor: powersave
+proxmox_power_cpu_epp: balance_power
+proxmox_power_cpu_boost: false
+proxmox_power_powertop_auto_tune: true
+proxmox_power_tuning_cron_entries_to_remove:
+  - "@reboot /usr/bin/cpupower frequency-set -g powersave"
+  - "@reboot /usr/sbin/powertop --auto-tune"
 
 # GPU Passthrough - Intel Iris Xe (Tiger Lake)
 proxmox_gpu_passthrough:

--- a/ansible/inventories/host_vars/pve2.yml
+++ b/ansible/inventories/host_vars/pve2.yml
@@ -1,9 +1,4 @@
 ---
-# Override ZFS pools managed by thin provisioning for this Proxmox host.
-# By default, proxmox role audits and fixes ['ssd-zfs'].
-proxmox_zfs_thin_pools:
-  - ssd-zfs
-
 proxmox_kernel_params_add:
   - "intel_iommu=on"
   - "iommu=pt"

--- a/ansible/inventories/host_vars/pve2.yml
+++ b/ansible/inventories/host_vars/pve2.yml
@@ -10,6 +10,16 @@ proxmox_kernel_params_remove:
   - "i915.enable_gvt=1"
   - "intel_iommu=on,igfx_off"
 
+proxmox_power_tuning_enabled: true
+proxmox_power_tuning_start_now: true
+proxmox_power_cpu_governor: powersave
+proxmox_power_cpu_epp: balance_power
+proxmox_power_cpu_boost: false
+proxmox_power_powertop_auto_tune: false
+proxmox_power_tuning_units_to_remove:
+  - disable-turbo.service
+  - powertop.service
+
 # GPU Passthrough - Intel UHD Graphics 630 (Comet Lake)
 proxmox_gpu_passthrough:
   pci_ids:

--- a/ansible/inventories/host_vars/pve3.yml
+++ b/ansible/inventories/host_vars/pve3.yml
@@ -12,3 +12,11 @@ proxmox_zfs_thin_pools:
 proxmox_kernel_params_add:
   - "ttm.pages_limit=28311552"
   - "ttm.page_pool_size=28311552"
+
+proxmox_power_tuning_enabled: true
+proxmox_power_cpu_governor: powersave
+proxmox_power_cpu_epp: balance_power
+proxmox_power_powertop_auto_tune: true
+proxmox_power_tuning_legacy_cron_jobs:
+  - "@reboot /usr/bin/cpupower frequency-set -g powersave"
+  - "@reboot /usr/sbin/powertop --auto-tune"

--- a/ansible/inventories/host_vars/pve3.yml
+++ b/ansible/inventories/host_vars/pve3.yml
@@ -4,11 +4,6 @@ common_extra_packages:
   - mesa-vulkan-drivers
   - mesa-utils
 
-# Override ZFS pools managed by thin provisioning for this Proxmox host.
-# By default, proxmox role audits and fixes ['ssd-zfs'].
-proxmox_zfs_thin_pools:
-  - ssd-zfs
-
 proxmox_kernel_params_add:
   - "ttm.pages_limit=28311552"
   - "ttm.page_pool_size=28311552"
@@ -17,6 +12,6 @@ proxmox_power_tuning_enabled: true
 proxmox_power_cpu_governor: powersave
 proxmox_power_cpu_epp: balance_power
 proxmox_power_powertop_auto_tune: true
-proxmox_power_tuning_legacy_cron_jobs:
+proxmox_power_tuning_cron_entries_to_remove:
   - "@reboot /usr/bin/cpupower frequency-set -g powersave"
   - "@reboot /usr/sbin/powertop --auto-tune"

--- a/ansible/roles/proxmox/README.md
+++ b/ansible/roles/proxmox/README.md
@@ -1,0 +1,60 @@
+# Proxmox Role
+
+This role manages durable host configuration for Proxmox nodes. It is intended to run through
+`ansible/playbooks/proxmox.yml` against the `proxmox` inventory group.
+
+## Responsibilities
+
+- Kernel command-line parameters for systemd-boot and GRUB hosts.
+- GPU passthrough module loading, VFIO binding, and driver blacklisting.
+- Swapfile creation and swappiness configuration.
+- Power tuning through an optional boot-time systemd unit.
+- ZFS thin-provisioning audit and optional enforcement.
+- ZFS ARC limits.
+- Optional CoreFreq DKMS install/removal.
+- Root shell profile defaults.
+
+## Important Variables
+
+- `proxmox_kernel_params_base_add` / `proxmox_kernel_params_base_remove`: shared kernel parameters.
+- `proxmox_kernel_params_add` / `proxmox_kernel_params_remove`: host-specific kernel parameters.
+- `proxmox_gpu_passthrough`: GPU passthrough config. Leave empty to disable.
+- `proxmox_gpu_passthrough_cleanup`: remove passthrough files when passthrough is disabled.
+- `proxmox_swapfile_path`, `proxmox_swapfile_size`, `proxmox_swapfile_size_bytes`: swapfile settings.
+- `proxmox_zfs_thin_pools`: ZFS pools audited for non-thin refreservations.
+- `proxmox_zfs_thin_enforce`: set `refreservation=none` for discovered datasets. Enabled for the
+  `proxmox` inventory group.
+- `proxmox_zfs_arc_min_bytes` / `proxmox_zfs_arc_max_bytes`: ARC module limits.
+- `proxmox_power_tuning_enabled`: install and enable the power tuning service.
+- `proxmox_power_cpu_governor`, `proxmox_power_cpu_epp`: CPU power policy written at boot.
+- `proxmox_power_cpu_boost`: enable or disable CPU boost/turbo at boot.
+- `proxmox_power_powertop_auto_tune`: run `powertop --auto-tune` at boot.
+- `proxmox_power_tuning_cron_entries_to_remove`: exact root crontab lines removed after migration to
+  the systemd unit.
+- `proxmox_corefreq_enabled`: install or remove CoreFreq.
+
+## Tags
+
+- `kernel`: kernel command-line management.
+- `gpu_passthrough`: VFIO and GPU driver management.
+- `storage`: swap and ZFS tasks.
+- `swap`: swapfile tasks.
+- `zfs`: ZFS audit, enforcement, and ARC tasks.
+- `power` / `power_tuning`: power tuning service management.
+- `corefreq`: CoreFreq tasks.
+- `shell`: root shell profile files.
+
+## Operational Notes
+
+Kernel parameter, module, initramfs, and ZFS ARC changes usually require a reboot to take effect.
+Power tuning changes can be applied immediately with:
+
+```bash
+systemctl restart proxmox-power-tuning.service
+```
+
+Run Ansible from the `ansible/` directory so `ansible.cfg` supplies the expected inventory and role paths:
+
+```bash
+ansible-playbook -i inventories/baremetal.yml playbooks/proxmox.yml --limit pve3 --tags power_tuning
+```

--- a/ansible/roles/proxmox/defaults/main.yml
+++ b/ansible/roles/proxmox/defaults/main.yml
@@ -18,6 +18,12 @@ proxmox_zfs_thin_pools:
 proxmox_zfs_thin_enforce: false
 proxmox_zfs_thin_audit: true
 
+# --- Swap ---
+proxmox_swapfile_path: /swapfile
+proxmox_swapfile_size: 16G
+proxmox_swapfile_size_bytes: 17179869184
+proxmox_swappiness: 10
+
 # --- ZFS ARC ---
 proxmox_zfs_arc_min_bytes: 1073741824  # 1 GiB
 proxmox_zfs_arc_max_bytes: 4294967296  # 4 GiB
@@ -26,6 +32,9 @@ proxmox_zfs_arc_max_bytes: 4294967296  # 4 GiB
 proxmox_corefreq_enabled: false
 
 proxmox_corefreq_version: "2.00"
+proxmox_corefreq_cleanup_versions:
+  - "2.00"
+  - "2.01"
 proxmox_corefreq_git_repo: "https://github.com/cyring/CoreFreq.git"
 proxmox_corefreq_git_ref: "master"
 
@@ -42,7 +51,11 @@ proxmox_power_tuning_enabled: false
 proxmox_power_tuning_start_now: false
 proxmox_power_cpu_governor: ""
 proxmox_power_cpu_epp: ""
+proxmox_power_cpu_boost: true
 proxmox_power_powertop_auto_tune: false
 proxmox_power_tuning_extra_commands: []
 proxmox_power_tuning_remove_legacy_cron: true
-proxmox_power_tuning_legacy_cron_jobs: []
+proxmox_power_tuning_cron_entries_to_remove: []
+
+# --- GPU passthrough ---
+proxmox_gpu_passthrough_cleanup: true

--- a/ansible/roles/proxmox/defaults/main.yml
+++ b/ansible/roles/proxmox/defaults/main.yml
@@ -36,3 +36,13 @@ proxmox_corefreq_modprobe_options: >-
   Register_Governor=1
   Register_CPU_Idle=1
   Override_SubCstate="1,1,1,1,1,1,0,0"
+
+# --- Power tuning ---
+proxmox_power_tuning_enabled: false
+proxmox_power_tuning_start_now: false
+proxmox_power_cpu_governor: ""
+proxmox_power_cpu_epp: ""
+proxmox_power_powertop_auto_tune: false
+proxmox_power_tuning_extra_commands: []
+proxmox_power_tuning_remove_legacy_cron: true
+proxmox_power_tuning_legacy_cron_jobs: []

--- a/ansible/roles/proxmox/defaults/main.yml
+++ b/ansible/roles/proxmox/defaults/main.yml
@@ -54,6 +54,7 @@ proxmox_power_cpu_epp: ""
 proxmox_power_cpu_boost: true
 proxmox_power_powertop_auto_tune: false
 proxmox_power_tuning_extra_commands: []
+proxmox_power_tuning_units_to_remove: []
 proxmox_power_tuning_remove_legacy_cron: true
 proxmox_power_tuning_cron_entries_to_remove: []
 

--- a/ansible/roles/proxmox/tasks/corefreq.yml
+++ b/ansible/roles/proxmox/tasks/corefreq.yml
@@ -29,9 +29,7 @@
       ansible.builtin.file:
         path: "/usr/src/corefreqk-{{ item }}"
         state: absent
-      loop:
-        - "2.00"
-        - "2.01"
+      loop: "{{ proxmox_corefreq_cleanup_versions }}"
       failed_when: false
 
     - name: CoreFreq | Remove module load config
@@ -142,25 +140,13 @@
         state: present
       when: (proxmox_corefreqk_module_files.matched | default(0)) > 0
 
-    # Ensure systemd unit exists (pve1 may not have it even if binaries are installed)
     - name: CoreFreq | Install systemd unit
-      ansible.builtin.copy:
+      ansible.builtin.template:
+        src: corefreqd.service.j2
         dest: /usr/lib/systemd/system/corefreqd.service
+        owner: root
+        group: root
         mode: "0644"
-        content: |
-          [Unit]
-          Description=CoreFreq Daemon
-
-          [Service]
-          Type=simple
-          ExecStart=/usr/bin/corefreqd -q
-          ExecStop=/bin/kill -QUIT $MAINPID
-          RemainAfterExit=no
-          SuccessExitStatus=SIGQUIT SIGUSR1 SIGTERM
-          Slice=-.slice
-
-          [Install]
-          WantedBy=multi-user.target
       notify: Reload systemd daemon
 
     - name: CoreFreq | Check systemd unit presence

--- a/ansible/roles/proxmox/tasks/gpu_passthrough.yml
+++ b/ansible/roles/proxmox/tasks/gpu_passthrough.yml
@@ -53,7 +53,9 @@
       notify: Update initramfs
 
 - name: GPU Passthrough - Cleanup when disabled
-  when: proxmox_gpu_passthrough | default({}) | length == 0
+  when:
+    - proxmox_gpu_passthrough_cleanup | bool
+    - proxmox_gpu_passthrough | default({}) | length == 0
   block:
     - name: Remove VFIO modules config
       ansible.builtin.file:

--- a/ansible/roles/proxmox/tasks/main.yml
+++ b/ansible/roles/proxmox/tasks/main.yml
@@ -9,6 +9,14 @@
 - name: Configure swap
   ansible.builtin.include_tasks: swap.yml
 
+- name: Manage power tuning
+  ansible.builtin.include_tasks:
+    file: power_saving.yml
+    apply:
+      tags: power_tuning
+  tags:
+    - power_tuning
+
 
 - name: Manage Proxmox module blacklist
   ansible.builtin.template:

--- a/ansible/roles/proxmox/tasks/main.yml
+++ b/ansible/roles/proxmox/tasks/main.yml
@@ -1,22 +1,44 @@
 ---
 
 - name: Manage Proxmox kernel parameters
-  ansible.builtin.include_tasks: bootloader_kernel_params.yml
+  ansible.builtin.include_tasks:
+    file: bootloader_kernel_params.yml
+    apply:
+      tags:
+        - kernel
+  tags:
+    - kernel
 
 - name: Manage GPU passthrough
-  ansible.builtin.include_tasks: gpu_passthrough.yml
+  ansible.builtin.include_tasks:
+    file: gpu_passthrough.yml
+    apply:
+      tags:
+        - gpu_passthrough
+  tags:
+    - gpu_passthrough
 
 - name: Configure swap
-  ansible.builtin.include_tasks: swap.yml
+  ansible.builtin.include_tasks:
+    file: swap.yml
+    apply:
+      tags:
+        - storage
+        - swap
+  tags:
+    - storage
+    - swap
 
 - name: Manage power tuning
   ansible.builtin.include_tasks:
     file: power_saving.yml
     apply:
-      tags: power_tuning
+      tags:
+        - power
+        - power_tuning
   tags:
+    - power
     - power_tuning
-
 
 - name: Manage Proxmox module blacklist
   ansible.builtin.template:
@@ -27,6 +49,8 @@
     mode: "0644"
   when: proxmox_modprobe_blacklist | default([]) | length > 0
   notify: Update initramfs
+  tags:
+    - kernel
 
 - name: Remove Proxmox module blacklist file when empty
   ansible.builtin.file:
@@ -34,6 +58,8 @@
     state: absent
   when: proxmox_modprobe_blacklist | default([]) | length == 0
   notify: Update initramfs
+  tags:
+    - kernel
 
 - name: Manage Proxmox module options
   ansible.builtin.template:
@@ -44,6 +70,8 @@
     mode: "0644"
   when: proxmox_modprobe_options | default([]) | length > 0
   notify: Update initramfs
+  tags:
+    - kernel
 
 - name: Remove Proxmox module options file when empty
   ansible.builtin.file:
@@ -51,20 +79,52 @@
     state: absent
   when: proxmox_modprobe_options | default([]) | length == 0
   notify: Update initramfs
+  tags:
+    - kernel
 
 - name: Include Proxmox ZFS thin provisioning audit
-  ansible.builtin.include_tasks: zfs_thin_audit.yml
+  ansible.builtin.include_tasks:
+    file: zfs_thin_audit.yml
+    apply:
+      tags:
+        - storage
+        - zfs
   when: proxmox_zfs_thin_enforce | default(false) | bool or proxmox_zfs_thin_audit | default(true) | bool
+  tags:
+    - storage
+    - zfs
 
 - name: Include Proxmox ZFS thin provisioning fix
-  ansible.builtin.include_tasks: zfs_thin_fix.yml
+  ansible.builtin.include_tasks:
+    file: zfs_thin_fix.yml
+    apply:
+      tags:
+        - storage
+        - zfs
   when: proxmox_zfs_thin_enforce | default(false) | bool
+  tags:
+    - storage
+    - zfs
 
 - name: Configure ZFS ARC cache limits
-  ansible.builtin.include_tasks: zfs_arc.yml
+  ansible.builtin.include_tasks:
+    file: zfs_arc.yml
+    apply:
+      tags:
+        - storage
+        - zfs
+  tags:
+    - storage
+    - zfs
 
 - name: CoreFreq (DKMS)
-  ansible.builtin.include_tasks: corefreq.yml
+  ansible.builtin.include_tasks:
+    file: corefreq.yml
+    apply:
+      tags:
+        - corefreq
+  tags:
+    - corefreq
 
 - name: Set root .profile
   ansible.builtin.template:
@@ -73,6 +133,8 @@
     owner: root
     group: root
     mode: "0644"
+  tags:
+    - shell
 
 - name: Set root .bashrc
   ansible.builtin.template:
@@ -81,6 +143,8 @@
     owner: root
     group: root
     mode: "0644"
+  tags:
+    - shell
 
 - name: Ensure root .hushlogin exists
   ansible.builtin.file:
@@ -91,3 +155,5 @@
     mode: "0644"
     access_time: preserve
     modification_time: preserve
+  tags:
+    - shell

--- a/ansible/roles/proxmox/tasks/power_saving.yml
+++ b/ansible/roles/proxmox/tasks/power_saving.yml
@@ -14,6 +14,25 @@
           - proxmox_power_cpu_epp in ["", "default", "performance", "balance_performance", "balance_power", "power"]
         fail_msg: "Unsupported CPU EPP '{{ proxmox_power_cpu_epp }}'."
 
+    - name: Power tuning | Stop and disable legacy units
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        enabled: false
+        state: stopped
+      loop: "{{ proxmox_power_tuning_units_to_remove }}"
+      failed_when: false
+      when:
+        - not ansible_check_mode
+        - proxmox_power_tuning_units_to_remove | length > 0
+
+    - name: Power tuning | Remove legacy unit files
+      ansible.builtin.file:
+        path: "/etc/systemd/system/{{ item }}"
+        state: absent
+      loop: "{{ proxmox_power_tuning_units_to_remove }}"
+      notify: Reload systemd daemon
+      when: proxmox_power_tuning_units_to_remove | length > 0
+
     - name: Power tuning | Install systemd unit
       ansible.builtin.template:
         src: power-tuning.service.j2

--- a/ansible/roles/proxmox/tasks/power_saving.yml
+++ b/ansible/roles/proxmox/tasks/power_saving.yml
@@ -38,7 +38,7 @@
       failed_when: proxmox_power_tuning_root_crontab.rc not in [0, 1]
       when:
         - proxmox_power_tuning_remove_legacy_cron | bool
-        - proxmox_power_tuning_legacy_cron_jobs | length > 0
+        - proxmox_power_tuning_cron_entries_to_remove | length > 0
 
     - name: Power tuning | Remove legacy root crontab entries
       ansible.builtin.shell: |
@@ -46,7 +46,7 @@
         crontab -l | grep -v -Fx {{ item | quote }} | crontab -
       args:
         executable: /bin/bash
-      loop: "{{ proxmox_power_tuning_legacy_cron_jobs }}"
+      loop: "{{ proxmox_power_tuning_cron_entries_to_remove }}"
       changed_when: true
       when:
         - proxmox_power_tuning_remove_legacy_cron | bool

--- a/ansible/roles/proxmox/tasks/power_saving.yml
+++ b/ansible/roles/proxmox/tasks/power_saving.yml
@@ -43,7 +43,7 @@
     - name: Power tuning | Remove legacy root crontab entries
       ansible.builtin.shell: |
         set -o pipefail
-        crontab -l | grep -v -Fx {{ item | quote }} | crontab -
+        (crontab -l | grep -v -Fx {{ item | quote }} || true) | crontab -
       args:
         executable: /bin/bash
       loop: "{{ proxmox_power_tuning_cron_entries_to_remove }}"

--- a/ansible/roles/proxmox/tasks/power_saving.yml
+++ b/ansible/roles/proxmox/tasks/power_saving.yml
@@ -1,0 +1,54 @@
+---
+- name: Power tuning | Manage service
+  when: proxmox_power_tuning_enabled | bool
+  block:
+    - name: Power tuning | Validate requested CPU governor
+      ansible.builtin.assert:
+        that:
+          - proxmox_power_cpu_governor in ["", "conservative", "ondemand", "userspace", "powersave", "performance", "schedutil"]
+        fail_msg: "Unsupported CPU governor '{{ proxmox_power_cpu_governor }}'."
+
+    - name: Power tuning | Validate requested CPU EPP
+      ansible.builtin.assert:
+        that:
+          - proxmox_power_cpu_epp in ["", "default", "performance", "balance_performance", "balance_power", "power"]
+        fail_msg: "Unsupported CPU EPP '{{ proxmox_power_cpu_epp }}'."
+
+    - name: Power tuning | Install systemd unit
+      ansible.builtin.template:
+        src: power-tuning.service.j2
+        dest: /etc/systemd/system/proxmox-power-tuning.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Reload systemd daemon
+
+    - name: Power tuning | Enable systemd unit
+      ansible.builtin.systemd:
+        name: proxmox-power-tuning.service
+        enabled: true
+        state: "{{ 'started' if proxmox_power_tuning_start_now | bool else omit }}"
+        daemon_reload: true
+      when: not ansible_check_mode
+
+    - name: Power tuning | Read root crontab
+      ansible.builtin.command: crontab -l
+      register: proxmox_power_tuning_root_crontab
+      changed_when: false
+      failed_when: proxmox_power_tuning_root_crontab.rc not in [0, 1]
+      when:
+        - proxmox_power_tuning_remove_legacy_cron | bool
+        - proxmox_power_tuning_legacy_cron_jobs | length > 0
+
+    - name: Power tuning | Remove legacy root crontab entries
+      ansible.builtin.shell: |
+        set -o pipefail
+        crontab -l | grep -v -Fx {{ item | quote }} | crontab -
+      args:
+        executable: /bin/bash
+      loop: "{{ proxmox_power_tuning_legacy_cron_jobs }}"
+      changed_when: true
+      when:
+        - proxmox_power_tuning_remove_legacy_cron | bool
+        - proxmox_power_tuning_root_crontab.rc == 0
+        - item in proxmox_power_tuning_root_crontab.stdout_lines

--- a/ansible/roles/proxmox/tasks/swap.yml
+++ b/ansible/roles/proxmox/tasks/swap.yml
@@ -1,13 +1,14 @@
 ---
 - name: Check if swapfile exists
   ansible.builtin.stat:
-    path: /swapfile
+    path: "{{ proxmox_swapfile_path }}"
   register: proxmox_swapfile_stat
 
 - name: Check swapfile attributes
-  ansible.builtin.command: lsattr /swapfile
+  ansible.builtin.command: "lsattr {{ proxmox_swapfile_path }}"
   register: proxmox_swapfile_attributes
   changed_when: false
+  check_mode: false
   when: proxmox_swapfile_stat.stat.exists
 
 - name: Determine if swapfile needs recreation
@@ -15,21 +16,25 @@
     proxmox_recreate_swapfile: >-
       {{
         not proxmox_swapfile_stat.stat.exists or
-        proxmox_swapfile_stat.stat.size | int != 17179869184 or
-        'C' not in proxmox_swapfile_attributes.stdout.split(' ')[1]
+        proxmox_swapfile_stat.stat.size | int != proxmox_swapfile_size_bytes | int or
+        'C' not in proxmox_swapfile_attr_flags
       }}
+  vars:
+    proxmox_swapfile_attr_flags: >-
+      {{ proxmox_swapfile_attributes.stdout.split()[0]
+         if proxmox_swapfile_attributes.stdout is defined else '' }}
 
 - name: Remove invalid swapfile
   when: proxmox_recreate_swapfile
   block:
     - name: Disable swap
-      ansible.builtin.command: swapoff /swapfile
+      ansible.builtin.command: "swapoff {{ proxmox_swapfile_path }}"
       failed_when: false
       changed_when: false
 
     - name: Remove swapfile
       ansible.builtin.file:
-        path: /swapfile
+        path: "{{ proxmox_swapfile_path }}"
         state: absent
 
 - name: Create BTRFS-compatible swapfile
@@ -37,26 +42,26 @@
   block:
     - name: Create empty swapfile
       ansible.builtin.file:
-        path: /swapfile
+        path: "{{ proxmox_swapfile_path }}"
         state: touch
         mode: '0600'
         owner: root
         group: root
 
     - name: Set NoCOW attribute
-      ansible.builtin.command: chattr +C /swapfile
+      ansible.builtin.command: "chattr +C {{ proxmox_swapfile_path }}"
       changed_when: false
 
-    - name: Allocate 16G to swapfile
-      ansible.builtin.command: fallocate -l 16G /swapfile
+    - name: Allocate swapfile
+      ansible.builtin.command: "fallocate -l {{ proxmox_swapfile_size }} {{ proxmox_swapfile_path }}"
       changed_when: false
 
     - name: Format swapfile
-      ansible.builtin.command: mkswap /swapfile
+      ansible.builtin.command: "mkswap {{ proxmox_swapfile_path }}"
       changed_when: false
 
 - name: Enable swap
-  ansible.builtin.command: swapon /swapfile
+  ansible.builtin.command: "swapon {{ proxmox_swapfile_path }}"
   changed_when: false
   failed_when: false
   when: proxmox_recreate_swapfile
@@ -64,14 +69,14 @@
 - name: Ensure swap is enabled and persists
   ansible.posix.mount:
     path: none
-    src: /swapfile
+    src: "{{ proxmox_swapfile_path }}"
     fstype: swap
     opts: sw
     state: present
 
 - name: Configure vm.swappiness
   ansible.builtin.copy:
-    content: "vm.swappiness=10\n"
+    content: "vm.swappiness={{ proxmox_swappiness }}\n"
     dest: /etc/sysctl.d/99-swappiness.conf
     owner: root
     group: root

--- a/ansible/roles/proxmox/tasks/zfs_thin_audit.yml
+++ b/ansible/roles/proxmox/tasks/zfs_thin_audit.yml
@@ -1,28 +1,27 @@
 ---
 - name: Verify required ZFS CLI tools exist
   ansible.builtin.command: "{{ item }}"
-  args:
-    executable: /bin/bash
   loop:
     - zfs
     - zpool
   register: proxmox_zfs_cli_check
   changed_when: false
+  check_mode: false
   failed_when: "'command not found' in proxmox_zfs_cli_check.stderr"
 
 - name: Verify all configured pools exist
   ansible.builtin.command: zpool list -H -o name "{{ item }}"
-  args:
-    executable: /bin/bash
   loop: "{{ proxmox_zfs_thin_pools }}"
   register: proxmox_zfs_pool_exists
   changed_when: false
+  check_mode: false
   failed_when: "'No such pool' in proxmox_zfs_pool_exists.stderr"
 
 - name: Show ZFS version for troubleshooting
   ansible.builtin.command: zfs version
   register: proxmox_zfs_version
   changed_when: false
+  check_mode: false
 
 - name: Show ZFS version output
   ansible.builtin.debug:
@@ -30,19 +29,17 @@
 
 - name: Collect pool health for all managed pools
   ansible.builtin.command: zpool list -H -o name,health "{{ item }}"
-  args:
-    executable: /bin/bash
   loop: "{{ proxmox_zfs_thin_pools }}"
   register: proxmox_zfs_pool_health
   changed_when: false
+  check_mode: false
 
 - name: Collect pool capacity for all managed pools (informational)
   ansible.builtin.command: zpool list -H -o name,cap "{{ item }}"
-  args:
-    executable: /bin/bash
   loop: "{{ proxmox_zfs_thin_pools }}"
   register: proxmox_zfs_pool_capacity
   changed_when: false
+  check_mode: false
 
 - name: Report pool status summary
   ansible.builtin.debug:
@@ -66,6 +63,7 @@
   loop: "{{ proxmox_zfs_thin_pools }}"
   register: proxmox_zfs_refreservation_findings
   changed_when: false
+  check_mode: false
 
 - name: Build consolidated findings list
   ansible.builtin.set_fact:

--- a/ansible/roles/proxmox/tasks/zfs_thin_fix.yml
+++ b/ansible/roles/proxmox/tasks/zfs_thin_fix.yml
@@ -57,6 +57,7 @@
   loop: "{{ proxmox_zfs_thin_pools }}"
   register: proxmox_zfs_postcheck
   changed_when: false
+  check_mode: false
   when: proxmox_datasets_to_fix_exist
 
 - name: Post-check report

--- a/ansible/roles/proxmox/templates/corefreqd.service.j2
+++ b/ansible/roles/proxmox/templates/corefreqd.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=CoreFreq Daemon
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/corefreqd -q
+ExecStop=/bin/kill -QUIT $MAINPID
+RemainAfterExit=no
+SuccessExitStatus=SIGQUIT SIGUSR1 SIGTERM
+Slice=-.slice
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/proxmox/templates/power-tuning.service.j2
+++ b/ansible/roles/proxmox/templates/power-tuning.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=Proxmox power tuning
+After=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+{% if proxmox_power_cpu_governor | length > 0 %}
+ExecStart=/bin/sh -c 'for p in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do [ -w "$p" ] && echo "{{ proxmox_power_cpu_governor }}" > "$p"; done'
+{% endif %}
+{% if proxmox_power_cpu_epp | length > 0 %}
+ExecStart=/bin/sh -c 'for p in /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_preference; do [ -w "$p" ] && echo "{{ proxmox_power_cpu_epp }}" > "$p"; done'
+{% endif %}
+{% if proxmox_power_powertop_auto_tune | bool %}
+ExecStart=/usr/sbin/powertop --auto-tune
+{% endif %}
+{% for command in proxmox_power_tuning_extra_commands %}
+ExecStart={{ command }}
+{% endfor %}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/proxmox/templates/power-tuning.service.j2
+++ b/ansible/roles/proxmox/templates/power-tuning.service.j2
@@ -11,6 +11,11 @@ ExecStart=/bin/sh -c 'for p in /sys/devices/system/cpu/cpu*/cpufreq/scaling_gove
 {% if proxmox_power_cpu_epp | length > 0 %}
 ExecStart=/bin/sh -c 'for p in /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_preference; do [ -w "$p" ] && echo "{{ proxmox_power_cpu_epp }}" > "$p"; done'
 {% endif %}
+{% if proxmox_power_cpu_boost | bool %}
+ExecStart=/bin/sh -c '[ -w /sys/devices/system/cpu/intel_pstate/no_turbo ] && echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo || true; [ -w /sys/devices/system/cpu/cpufreq/boost ] && echo 1 > /sys/devices/system/cpu/cpufreq/boost || true'
+{% else %}
+ExecStart=/bin/sh -c '[ -w /sys/devices/system/cpu/intel_pstate/no_turbo ] && echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo || true; [ -w /sys/devices/system/cpu/cpufreq/boost ] && echo 0 > /sys/devices/system/cpu/cpufreq/boost || true'
+{% endif %}
 {% if proxmox_power_powertop_auto_tune | bool %}
 ExecStart=/usr/sbin/powertop --auto-tune
 {% endif %}


### PR DESCRIPTION
## Summary

- Manage Proxmox power tuning through Ansible, including governor/EPP, powertop auto-tune, legacy cron cleanup, and optional CPU boost control.
- Enable power tuning for pve1 with boost disabled and keep pve3 power tuning enabled.
- Refactor the Proxmox role for maintainability with task tags, parameterized swap/CoreFreq/GPU cleanup defaults, a CoreFreq unit template, and role documentation.
- Enforce ZFS thin provisioning for all Proxmox nodes via group vars while removing redundant host overrides.

## Validation

- `env ANSIBLE_LOCAL_TEMP=/tmp/ansible-local pre-commit run --all-files`
- `ansible-playbook -i inventories/baremetal.yml playbooks/proxmox.yml --limit pve1 --check` returned `changed=0 failed=0 unreachable=0` after reboot validation.
- Live pve1 validation after reboot confirmed `proxmox-power-tuning.service` enabled/active, all CPUs using `powersave`, EPP set to `balance_power`, `intel_pstate/no_turbo=1`, and frequency policy capped at `400 MHz - 2.80 GHz` with clocks scaling under load.
- Earlier live pve3 validation confirmed the power tuning service state and ZFS thin provisioning enforcement.