### PR TITLE
feat(ansible): add whisper vulkan runtime

### DIFF
--- a/ansible/playbooks/llm_lxc.yml
+++ b/ansible/playbooks/llm_lxc.yml
@@ -6,4 +6,5 @@
     - lxc_hardening
     - lxc_bootstrap
     - llm_runtime
+    - whisper_runtime
     - llama_swap

--- a/ansible/roles/llama_swap/README.md
+++ b/ansible/roles/llama_swap/README.md
@@ -19,10 +19,14 @@ Important parameters:
 - `llama_swap_default_context_size`
 - `llama_swap_default_gpu_layers`
 - `llama_swap_default_extra_args`
+- `llama_swap_whisper_models_dir`
+- `llama_swap_whisper_default_extra_args`
 
 On first run only, the role scans `llama_swap_models_dir` for `*.gguf` files and
-creates `{{ llama_swap_config_path }}` with one `llama-server` backend per model.
-Model IDs are based on each GGUF path relative to `llama_swap_models_dir`.
+`llama_swap_whisper_models_dir` for Whisper `*.bin` files, then creates
+`{{ llama_swap_config_path }}` with one backend per model. LLM model IDs are
+based on each GGUF path relative to `llama_swap_models_dir`; STT model IDs are
+prefixed with `whisper/`.
 
 After the config file exists, the role does not modify it. Delete the file and
 rerun the playbook to regenerate the bootstrap config, or edit it manually for

--- a/ansible/roles/llama_swap/defaults/main.yml
+++ b/ansible/roles/llama_swap/defaults/main.yml
@@ -32,3 +32,11 @@ llama_swap_default_gpu_layers: 999
 llama_swap_default_flash_attention: true
 llama_swap_default_no_mmap: true
 llama_swap_default_extra_args: []
+
+llama_swap_whisper_models_dir: /opt/ai/models/whisper
+llama_swap_whisper_model_patterns:
+  - "ggml*.bin"
+  - "*.bin"
+llama_swap_whisper_default_extra_args:
+  - "--inference-path /v1/audio/transcriptions"
+  - "--convert"

--- a/ansible/roles/llama_swap/tasks/main.yml
+++ b/ansible/roles/llama_swap/tasks/main.yml
@@ -65,11 +65,32 @@
   register: llama_swap_discovered_models
   when: not llama_swap_config_stat.stat.exists
 
+- name: Check whisper model directory for initial llama-swap config
+  ansible.builtin.stat:
+    path: "{{ llama_swap_whisper_models_dir }}"
+  register: llama_swap_whisper_models_dir_stat
+  when: not llama_swap_config_stat.stat.exists
+
+- name: Find Whisper models for initial llama-swap config
+  ansible.builtin.find:
+    paths: "{{ llama_swap_whisper_models_dir }}"
+    patterns: "{{ llama_swap_whisper_model_patterns }}"
+    recurse: true
+    file_type: file
+  register: llama_swap_discovered_whisper_models
+  when:
+    - not llama_swap_config_stat.stat.exists
+    - llama_swap_whisper_models_dir_stat.stat.isdir | default(false)
+
 - name: Assert initial llama-swap config has models
   ansible.builtin.assert:
     that:
-      - llama_swap_discovered_models.files | length > 0
-    fail_msg: "No GGUF models found under {{ llama_swap_models_dir }} for initial llama-swap config"
+      - >-
+        (llama_swap_discovered_models.files | default([]) | length > 0)
+        or (llama_swap_discovered_whisper_models.files | default([]) | length > 0)
+    fail_msg: >-
+      No GGUF models found under {{ llama_swap_models_dir }} and no Whisper models found under
+      {{ llama_swap_whisper_models_dir }} for initial llama-swap config
   when: not llama_swap_config_stat.stat.exists
 
 - name: Create initial llama-swap config

--- a/ansible/roles/llama_swap/templates/config.yaml.j2
+++ b/ansible/roles/llama_swap/templates/config.yaml.j2
@@ -28,3 +28,17 @@ models:
 {% endfor %}
     name: {{ (model.path | basename | regex_replace('\\.gguf$', '')) | to_json }}
 {% endfor %}
+{% for model in llama_swap_discovered_whisper_models.files | default([]) | sort(attribute='path') %}
+{% set model_relative_path = model.path | replace(llama_swap_whisper_models_dir ~ '/', '') %}
+{% set model_id = 'whisper/' ~ (model_relative_path | regex_replace('\\.bin$', '')) %}
+  {{ model_id | to_json }}:
+    cmd: >-
+      whisper-server
+      --host 127.0.0.1
+      --port ${PORT}
+      -m {{ model.path | quote }}
+{% for arg in llama_swap_whisper_default_extra_args %}
+      {{ arg }}
+{% endfor %}
+    name: {{ (model.path | basename | regex_replace('\\.bin$', '')) | to_json }}
+{% endfor %}

--- a/ansible/roles/llm_runtime/README.md
+++ b/ansible/roles/llm_runtime/README.md
@@ -13,6 +13,8 @@ The role mirrors the important parts of the
 
 Important parameters:
 
+- `llm_runtime_enable_rocm`
+- `llm_runtime_enable_vulkan`
 - `llm_runtime_rocm_version`
 - `llm_runtime_llama_repo`
 - `llm_runtime_llama_ref`
@@ -26,6 +28,11 @@ Important parameters:
 - `llm_runtime_force_rebuild`
 - `llm_runtime_extra_packages`
 - `llm_runtime_vram_estimator_url`
+
+ROCm packages are installed only when `llm_runtime_enable_rocm` is true. Vulkan
+runtime/build packages are installed only when `llm_runtime_enable_vulkan` is
+true, so the same LXC can host ROCm `llama.cpp` and Vulkan workloads such as
+`whisper.cpp`.
 
 The role writes `{{ llm_runtime_llama_marker_path }}` after a successful build.
 Changing the ROCm version, llama.cpp ref, build flags, or patch settings causes

--- a/ansible/roles/llm_runtime/README.md
+++ b/ansible/roles/llm_runtime/README.md
@@ -15,6 +15,7 @@ Important parameters:
 
 - `llm_runtime_enable_rocm`
 - `llm_runtime_enable_vulkan`
+- `llm_runtime_enable_llama`
 - `llm_runtime_rocm_version`
 - `llm_runtime_llama_repo`
 - `llm_runtime_llama_ref`
@@ -33,6 +34,10 @@ ROCm packages are installed only when `llm_runtime_enable_rocm` is true. Vulkan
 runtime/build packages are installed only when `llm_runtime_enable_vulkan` is
 true, so the same LXC can host ROCm `llama.cpp` and Vulkan workloads such as
 `whisper.cpp`.
+
+`llm_runtime_enable_llama` controls whether this role builds `llama.cpp`.
+The current `llama.cpp` build is HIP/ROCm-based, so enabling it requires
+`llm_runtime_enable_rocm`.
 
 The role writes `{{ llm_runtime_llama_marker_path }}` after a successful build.
 Changing the ROCm version, llama.cpp ref, build flags, or patch settings causes

--- a/ansible/roles/llm_runtime/defaults/main.yml
+++ b/ansible/roles/llm_runtime/defaults/main.yml
@@ -5,6 +5,9 @@ llm_runtime_rocm_repo_description: "ROCm{{ llm_runtime_rocm_version }}"
 llm_runtime_rocm_repo_baseurl: "https://repo.radeon.com/rocm/rhel10/{{ llm_runtime_rocm_version }}/main"
 llm_runtime_rocm_repo_gpgkey: "https://repo.radeon.com/rocm/rocm.gpg.key"
 
+llm_runtime_enable_rocm: true
+llm_runtime_enable_vulkan: true
+
 llm_runtime_rocm_runtime_packages:
   - hip-runtime-amd
   - rocblas
@@ -36,6 +39,20 @@ llm_runtime_rocm_build_packages:
   - libomp
   - libomp-devel
   - patch
+
+llm_runtime_vulkan_runtime_packages:
+  - mesa-vulkan-drivers
+  - vulkan-loader
+  - vulkan-tools
+
+llm_runtime_vulkan_build_packages:
+  - vulkan-headers
+  - vulkan-loader-devel
+  - glslc
+  - glslang
+  - spirv-tools
+  - spirv-headers-devel
+  - vulkan-utility-libraries-devel
 
 llm_runtime_extra_packages: []
 

--- a/ansible/roles/llm_runtime/defaults/main.yml
+++ b/ansible/roles/llm_runtime/defaults/main.yml
@@ -7,6 +7,7 @@ llm_runtime_rocm_repo_gpgkey: "https://repo.radeon.com/rocm/rocm.gpg.key"
 
 llm_runtime_enable_rocm: true
 llm_runtime_enable_vulkan: true
+llm_runtime_enable_llama: true
 
 llm_runtime_rocm_runtime_packages:
   - hip-runtime-amd

--- a/ansible/roles/llm_runtime/tasks/main.yml
+++ b/ansible/roles/llm_runtime/tasks/main.yml
@@ -19,6 +19,13 @@
         + (['/dev/dri/renderD128'] if (llm_runtime_enable_rocm | bool or llm_runtime_enable_vulkan | bool) else [])
       }}
 
+- name: Ensure llama.cpp ROCm build has ROCm enabled
+  ansible.builtin.assert:
+    that:
+      - llm_runtime_enable_rocm | bool
+    fail_msg: "llm_runtime_enable_llama requires llm_runtime_enable_rocm because llama.cpp is built with HIP/ROCm."
+  when: llm_runtime_enable_llama | bool
+
 - name: Ensure GPU device nodes are present
   ansible.builtin.stat:
     path: "{{ item }}"
@@ -62,6 +69,7 @@
     owner: root
     group: root
     mode: "0755"
+  when: llm_runtime_enable_rocm | bool
 
 - name: Ensure llama.cpp parent directory exists
   ansible.builtin.file:
@@ -70,23 +78,28 @@
     owner: root
     group: root
     mode: "0755"
+  when: llm_runtime_enable_llama | bool
 
 - name: Check llama.cpp source directory
   ansible.builtin.stat:
     path: "{{ llm_runtime_llama_dir }}"
   register: llm_runtime_llama_dir_stat
+  when: llm_runtime_enable_llama | bool
 
 - name: Check llama.cpp git metadata
   ansible.builtin.stat:
     path: "{{ llm_runtime_llama_dir }}/.git"
   register: llm_runtime_llama_git_dir_stat
-  when: llm_runtime_llama_dir_stat.stat.exists
+  when:
+    - llm_runtime_enable_llama | bool
+    - llm_runtime_llama_dir_stat.stat.exists
 
 - name: Remove unmanaged llama.cpp source directory
   ansible.builtin.file:
     path: "{{ llm_runtime_llama_dir }}"
     state: absent
   when:
+    - llm_runtime_enable_llama | bool
     - llm_runtime_llama_dir_stat.stat.exists
     - not (llm_runtime_llama_git_dir_stat.stat.isdir | default(false))
 
@@ -101,6 +114,7 @@
     single_branch: "{{ llm_runtime_llama_single_branch }}"
     depth: "{{ llm_runtime_llama_depth }}"
   register: llm_runtime_llama_git
+  when: llm_runtime_enable_llama | bool
 
 - name: Ensure llama.cpp support directory exists
   ansible.builtin.file:
@@ -109,6 +123,7 @@
     owner: root
     group: root
     mode: "0755"
+  when: llm_runtime_enable_llama | bool
 
 - name: Update llama.cpp submodules # noqa command-instead-of-module
   ansible.builtin.command: git submodule update --recursive
@@ -116,6 +131,7 @@
     chdir: "{{ llm_runtime_llama_dir }}"
   register: llm_runtime_submodules
   changed_when: llm_runtime_submodules.stdout | length > 0
+  when: llm_runtime_enable_llama | bool
 
 - name: Install llama grammar patch
   ansible.builtin.copy:
@@ -125,7 +141,9 @@
     group: root
     mode: "0644"
   register: llm_runtime_grammar_patch_file
-  when: llm_runtime_llama_apply_grammar_patch | bool
+  when:
+    - llm_runtime_enable_llama | bool
+    - llm_runtime_llama_apply_grammar_patch | bool
 
 - name: Check whether llama grammar patch is already applied # noqa command-instead-of-module
   ansible.builtin.command: git apply --reverse --check {{ llm_runtime_llama_patch_path | quote }}
@@ -134,7 +152,9 @@
   register: llm_runtime_grammar_patch_reverse_check
   changed_when: false
   failed_when: false
-  when: llm_runtime_llama_apply_grammar_patch | bool
+  when:
+    - llm_runtime_enable_llama | bool
+    - llm_runtime_llama_apply_grammar_patch | bool
 
 - name: Check whether llama grammar patch can be applied # noqa command-instead-of-module
   ansible.builtin.command: git apply --check {{ llm_runtime_llama_patch_path | quote }}
@@ -144,6 +164,7 @@
   changed_when: false
   failed_when: false
   when:
+    - llm_runtime_enable_llama | bool
     - llm_runtime_llama_apply_grammar_patch | bool
     - llm_runtime_grammar_patch_reverse_check.rc != 0
 
@@ -154,6 +175,7 @@
   register: llm_runtime_grammar_patch_apply
   changed_when: true
   when:
+    - llm_runtime_enable_llama | bool
     - llm_runtime_llama_apply_grammar_patch | bool
     - llm_runtime_grammar_patch_reverse_check.rc != 0
     - llm_runtime_grammar_patch_forward_check.rc == 0
@@ -162,6 +184,7 @@
   ansible.builtin.fail:
     msg: "llama grammar patch is neither applied nor cleanly applicable"
   when:
+    - llm_runtime_enable_llama | bool
     - llm_runtime_llama_apply_grammar_patch | bool
     - llm_runtime_grammar_patch_reverse_check.rc != 0
     - llm_runtime_grammar_patch_forward_check.rc != 0
@@ -173,12 +196,14 @@
     owner: root
     group: root
     mode: "0644"
+  when: llm_runtime_enable_llama | bool
 
 - name: Check current llama.cpp build marker
   ansible.builtin.command: cmp -s /tmp/llm-runtime-build-marker.json {{ llm_runtime_llama_marker_path | quote }}
   register: llm_runtime_marker_cmp
   changed_when: false
   failed_when: false
+  when: llm_runtime_enable_llama | bool
 
 - name: Determine whether llama.cpp rebuild is required
   ansible.builtin.set_fact:
@@ -190,6 +215,7 @@
         or (llm_runtime_grammar_patch_apply.changed | default(false))
         or llm_runtime_marker_cmp.rc != 0
       }}
+  when: llm_runtime_enable_llama | bool
 
 - name: Configure llama.cpp ROCm build
   ansible.builtin.command: >-
@@ -205,7 +231,9 @@
   args:
     chdir: "{{ llm_runtime_llama_dir }}"
   changed_when: true
-  when: llm_runtime_rebuild_required | bool
+  when:
+    - llm_runtime_enable_llama | bool
+    - llm_runtime_rebuild_required | bool
 
 - name: Build llama.cpp
   ansible.builtin.command: >-
@@ -215,7 +243,9 @@
   args:
     chdir: "{{ llm_runtime_llama_dir }}"
   changed_when: true
-  when: llm_runtime_rebuild_required | bool
+  when:
+    - llm_runtime_enable_llama | bool
+    - llm_runtime_rebuild_required | bool
 
 - name: Install llama.cpp
   ansible.builtin.command: >-
@@ -224,7 +254,9 @@
   args:
     chdir: "{{ llm_runtime_llama_dir }}"
   changed_when: true
-  when: llm_runtime_rebuild_required | bool
+  when:
+    - llm_runtime_enable_llama | bool
+    - llm_runtime_rebuild_required | bool
 
 - name: Configure local library path
   ansible.builtin.copy:
@@ -236,6 +268,7 @@
     group: root
     mode: "0644"
   register: llm_runtime_ld_config_file
+  when: llm_runtime_enable_llama | bool
 
 - name: Copy llama.cpp shared libraries to lib64
   ansible.builtin.shell: |
@@ -244,11 +277,14 @@
   args:
     executable: /bin/bash
   changed_when: true
-  when: llm_runtime_rebuild_required | bool
+  when:
+    - llm_runtime_enable_llama | bool
+    - llm_runtime_rebuild_required | bool
 
 - name: Refresh dynamic linker cache
   ansible.builtin.command: ldconfig
   changed_when: llm_runtime_rebuild_required | bool or llm_runtime_ld_config_file.changed
+  when: llm_runtime_enable_llama | bool
 
 - name: Save llama.cpp build marker
   ansible.builtin.copy:
@@ -258,7 +294,9 @@
     group: root
     mode: "0644"
     remote_src: true
-  when: llm_runtime_rebuild_required | bool
+  when:
+    - llm_runtime_enable_llama | bool
+    - llm_runtime_rebuild_required | bool
 
 - name: Install GGUF VRAM estimator helper
   ansible.builtin.get_url:
@@ -277,6 +315,7 @@
 - name: Validate llama.cpp binary is installed
   ansible.builtin.command: llama-cli --help
   changed_when: false
+  when: llm_runtime_enable_llama | bool
 
 - name: Validate Vulkan can inspect devices
   ansible.builtin.command: vulkaninfo --summary

--- a/ansible/roles/llm_runtime/tasks/main.yml
+++ b/ansible/roles/llm_runtime/tasks/main.yml
@@ -5,19 +5,31 @@
       - ansible_os_family == 'RedHat'
     fail_msg: "llm_runtime currently supports Fedora/RedHat containers only"
 
-- name: Ensure ROCm device nodes are present
+- name: Resolve LLM runtime package list
+  ansible.builtin.set_fact:
+    llm_runtime_packages_effective: >-
+      {{
+        (llm_runtime_rocm_runtime_packages + llm_runtime_rocm_build_packages if llm_runtime_enable_rocm | bool else [])
+        + (llm_runtime_vulkan_runtime_packages + llm_runtime_vulkan_build_packages if llm_runtime_enable_vulkan | bool else [])
+        + llm_runtime_extra_packages
+      }}
+    llm_runtime_required_device_nodes: >-
+      {{
+        (['/dev/kfd'] if llm_runtime_enable_rocm | bool else [])
+        + (['/dev/dri/renderD128'] if (llm_runtime_enable_rocm | bool or llm_runtime_enable_vulkan | bool) else [])
+      }}
+
+- name: Ensure GPU device nodes are present
   ansible.builtin.stat:
     path: "{{ item }}"
-  loop:
-    - /dev/kfd
-    - /dev/dri/renderD128
+  loop: "{{ llm_runtime_required_device_nodes }}"
   register: llm_runtime_device_nodes
 
-- name: Assert ROCm device nodes are present
+- name: Assert GPU device nodes are present
   ansible.builtin.assert:
     that:
       - item.stat.exists
-    fail_msg: "Required ROCm device node {{ item.item }} is missing"
+    fail_msg: "Required GPU device node {{ item.item }} is missing"
   loop: "{{ llm_runtime_device_nodes.results }}"
   loop_control:
     label: "{{ item.item }}"
@@ -29,15 +41,11 @@
     owner: root
     group: root
     mode: "0644"
+  when: llm_runtime_enable_rocm | bool
 
-- name: Install ROCm runtime and llama.cpp build packages
+- name: Install LLM runtime backend packages
   ansible.builtin.dnf:
-    name: >-
-      {{
-        llm_runtime_rocm_runtime_packages
-        + llm_runtime_rocm_build_packages
-        + llm_runtime_extra_packages
-      }}
+    name: "{{ llm_runtime_packages_effective }}"
     state: present
     install_weak_deps: false
     exclude:
@@ -45,6 +53,7 @@
       - "*samples*"
       - "*-doc*"
       - "*-docs*"
+  when: llm_runtime_packages_effective | length > 0
 
 - name: Configure ROCm shell environment
   ansible.builtin.template:
@@ -263,7 +272,13 @@
 - name: Validate ROCm can inspect devices
   ansible.builtin.command: rocminfo
   changed_when: false
+  when: llm_runtime_enable_rocm | bool
 
 - name: Validate llama.cpp binary is installed
   ansible.builtin.command: llama-cli --help
   changed_when: false
+
+- name: Validate Vulkan can inspect devices
+  ansible.builtin.command: vulkaninfo --summary
+  changed_when: false
+  when: llm_runtime_enable_vulkan | bool

--- a/ansible/roles/llm_runtime/templates/build-marker.json.j2
+++ b/ansible/roles/llm_runtime/templates/build-marker.json.j2
@@ -5,6 +5,7 @@
   "llama_single_branch": {{ llm_runtime_llama_single_branch | bool | to_json }},
   "llama_depth": {{ llm_runtime_llama_depth | to_json }},
   "apply_grammar_patch": {{ llm_runtime_llama_apply_grammar_patch | bool | to_json }},
+  "enable_llama": {{ llm_runtime_enable_llama | bool | to_json }},
   "amdgpu_targets": {{ llm_runtime_amdgpu_targets | to_json }},
   "build_type": {{ llm_runtime_build_type | to_json }},
   "enable_rpc": {{ llm_runtime_enable_rpc | bool | to_json }},

--- a/ansible/roles/whisper_runtime/README.md
+++ b/ansible/roles/whisper_runtime/README.md
@@ -12,9 +12,15 @@ Important parameters:
 - `whisper_runtime_update`
 - `whisper_runtime_depth`
 - `whisper_runtime_enable_vulkan`
+- `whisper_runtime_build_examples`
 - `whisper_runtime_packages`
 - `whisper_runtime_force_rebuild`
 - `whisper_runtime_extra_cmake_args`
+
+`whisper_runtime_build_examples` controls whether the upstream examples are
+built. Keep it enabled when using `whisper-server`, including through
+`llama-swap`; when disabled, the role skips the `whisper-server --help`
+validation.
 
 Source updates are opt-in with `whisper_runtime_update`, matching the
 `llm_runtime` role. To update from `master`, set `whisper_runtime_update: true`

--- a/ansible/roles/whisper_runtime/README.md
+++ b/ansible/roles/whisper_runtime/README.md
@@ -1,0 +1,21 @@
+# Whisper Runtime Role
+
+Builds and installs `whisper.cpp` for STT workloads in LLM LXCs.
+
+The default build enables the Vulkan backend so STT can run alongside the ROCm
+`llama.cpp` runtime without changing the known-good LLM build.
+
+Important parameters:
+
+- `whisper_runtime_repo`
+- `whisper_runtime_ref`
+- `whisper_runtime_update`
+- `whisper_runtime_depth`
+- `whisper_runtime_enable_vulkan`
+- `whisper_runtime_packages`
+- `whisper_runtime_force_rebuild`
+- `whisper_runtime_extra_cmake_args`
+
+Source updates are opt-in with `whisper_runtime_update`, matching the
+`llm_runtime` role. To update from `master`, set `whisper_runtime_update: true`
+for one playbook run, then set it back to `false`.

--- a/ansible/roles/whisper_runtime/defaults/main.yml
+++ b/ansible/roles/whisper_runtime/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+whisper_runtime_enabled: true
+
+whisper_runtime_repo: "https://github.com/ggml-org/whisper.cpp.git"
+whisper_runtime_ref: "master"
+whisper_runtime_update: false
+whisper_runtime_single_branch: true
+whisper_runtime_depth: 1
+whisper_runtime_dir: /opt/whisper.cpp
+whisper_runtime_build_dir: "{{ whisper_runtime_dir }}/build"
+whisper_runtime_marker_path: "{{ whisper_runtime_dir }}/.ansible-build.json"
+
+whisper_runtime_build_type: Release
+whisper_runtime_build_jobs: "{{ ansible_processor_vcpus | default(ansible_processor_nproc | default(4)) }}"
+whisper_runtime_force_rebuild: false
+
+whisper_runtime_enable_vulkan: true
+whisper_runtime_build_shared_libs: false
+whisper_runtime_build_examples: true
+whisper_runtime_extra_cmake_args: []
+
+whisper_runtime_packages:
+  - cmake
+  - gcc
+  - gcc-c++
+  - git
+  - make
+  - ffmpeg-free
+  - libgomp
+  - mesa-vulkan-drivers
+  - vulkan-loader
+  - vulkan-headers
+  - vulkan-loader-devel
+  - glslc
+  - glslang
+  - spirv-tools
+  - spirv-headers-devel

--- a/ansible/roles/whisper_runtime/tasks/main.yml
+++ b/ansible/roles/whisper_runtime/tasks/main.yml
@@ -1,0 +1,159 @@
+---
+- name: Ensure whisper runtime supports this OS family
+  ansible.builtin.assert:
+    that:
+      - ansible_os_family == 'RedHat'
+    fail_msg: "whisper_runtime currently supports Fedora/RedHat containers only"
+  when: whisper_runtime_enabled | bool
+
+- name: Ensure Vulkan render node is present
+  ansible.builtin.stat:
+    path: /dev/dri/renderD128
+  register: whisper_runtime_render_node
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_enable_vulkan | bool
+
+- name: Assert Vulkan render node is present
+  ansible.builtin.assert:
+    that:
+      - whisper_runtime_render_node.stat.exists
+    fail_msg: "Required Vulkan render node /dev/dri/renderD128 is missing"
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_enable_vulkan | bool
+
+- name: Install whisper.cpp runtime and build packages
+  ansible.builtin.dnf:
+    name: "{{ whisper_runtime_packages }}"
+    state: present
+    install_weak_deps: false
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_packages | length > 0
+
+- name: Ensure whisper.cpp parent directory exists
+  ansible.builtin.file:
+    path: "{{ whisper_runtime_dir | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: whisper_runtime_enabled | bool
+
+- name: Check whisper.cpp source directory
+  ansible.builtin.stat:
+    path: "{{ whisper_runtime_dir }}"
+  register: whisper_runtime_dir_stat
+  when: whisper_runtime_enabled | bool
+
+- name: Check whisper.cpp git metadata
+  ansible.builtin.stat:
+    path: "{{ whisper_runtime_dir }}/.git"
+  register: whisper_runtime_git_dir_stat
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_dir_stat.stat.exists
+
+- name: Remove unmanaged whisper.cpp source directory
+  ansible.builtin.file:
+    path: "{{ whisper_runtime_dir }}"
+    state: absent
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_dir_stat.stat.exists
+    - not (whisper_runtime_git_dir_stat.stat.isdir | default(false))
+
+- name: Clone or update whisper.cpp source
+  ansible.builtin.git:
+    repo: "{{ whisper_runtime_repo }}"
+    dest: "{{ whisper_runtime_dir }}"
+    version: "{{ whisper_runtime_ref }}"
+    recursive: true
+    update: "{{ whisper_runtime_update | bool }}"
+    force: false
+    single_branch: "{{ whisper_runtime_single_branch }}"
+    depth: "{{ whisper_runtime_depth }}"
+  register: whisper_runtime_git
+  when: whisper_runtime_enabled | bool
+
+- name: Render desired whisper.cpp build marker
+  ansible.builtin.template:
+    src: build-marker.json.j2
+    dest: /tmp/whisper-runtime-build-marker.json
+    owner: root
+    group: root
+    mode: "0644"
+  when: whisper_runtime_enabled | bool
+
+- name: Check current whisper.cpp build marker
+  ansible.builtin.command: cmp -s /tmp/whisper-runtime-build-marker.json {{ whisper_runtime_marker_path | quote }}
+  register: whisper_runtime_marker_cmp
+  changed_when: false
+  failed_when: false
+  when: whisper_runtime_enabled | bool
+
+- name: Determine whether whisper.cpp rebuild is required
+  ansible.builtin.set_fact:
+    whisper_runtime_rebuild_required: >-
+      {{
+        whisper_runtime_force_rebuild | bool
+        or whisper_runtime_git.changed
+        or whisper_runtime_marker_cmp.rc != 0
+      }}
+  when: whisper_runtime_enabled | bool
+
+- name: Configure whisper.cpp Vulkan build
+  ansible.builtin.command: >-
+    cmake -S . -B {{ whisper_runtime_build_dir | quote }}
+    -DCMAKE_BUILD_TYPE={{ whisper_runtime_build_type | quote }}
+    -DGGML_VULKAN={{ 'ON' if whisper_runtime_enable_vulkan | bool else 'OFF' }}
+    -DBUILD_SHARED_LIBS={{ 'ON' if whisper_runtime_build_shared_libs | bool else 'OFF' }}
+    -DWHISPER_BUILD_EXAMPLES={{ 'ON' if whisper_runtime_build_examples | bool else 'OFF' }}
+    {{ whisper_runtime_extra_cmake_args | join(' ') }}
+  args:
+    chdir: "{{ whisper_runtime_dir }}"
+  changed_when: true
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_rebuild_required | bool
+
+- name: Build whisper.cpp
+  ansible.builtin.command: >-
+    cmake --build {{ whisper_runtime_build_dir | quote }}
+    --config {{ whisper_runtime_build_type | quote }}
+    -- -j{{ whisper_runtime_build_jobs }}
+  args:
+    chdir: "{{ whisper_runtime_dir }}"
+  changed_when: true
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_rebuild_required | bool
+
+- name: Install whisper.cpp
+  ansible.builtin.command: >-
+    cmake --install {{ whisper_runtime_build_dir | quote }}
+    --config {{ whisper_runtime_build_type | quote }}
+  args:
+    chdir: "{{ whisper_runtime_dir }}"
+  changed_when: true
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_rebuild_required | bool
+
+- name: Save whisper.cpp build marker
+  ansible.builtin.copy:
+    src: /tmp/whisper-runtime-build-marker.json
+    dest: "{{ whisper_runtime_marker_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+    remote_src: true
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_rebuild_required | bool
+
+- name: Validate whisper-server binary is installed
+  ansible.builtin.command: whisper-server --help
+  changed_when: false
+  when: whisper_runtime_enabled | bool

--- a/ansible/roles/whisper_runtime/tasks/main.yml
+++ b/ansible/roles/whisper_runtime/tasks/main.yml
@@ -156,4 +156,6 @@
 - name: Validate whisper-server binary is installed
   ansible.builtin.command: whisper-server --help
   changed_when: false
-  when: whisper_runtime_enabled | bool
+  when:
+    - whisper_runtime_enabled | bool
+    - whisper_runtime_build_examples | bool

--- a/ansible/roles/whisper_runtime/templates/build-marker.json.j2
+++ b/ansible/roles/whisper_runtime/templates/build-marker.json.j2
@@ -1,0 +1,11 @@
+{
+  "repo": {{ whisper_runtime_repo | to_json }},
+  "ref": {{ whisper_runtime_ref | to_json }},
+  "single_branch": {{ whisper_runtime_single_branch | bool | to_json }},
+  "depth": {{ whisper_runtime_depth | to_json }},
+  "build_type": {{ whisper_runtime_build_type | to_json }},
+  "enable_vulkan": {{ whisper_runtime_enable_vulkan | bool | to_json }},
+  "build_shared_libs": {{ whisper_runtime_build_shared_libs | bool | to_json }},
+  "build_examples": {{ whisper_runtime_build_examples | bool | to_json }},
+  "extra_cmake_args": {{ whisper_runtime_extra_cmake_args | to_json }}
+}


### PR DESCRIPTION
## Summary
- add backend-specific ROCm/Vulkan package flags to the LLM LXC runtime
- add a whisper_runtime role that builds and installs whisper.cpp with Vulkan
- extend llama-swap bootstrap config generation to include Whisper model files under /opt/ai/models/whisper

## Validation
- ansible-playbook -i inventories/llm.yml playbooks/llm_lxc.yml --syntax-check
- ansible-lint playbooks/llm_lxc.yml roles/llm_runtime roles/whisper_runtime roles/llama_swap
- full playbook run against ct-llm completed successfully
- repeat full playbook run against ct-llm completed with changed=0
- verified vulkaninfo sees AMD Radeon 8060S Graphics via RADV
- verified /usr/local/bin/whisper-server is installed and responds to --help