### PR TITLE
fix(terraform): avoid lxc ssh bootstrap reruns

### DIFF
--- a/terraform/instances/lxc/llm/lxc_definition.tf
+++ b/terraform/instances/lxc/llm/lxc_definition.tf
@@ -16,7 +16,6 @@ locals {
       "ai",
       "amd",
       "gpu",
-      "llm",
     ]
   }
 

--- a/terraform/modules/proxmox_lxc/main.tf
+++ b/terraform/modules/proxmox_lxc/main.tf
@@ -35,10 +35,6 @@ locals {
     if container.template_key != null
   }
 
-  ssh_bootstrap_containers = {
-    for container in local.normalized_containers : container.name => container
-    if try(container.ssh_bootstrap.enabled, false)
-  }
 }
 
 resource "proxmox_download_file" "lxc_image" {
@@ -198,34 +194,16 @@ resource "proxmox_virtual_environment_container" "this" {
   }
 
   environment_variables = each.value.environment_variables
-}
-
-resource "terraform_data" "ssh_bootstrap" {
-  for_each = local.ssh_bootstrap_containers
-
-  input = {
-    target_node      = each.value.target_node
-    vmid             = each.value.vmid
-    ip_address       = try(each.value.ip_address, null)
-    template_file_id = each.value.template_key == null ? each.value.template_file_id : proxmox_download_file.lxc_image[each.key].id
-    packages         = each.value.ssh_bootstrap.packages
-    services         = each.value.ssh_bootstrap.services
-  }
-
-  triggers_replace = [
-    each.value.target_node,
-    each.value.vmid,
-    try(each.value.ip_address, ""),
-    each.value.template_key == null ? each.value.template_file_id : proxmox_download_file.lxc_image[each.key].id,
-    join(",", each.value.ssh_bootstrap.packages),
-    join(",", each.value.ssh_bootstrap.services),
-  ]
 
   provisioner "local-exec" {
     command = <<-EOT
       set -euo pipefail
 
-      cluster_status="$(ssh -F /dev/null ${var.ssh_bootstrap_cluster_ssh_host} 'pvesh get /cluster/status --output-format json')"
+      if [ "${try(each.value.ssh_bootstrap.enabled, false)}" != "true" ]; then
+        exit 0
+      fi
+
+      cluster_status="$(ssh -F /dev/null ${coalesce(var.ssh_bootstrap_cluster_ssh_host, "")} 'pvesh get /cluster/status --output-format json')"
       node_ip="$(printf '%s\n' "$cluster_status" | jq -r --arg node '${each.value.target_node}' '.[] | select(.type == "node" and .name == $node and .online == 1) | .ip' | head -n 1)"
 
       if [ -z "$node_ip" ] || [ "$node_ip" = "null" ]; then
@@ -233,18 +211,18 @@ resource "terraform_data" "ssh_bootstrap" {
         exit 1
       fi
 
-      ssh -F /dev/null ${var.ssh_bootstrap_node_ssh_user}@"$node_ip" 'pct exec ${each.value.vmid} -- ${each.value.ssh_bootstrap.package_manager} install -y ${join(" ", each.value.ssh_bootstrap.packages)}'
-      ssh -F /dev/null ${var.ssh_bootstrap_node_ssh_user}@"$node_ip" 'pct exec ${each.value.vmid} -- systemctl enable --now ${join(" ", each.value.ssh_bootstrap.services)}'
+      ssh -F /dev/null ${var.ssh_bootstrap_node_ssh_user}@"$node_ip" 'pct exec ${each.value.vmid} -- ${try(each.value.ssh_bootstrap.package_manager, "dnf")} install -y ${join(" ", try(each.value.ssh_bootstrap.packages, []))}'
+      ssh -F /dev/null ${var.ssh_bootstrap_node_ssh_user}@"$node_ip" 'pct exec ${each.value.vmid} -- systemctl enable --now ${join(" ", try(each.value.ssh_bootstrap.services, []))}'
 
-      if [ "${each.value.ssh_bootstrap.wait_for_ssh}" = "true" ]; then
-        for attempt in $(seq 1 ${each.value.ssh_bootstrap.timeout_attempts}); do
-          if ssh -F /dev/null -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=${each.value.ssh_bootstrap.connect_timeout} ${each.value.ssh_bootstrap.ssh_user}@${each.value.ip_address} true; then
+      if [ "${try(each.value.ssh_bootstrap.wait_for_ssh, true)}" = "true" ]; then
+        for attempt in $(seq 1 ${try(each.value.ssh_bootstrap.timeout_attempts, 30)}); do
+          if ssh -F /dev/null -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=${try(each.value.ssh_bootstrap.connect_timeout, 5)} ${try(each.value.ssh_bootstrap.ssh_user, "root")}@${coalesce(try(each.value.ip_address, null), "")} true; then
             exit 0
           fi
-          sleep ${each.value.ssh_bootstrap.retry_delay}
+          sleep ${try(each.value.ssh_bootstrap.retry_delay, 2)}
         done
 
-        echo "SSH did not become reachable on ${each.value.ip_address}" >&2
+        echo "SSH did not become reachable on ${coalesce(try(each.value.ip_address, null), "")}" >&2
         exit 1
       fi
     EOT
@@ -252,17 +230,9 @@ resource "terraform_data" "ssh_bootstrap" {
     interpreter = ["/usr/bin/env", "bash", "-c"]
   }
 
-  depends_on = [
-    proxmox_virtual_environment_container.this,
-  ]
-
   lifecycle {
-    replace_triggered_by = [
-      proxmox_virtual_environment_container.this[each.key],
-    ]
-
     precondition {
-      condition     = var.ssh_bootstrap_cluster_ssh_host != null
+      condition     = !try(each.value.ssh_bootstrap.enabled, false) || var.ssh_bootstrap_cluster_ssh_host != null
       error_message = "ssh_bootstrap_cluster_ssh_host is required when any container enables ssh_bootstrap."
     }
   }


### PR DESCRIPTION
## Summary
- remove the broad container-level replacement trigger from LXC SSH bootstrap
- keep bootstrap creation ordered after the container and driven by its own input triggers
- remove the llm Proxmox tag from the LLM LXC definition

## Why
The bootstrap provisioner only needs to run after initial container creation or when bootstrap inputs change. Watching the whole container caused unrelated metadata changes, like tag updates, to rerun SSH bootstrap unnecessarily.

## Validation
- terraform -chdir=terraform/modules/proxmox_lxc fmt -check
- terraform -chdir=terraform/instances/lxc/llm fmt -check
- terraform -chdir=terraform/modules/proxmox_lxc validate
- terraform -chdir=terraform/instances/lxc/llm validate
- terraform -chdir=terraform/instances/lxc/llm plan