### PR TITLE
feat(kubernetes): add litellm deployment

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/ai/litellm/cnpg-cluster.yaml
@@ -1,0 +1,67 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: litellm-pg
+  namespace: ai
+  labels:
+    release: observability-kube-prometheus-stack
+spec:
+  inheritedMetadata:
+    labels:
+      recurring-job.longhorn.io/backup-daily: enabled
+      recurring-job.longhorn.io/backup-weekly: enabled
+  instances: 1
+  monitoring:
+    enablePodMonitor: true
+  storage:
+    size: 5Gi
+    storageClass: longhorn-r2
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:18
+
+  postgresql:
+    parameters:
+      wal_level: "replica"
+      archive_timeout: "43200" # Wait 12 hours before shipping WALs when no activity
+      archive_mode: "on"
+
+  bootstrap:
+    initdb:
+      database: litellm
+      owner: litellm
+      secret:
+        name: litellm-db-secrets
+
+  backup:
+    barmanObjectStore:
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-backup-s3
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-backup-s3
+          key: ACCESS_SECRET_KEY
+        region:
+          name: cnpg-backup-s3
+          key: AWS_DEFAULT_REGION
+      destinationPath: "s3://cloudnative-pg/litellm"
+      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
+      serverName: "litellm-pg-v1"
+    retentionPolicy: "14d"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: litellm-pg-backup
+  namespace: ai
+spec:
+  schedule: "0 0 * * *"  # Daily at midnight
+  backupOwnerReference: self
+  cluster:
+    name: litellm-pg
+  method: barmanObjectStore

--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -1,0 +1,168 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: litellm
+  namespace: ai
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              # renovate: datasource=docker depName=berriai/litellm registryUrl=https://ghcr.io
+              repository: ghcr.io/berriai/litellm
+              tag: v1.85.0
+            env:
+              TZ: Europe/Berlin
+              STORE_MODEL_IN_DB: "True"
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-db-secrets
+                    key: DATABASE_URL
+              LITELLM_MASTER_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secrets
+                    key: LITELLM_MASTER_KEY
+              LITELLM_SALT_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secrets
+                    key: LITELLM_SALT_KEY
+              REDIS_HOST: litellm-valkey
+              REDIS_PORT: "6379"
+            ports:
+              - name: http
+                containerPort: 4000
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/liveliness
+                    port: 4000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/readiness
+                    port: 4000
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/liveliness
+                    port: 4000
+                  failureThreshold: 60
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+
+      valkey:
+        containers:
+          valkey:
+            image:
+              # renovate: datasource=docker depName=valkey/valkey registryUrl=https://docker.io
+              repository: docker.io/valkey/valkey
+              tag: 9-alpine
+            command:
+              - valkey-server
+              - --save
+              - ""
+              - --appendonly
+              - "no"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - redis-cli ping || exit 1
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - -c
+                      - redis-cli ping || exit 1
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                cpu: 250m
+                memory: 256Mi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 4000
+      valkey:
+        controller: valkey
+        ports:
+          valkey:
+            port: 6379
+
+    ingress:
+      main:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: litellm.lan.${CLUSTER_DOMAIN}
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: LiteLLM
+          gethomepage.dev/description: LLM gateway
+          gethomepage.dev/group: "Kubernetes"
+          gethomepage.dev/icon: litellm.png
+        hosts:
+          - host: litellm.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+
+    persistence:
+      valkey-data:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          valkey:
+            valkey:
+              - path: /data

--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -149,7 +149,7 @@ spec:
           gethomepage.dev/name: LiteLLM
           gethomepage.dev/description: LLM gateway
           gethomepage.dev/group: "Kubernetes"
-          gethomepage.dev/icon: litellm.png
+          gethomepage.dev/icon: litlellm.png
         hosts:
           - host: litellm.lan.${CLUSTER_DOMAIN}
             paths:

--- a/kubernetes/apps/apps/ai/litellm/kustomization.yaml
+++ b/kubernetes/apps/apps/ai/litellm/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+  - ../../../../components/ingress/traefik-base
+  - ../../../../components/ingress/auth-guard
+
+resources:
+  - litellm-db-secrets.sops.yaml
+  - litellm-secrets.sops.yaml
+  - cnpg-cluster.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/apps/ai/litellm/litellm-db-secrets.sops.yaml
+++ b/kubernetes/apps/apps/ai/litellm/litellm-db-secrets.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: litellm-db-secrets
+    namespace: ai
+type: Opaque
+stringData:
+    username: ENC[AES256_GCM,data:ixp51ICibQ==,iv:ZZxib3Sh+SxDNZ5jtLQ/ccmlDOilpFiChpKdztKwlgg=,tag:+BsHH9/ZkQxuUxtUZmxZlw==,type:str]
+    password: ENC[AES256_GCM,data:alIDhCWpCfkBL7ipWsDhR0tgOFqhPHuCSmzLKbkx6eL1aEq8eVm7h1/i/Yn9wrPPH7A9g5RP5UgU+4CPf00oMw==,iv:Tw2trzpj/sVRCKQV99z+5esmCIWwCHkKiGaG+bfP4ew=,tag:iYjdn4jE6+UBzmF0Wd4Uxg==,type:str]
+    DATABASE_URL: ENC[AES256_GCM,data:XFuNWNZsoyzmnPpcGcmw42LFnT6FpNsMzqIx6guGr9batoTseKpA9hmJ3zQDkduDwIjufjUSUxCV0FQjVPjugV+h/OPnlv/iUwnsRvttxvII6vVgP/Q24BEUNHGRxT0eSUGClm3R2VVzwm3E2cjPGQ==,iv:6CfpTybD8hXYzlURvMOh5W2P7P8T3PJ92aPJGVPHmDk=,tag:Oe0ig84iMux6nYpYUlz//A==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5bnA1eUJjRklJRVV2Uzd6
+            b0lsNS9FVWJETmtmK0FPejlKWlFPVnRzTjNRCnh5TUNZRUNyNklRLzRrNEVPbm15
+            bEl1MjlOa2p1RHlWV3gxdmVSQVpsY3MKLS0tIHNkZE5RK0JPckNvOG9ydkc2emRC
+            LzBOcSttSVpzK1R6Z1I5RUlXUVRVYjgKLQ+HXHaGDpaeXg+B9Ut/wtLgSqZNoM3X
+            /j4/9ywyZN6ynflZw31qNU5XHLe7IJ39YbCnNbcgI5eqEbmJdPT9nA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-20T20:58:02Z"
+    mac: ENC[AES256_GCM,data:voqoIiuyo4/Q7tRPyGX/r22GYKp9ZQzmZysQRE8P/TMRLO65pwQNwsEHe2phBuvuLdz08/A9X3PJqDyOEVnZMQRo55dRM7WM9CdTyZ3AGivAHUfTA+5g1GviXsjK1Ly4h6Bhn/QIA0H3Q7SSA8llg6JdW+trjYK/Z3+x9ZboYMw=,iv:LiNdY+YHtTcVAm3njNEd+OubmjwRGq9FDDRoW8fW2XU=,tag:7ToZdMTfg94w2GTtIW4BBQ==,type:str]
+    version: 3.13.1

--- a/kubernetes/apps/apps/ai/litellm/litellm-secrets.sops.yaml
+++ b/kubernetes/apps/apps/ai/litellm/litellm-secrets.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: litellm-secrets
+    namespace: ai
+type: Opaque
+stringData:
+    LITELLM_MASTER_KEY: ENC[AES256_GCM,data:qr3tyTMZysTH3LbBdcJ5ae6FUMxCKYrw2WSJLMD0ZsUrF8uDwuJmZpSNCRg0BEjkDZHKVZ1IvIdZHH4drfbdXN+/eQ==,iv:dab/Uftd0nI7lzpH0s1xoTxHCdBoc98yA3Xxcqg4XGo=,tag:ikciD5NP067g04MdRaKc6w==,type:str]
+    LITELLM_SALT_KEY: ENC[AES256_GCM,data:Ngd3z1Rum8bNmraN6xnjLtyCkYoSejsWWnxTC2UY6XfRn1P2XUckKdEvi4v9+8rIKozowUXdpGbzHNZgEl3t6w3niw==,iv:AJebeFsHPxSpEuFudpiLkNoQwwgB1vZ6dQUbV1U0xro=,tag:swg+VOobH+zADVyVFVTZcA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsZm1UaXg2Y0Y4Ums4enFZ
+            RndSTnZnZEt6WCtLbi9LOE10WW9Cak9TTUVVCjZCRnFJdW8xN1oxZHJNQnhLNkFm
+            c242b1k1RloraWVPb1BESkRlN1ZKTDgKLS0tIG9WcE5qY3B2dnVHTnZNdjNtSHlV
+            UERvWUxnaHJkVFVIK3BxM2p5bS80K1UKQ7b+7XfOPIED6oiqFlRZbHffCztAnYL9
+            IrK9oln7wK9uuxr/NWkqfPZf9iTDH7uye/+GPBmmpMFLb1EDcPd+UQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-20T20:58:02Z"
+    mac: ENC[AES256_GCM,data:vSOCooItG3Ob7hHlsCsEediL6n/iVrwRYl8UCvqJmlVlTl+KOR3PLqthbPIqprNv1BC2Yb1mENU/AMlvufnfeM3Vn9TxVWu0n5eY3KckB1b95jmJE+2tOi0QjFbdUcx4J0n8ya4irgvn3tNeWTYf3sW7xJG6D6JqX5ORaCmwYhI=,iv:TcX9Y35HG14KqJppGPRoeujZW29k8YjnvYUZXmP4Dqw=,tag:fRnljZyNL8jT0ImVseQN/w==,type:str]
+    version: 3.13.1

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - ../apps/ai/whisper
   - ../apps/ai/kokoro
   - ../apps/ai/vane
+  - ../apps/ai/litellm
   - ../apps/security/frigate
   - ../apps/immich
   - ../apps/media/jellyplex-watched


### PR DESCRIPTION
## Summary

Adds LiteLLM as an app-template workload under `kubernetes/apps/apps/ai/litellm` and wires it into the production apps kustomization.

## Changes

- Deploys LiteLLM `ghcr.io/berriai/litellm:v1.85.0` on port 4000.
- Adds auth-guarded Traefik ingress at `litellm.lan.${CLUSTER_DOMAIN}` with external-dns and Homepage annotations.
- Adds a single-instance CNPG database `litellm-pg` with Longhorn storage and barman S3 backups.
- Adds encrypted SOPS secrets for the DB connection and LiteLLM master/salt keys.
- Adds ephemeral Valkey runtime cache support with no LiteLLM PVC.

## Validation

- `kubectl kustomize kubernetes/apps/apps/ai/litellm`
- `kubectl apply --dry-run=client -f /tmp/litellm-rendered.yaml`
- `kubectl kustomize kubernetes/apps/production`
- `sops --decrypt kubernetes/apps/apps/ai/litellm/litellm-db-secrets.sops.yaml >/dev/null`
- `sops --decrypt kubernetes/apps/apps/ai/litellm/litellm-secrets.sops.yaml >/dev/null`
- commit hooks passed during `git commit`