### PR TITLE
feat(paperless): enable LLM helpers

### DIFF
--- a/kubernetes/apps/apps/paperless/paperless-ai-helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/paperless-ai-helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   values:
     controllers:
       main:
-        replicas: 0
+        replicas: 1
         containers:
           main:
             image:

--- a/kubernetes/apps/apps/paperless/paperless-gpt-helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/paperless-gpt-helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   values:
     controllers:
       main:
-        replicas: 0
+        replicas: 1
         containers:
           main:
             image:
@@ -28,16 +28,16 @@ spec:
               MANUAL_TAG: paperless-gpt
               AUTO_TAG: paperless-gpt-auto
               LLM_PROVIDER: openai
-              LLM_MODEL: qwen3_5_35b
+              LLM_MODEL: local/document-analysis
               OPENAI_API_KEY:
                 valueFrom:
                   secretKeyRef:
                     name: paperless-gpt-secrets
                     key: OPENAI_API_KEY
-              OPENAI_BASE_URL: http://192.168.10.70:8080/v1
+              OPENAI_BASE_URL: http://litellm-main.ai.svc.cluster.local:4000/v1
               OCR_PROVIDER: llm
               VISION_LLM_PROVIDER: openai
-              VISION_LLM_MODEL: qwen3_5_35b
+              VISION_LLM_MODEL: local/document-analysis
               OLLAMA_HOST: http://192.168.10.70:8080/v1
               OCR_PROCESS_MODE: image
               PDF_SKIP_EXISTING_OCR: "false"

--- a/kubernetes/apps/apps/paperless/paperless-gpt-secrets.sops.yaml
+++ b/kubernetes/apps/apps/paperless/paperless-gpt-secrets.sops.yaml
@@ -5,20 +5,20 @@ metadata:
     namespace: paperless
 type: Opaque
 stringData:
-    PAPERLESS_API_TOKEN: ENC[AES256_GCM,data:yjo6n/hsVokw+2cUHPv1YKlCEmTs+jqW3CPOy/DVPt1PBd77Xspl/A==,iv:BxJC3BqV0Kl9GWtLDYNLLOqAUI4lv90kytJmBzq1ivw=,tag:xdayGn0fXHKQw6lwlWt7SQ==,type:str]
-    OPENAI_API_KEY: ENC[AES256_GCM,data:5Ms1bPNHFQUQpB4=,iv:GLo1Lt/zoKZO1Fe59nz7TwsJpOV4K+BAJCh4jBh0B8w=,tag:a8d7XdwjIs3HdMgQkw3fbA==,type:str]
+    PAPERLESS_API_TOKEN: ENC[AES256_GCM,data:nRbrAQkhiwL2a/pXz4aXN2CExriF9oxaYZI3EhwfEfqp6PxmKx1R/w==,iv:F7CgB0vfzbnTMJX8O/hxnBc++/66dzguMrUQFFiUjdY=,tag:S5Lk2MSYn4aH9IpBzxAS/g==,type:str]
+    OPENAI_API_KEY: ENC[AES256_GCM,data:8YuaYThHMFH34Z/9S03AFEhw7OC/sQIQAw==,iv:chEYiQExCKVi1fKW0qYQHm90bKAYT8qhcs7AoBzSlkc=,tag:f4T3nRWpvMfRL1PvqUQSxw==,type:str]
 sops:
     age:
-        - recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIaG9WMVVkWlhlQjRUUmtE
-            Qi9saDg5ejBLVzZTYzIwZmFNOW1Iazc1QzMwCmtEcG9lUHduUmRWZUFmaGl6b3c4
-            Q0t5bWMyNlVhN2xGZ2VvVGErYytYWm8KLS0tIDVydVlyY2Q1Qi92Zm1TQXpuNGcv
-            N0xNR05YR0V1ejczaUdMOFJOVGM4MVEKRJ8p4JQuUFOjEWX5oHx7tradTF9frcD2
-            zqD/qrGLQuo7sOCzfZ7TO3GscA96d6EsyxWeKZyAKanYa2eArHpplA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHTkJFQ2VwUmFjc2t6TUE3
+            TlNrZzYvNWZHS3lzVyt3SEpEN2RMUzJ5NmtvCnp0K0NSTmZaajl4OE9sQVdPR1Ri
+            dGwyNk9yQXNtM2luQlcwN1EzNFFsRTAKLS0tIE9TS1JvUjRXNU41VVJDeE15ZkJq
+            Si9Rei9Oa2FsMVk4eWZrcVRpS29HMzQKA/2sRcqvEVrX9q1UjY60L/6Ieby2pTs4
+            dDhmkJU48K+prb/B9hppmYxhuhjDXHZiDcZS263aMrdi6IFbJNvdCw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-22T21:22:28Z"
-    mac: ENC[AES256_GCM,data:AwsVZpqBkjS0B1VEO4IjOCoxZ3loJsdfNbHppE1bO3Xab1gf69Ots9+IzeUKG7nj0DLjpyx2BbCOFYgZ+JGUR7+wax7u6OPybWLL+nrRjD0+Vt/E0SDhZrtIro2QvIejRYBJDCc6aUtj/B7NndkYdaPtYjvgSaLjuYdNA6aSEQk=,iv:g2sdxH+7Yi3Pp3QYYH0lEBiFGddLYqiz1hN7PLiJ3XY=,tag:3jVelG0fBdAnvDWDl/Qu2w==,type:str]
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
     encrypted_regex: ^(data|stringData)$
-    version: 3.12.1
+    lastmodified: "2026-05-21T23:01:13Z"
+    mac: ENC[AES256_GCM,data:J6NTVzigmOB+g8pvRBJwJNdDahHpRtEKpkXSOj0BJi+0qyhAEcPqRgao8khE/IjihCffHUJFLLCbiya8/rSAfIBkIfz/3tkjP93yqS+jCVfDUezuKKS2PImmhIWDscLkmO//rqpa5WCbTJhEola2SV8vHJrMcX4OU2c2iuvO7i8=,iv:Ub8bLs0wETJUG5egYW2xcDhEATJ8Inw6vkhnidBnuY4=,tag:8aJreQiKtxU2IsUhhUdZHQ==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## Summary

- Enable `paperless-ai` and `paperless-gpt` by setting each helper to one replica.
- Route `paperless-gpt` OpenAI-compatible requests through the in-cluster LiteLLM service.
- Switch `paperless-gpt` text and vision model names to `local/document-analysis`.
- Include the updated `paperless-gpt` SOPS secret for its Paperless token and OpenAI-compatible API key.

## Validation

- Parsed both modified HelmRelease YAML files with `yq`.
- Parsed the updated SOPS secret YAML with `yq`.
- Tested the LiteLLM in-cluster URL from `paperless-main`: `http://litellm-main.ai.svc.cluster.local:4000/v1/models` returns LiteLLM's expected `401` missing API key response.
- Commit hooks passed during `git commit --amend`.