### PR TITLE
feat(authentik): inject llama basic auth

### DIFF
--- a/kubernetes/apps/apps/external-proxy/llama-swap.yaml
+++ b/kubernetes/apps/apps/external-proxy/llama-swap.yaml
@@ -29,7 +29,7 @@ metadata:
   name: llama-swap
   namespace: external-proxy
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-gatekeeper-auth-chain@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-llama-auth-chain@kubernetescrd
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     external-dns.alpha.kubernetes.io/hostname: llama.lan.${CLUSTER_DOMAIN}
 spec:

--- a/kubernetes/infrastructure/networking/traefik/config/kustomization.yaml
+++ b/kubernetes/infrastructure/networking/traefik/config/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - middlewares/frigate-auth-chain.yaml
   - middlewares/discord-auth-chain.yaml
   - middlewares/kopia-auth-chain.yaml
+  - middlewares/llama-auth-chain.yaml
   - middlewares/openclaw-auth-chain.yaml
   - middlewares/opencode-buffering.yaml
   - middlewares/opencode-streaming-headers.yaml

--- a/kubernetes/infrastructure/networking/traefik/config/middlewares/llama-auth-chain.yaml
+++ b/kubernetes/infrastructure/networking/traefik/config/middlewares/llama-auth-chain.yaml
@@ -1,0 +1,13 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: llama-auth-chain
+  namespace: traefik
+spec:
+  chain:
+    middlewares:
+      - name: default-headers
+      - name: crowdsec-bouncer
+        namespace: crowdsec
+      - name: authentik-auth-llama
+        namespace: authentik

--- a/kubernetes/infrastructure/security/authentik/config/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/config/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - middleware-frigate.yaml
   - middleware-discord.yaml
   - middleware-kopia.yaml
+  - middleware-llama.yaml
   - middleware-openclaw.yaml
   - ingress.yaml
   - outpost-callback-ingress.yaml

--- a/kubernetes/infrastructure/security/authentik/config/middleware-llama.yaml
+++ b/kubernetes/infrastructure/security/authentik/config/middleware-llama.yaml
@@ -1,0 +1,17 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: authentik-auth-llama
+  namespace: authentik
+spec:
+  forwardAuth:
+    address: http://ak-outpost-gatekeeper-proxy.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/traefik
+    trustForwardHeader: true
+    preserveLocationHeader: true
+    authResponseHeaders:
+      - X-authentik-username
+      - X-authentik-groups
+      - X-authentik-email
+      - X-authentik-name
+      - X-authentik-uid
+      - Authorization

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -917,6 +917,80 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "LiteLLM Admin"]]
 
+  527-llama.yaml: |
+    version: 1
+    metadata:
+      name: llama-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Llama Users group
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Llama Users"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+
+      # Custom scope mapping that injects Authorization header
+      - model: authentik_providers_oauth2.scopemapping
+        state: present
+        id: llama-auth-mapping
+        identifiers:
+          name: "Llama Auth Mapping"
+        attrs:
+          scope_name: llama-auth
+          description: "Injects basic auth header for llama-swap bypass"
+          expression: |
+            import os
+            basic_auth = os.environ.get("LLAMA_BASIC_AUTH", "")
+            headers = {}
+            if basic_auth:
+                headers["Authorization"] = basic_auth
+            return {
+                "ak_proxy": {
+                    "user_attributes": {
+                        "additionalHeaders": headers
+                    }
+                }
+            }
+
+      # Llama Proxy Provider
+      - model: authentik_providers_proxy.proxyprovider
+        id: llama-provider
+        identifiers:
+          name: "Llama"
+        attrs:
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: forward_single
+          external_host: "https://llama.lan.${CLUSTER_DOMAIN}"
+          access_token_validity: "hours=24"
+          refresh_token_validity: "days=30"
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "ak-proxy"]]
+            - !Find [authentik_providers_oauth2.scopemapping, [name, "Llama Auth Mapping"]]
+
+      # Llama Application
+      - model: authentik_core.application
+        identifiers:
+          slug: "llama"
+        attrs:
+          name: "Llama"
+          provider: !KeyOf llama-provider
+          group: "AI"
+
+      # Restrict Llama to Llama Users group
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "llama"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Llama Users"]]
+
   530-openclaw.yaml: |
     version: 1
     metadata:
@@ -1276,6 +1350,7 @@ data:
             - !Find [authentik_providers_proxy.proxyprovider, [name, "Discord Main"]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, "Discord Alternate"]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, "Kopia"]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, "Llama"]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, "OpenClaw"]]
           config:
             authentik_host: "http://authentik-server.authentik.svc.cluster.local"

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -136,6 +136,11 @@ spec:
             secretKeyRef:
               name: kopia-auth-secret
               key: BASIC_AUTH
+        - name: LLAMA_BASIC_AUTH
+          valueFrom:
+            secretKeyRef:
+              name: llama-auth-secret
+              key: BASIC_AUTH
         - name: FRIGATE_PROXY_SECRET
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -19,5 +19,6 @@ resources:
   - litellm-sso-secret.sops.yaml
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml
+  - llama-auth-secret.sops.yaml
   - frigate-proxy-secret.sops.yaml
   - openclaw-gateway-secret.sops.yaml

--- a/kubernetes/infrastructure/security/authentik/install/llama-auth-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/llama-auth-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: llama-auth-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    BASIC_AUTH: ENC[AES256_GCM,data:jvoKDPfC/FErVf9v6CSgZCAAJ+8dkSzWfSvn4zwGls3qij7Mx2gxzX6vt2yH5sBSLURCzra7CNOZViLqJ5k96pjwKknIbt2wwssUym1qvoxaC5lR6JJ9g9jZTNM53Q==,iv:NWTM0cUER8FYlY2+H+ID2qZsbD0P5lfBaf0H0RCdJ/0=,tag:FUDNV+hL0Vmww3xxxfnmDg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBNlBHTDdIODFocDh3TFdS
+            RjZiS3lXNGJiaFpubVdhN2lWN0xIZ1U0RG13CmZUQjZiSnNCWS9iZXBWM1Vhc2h2
+            d0hVMmN6cVJ2MTRaNm90cEw2RFV5VFkKLS0tIEZlWlRNS1o0SnJMZEIzVVh0L01o
+            aTFhUHZRWldteURqbVVBVS93VGNqZE0Khg7nKUTqLzFSXckE0NKiRcv0FFCSIQi8
+            8kzgs9AuY1a/4bpMOr80rBFJZJ5Ds5l9AmxugMMCcMlZWIVBGwKN7w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-22T11:59:27Z"
+    mac: ENC[AES256_GCM,data:s37JmIL8O+AZq3uty60HElWW3cx/aIBSr2YSSAlCJTbCTRCNMCwy/sMMiIxAI68j4km2Mo+/29c0I2PYvB7oeGgrtS6PzlMdLSlVSFzArnGkoh6IMGyouLZtBaAq5KDlwHPPRscq1vUZaAG2q3x5fdUPlwvhafyZ41g5fmtKvr4=,iv:xSEvAY4hqrCGCfBBRIv9sTI7cYuTaf/aM8ugInLG0uU=,tag:MC8xnHgK9M3/1uRkeU4gaw==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## Summary

Adds a dedicated Authentik proxy provider and Traefik middleware chain for `llama.lan.${CLUSTER_DOMAIN}` so Authentik can inject the upstream Basic auth `Authorization` header after login.

## Why

`llama-swap` still prompts for password-only Basic auth after the Authentik step. This mirrors the existing Kopia/Discord Authentik `additionalHeaders` pattern and stores the generated header in a SOPS-managed secret.

## Validation

- `sops -d kubernetes/infrastructure/security/authentik/install/llama-auth-secret.sops.yaml | yq -r '.stringData.BASIC_AUTH | select(. != null) | length'`
- `sops -d kubernetes/infrastructure/security/authentik/install/llama-auth-secret.sops.yaml | yq -r '.stringData.BASIC_AUTH | startswith("Basic ")'`
- `sops -d kubernetes/infrastructure/security/authentik/install/llama-auth-secret.sops.yaml | kubectl apply --dry-run=client -f -`
- `kubectl apply --dry-run=client -f` for the changed Authentik, Traefik, and llama-swap manifests
- `git diff --check`
- commit hooks during `git commit`