### PR TITLE
feat(ansible): support docker installs on fedora

### DIFF
--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -6,6 +6,30 @@ docker_install_enabled: false
 # Docker package state (present = latest, "x.y.z" to pin version)
 docker_package_state: present
 
+# OS families supported by this role
+docker_supported_os_families:
+  - Debian
+  - RedHat
+
+# Docker packages
+docker_packages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - docker-buildx-plugin
+  - docker-compose-plugin
+
+# Debian/Ubuntu prerequisites
+docker_debian_prerequisite_packages:
+  - ca-certificates
+  - curl
+  - gnupg
+  - lsb-release
+
+# Fedora/RHEL prerequisites
+docker_redhat_prerequisite_packages:
+  - dnf-plugins-core
+
 # Users to add to docker group
 docker_users:
   - "{{ common_user }}"
@@ -22,5 +46,7 @@ docker_daemon_config:
 docker_log_max_size: "100m"
 docker_log_max_files: "3"
 
-# Docker APT repository base URL (auto-detected per OS)
+# Docker repository settings
 docker_repo_base_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}"
+docker_redhat_repo_baseurl: "{{ docker_repo_base_url }}/$releasever/$basearch/stable"
+docker_redhat_repo_gpgkey: "{{ docker_repo_base_url }}/gpg"

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -9,7 +9,8 @@ docker_package_state: present
 # OS families supported by this role
 docker_supported_os_families:
   - Debian
-  - RedHat
+docker_supported_distributions:
+  - Fedora
 
 # Docker packages
 docker_packages:
@@ -26,8 +27,8 @@ docker_debian_prerequisite_packages:
   - gnupg
   - lsb-release
 
-# Fedora/RHEL prerequisites
-docker_redhat_prerequisite_packages:
+# Fedora prerequisites
+docker_fedora_prerequisite_packages:
   - dnf-plugins-core
 
 # Users to add to docker group
@@ -48,5 +49,5 @@ docker_log_max_files: "3"
 
 # Docker repository settings
 docker_repo_base_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}"
-docker_redhat_repo_baseurl: "{{ docker_repo_base_url }}/$releasever/$basearch/stable"
-docker_redhat_repo_gpgkey: "{{ docker_repo_base_url }}/gpg"
+docker_fedora_repo_baseurl: "{{ docker_repo_base_url }}/$releasever/$basearch/stable"
+docker_fedora_repo_gpgkey: "{{ docker_repo_base_url }}/gpg"

--- a/ansible/roles/docker/handlers/main.yml
+++ b/ansible/roles/docker/handlers/main.yml
@@ -9,3 +9,7 @@
   ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 0
+
+- name: Update dnf cache
+  ansible.builtin.dnf:
+    update_cache: true

--- a/ansible/roles/docker/tasks/install-debian.yml
+++ b/ansible/roles/docker/tasks/install-debian.yml
@@ -1,0 +1,49 @@
+---
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Install Docker prerequisites
+  ansible.builtin.apt:
+    name: "{{ docker_debian_prerequisite_packages }}"
+    state: present
+
+- name: Create keyrings directory for GPG keys
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Download Docker official GPG key
+  ansible.builtin.get_url:
+    url: "{{ docker_repo_base_url }}/gpg"
+    dest: /tmp/docker.gpg.asc
+    mode: "0644"
+    force: true
+
+- name: Convert GPG key to dearmor format
+  ansible.builtin.command:
+    cmd: gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg /tmp/docker.gpg.asc
+    creates: /usr/share/keyrings/docker-archive-keyring.gpg
+
+- name: Determine architecture for repo
+  ansible.builtin.set_fact:
+    docker_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+
+- name: Add Docker APT repository
+  ansible.builtin.copy:
+    content: |
+      deb [arch={{ docker_arch }} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ docker_repo_base_url }} {{ ansible_distribution_release }} stable
+    dest: /etc/apt/sources.list.d/docker.list
+    mode: "0644"
+  notify: Update apt cache
+
+- name: Update apt cache after adding repo
+  ansible.builtin.apt:
+    update_cache: true
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name: "{{ docker_packages }}"
+    state: "{{ docker_package_state }}"

--- a/ansible/roles/docker/tasks/install-fedora.yml
+++ b/ansible/roles/docker/tasks/install-fedora.yml
@@ -5,17 +5,17 @@
 
 - name: Install Docker prerequisites
   ansible.builtin.dnf:
-    name: "{{ docker_redhat_prerequisite_packages }}"
+    name: "{{ docker_fedora_prerequisite_packages }}"
     state: present
 
 - name: Add Docker DNF repository
   ansible.builtin.yum_repository:
     name: docker-ce-stable
     description: Docker CE Stable - $basearch
-    baseurl: "{{ docker_redhat_repo_baseurl }}"
+    baseurl: "{{ docker_fedora_repo_baseurl }}"
     enabled: true
     gpgcheck: true
-    gpgkey: "{{ docker_redhat_repo_gpgkey }}"
+    gpgkey: "{{ docker_fedora_repo_gpgkey }}"
   notify: Update dnf cache
 
 - name: Update dnf cache after adding repo

--- a/ansible/roles/docker/tasks/install-redhat.yml
+++ b/ansible/roles/docker/tasks/install-redhat.yml
@@ -1,0 +1,28 @@
+---
+- name: Update dnf cache
+  ansible.builtin.dnf:
+    update_cache: true
+
+- name: Install Docker prerequisites
+  ansible.builtin.dnf:
+    name: "{{ docker_redhat_prerequisite_packages }}"
+    state: present
+
+- name: Add Docker DNF repository
+  ansible.builtin.yum_repository:
+    name: docker-ce-stable
+    description: Docker CE Stable - $basearch
+    baseurl: "{{ docker_redhat_repo_baseurl }}"
+    enabled: true
+    gpgcheck: true
+    gpgkey: "{{ docker_redhat_repo_gpgkey }}"
+  notify: Update dnf cache
+
+- name: Update dnf cache after adding repo
+  ansible.builtin.dnf:
+    update_cache: true
+
+- name: Install Docker packages
+  ansible.builtin.dnf:
+    name: "{{ docker_packages }}"
+    state: "{{ docker_package_state }}"

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -18,8 +18,10 @@
 - name: Verify Docker role supports this OS family
   ansible.builtin.assert:
     that:
-      - ansible_os_family in docker_supported_os_families
-    fail_msg: "Docker installation is not supported for OS family {{ ansible_os_family }}"
+      - ansible_os_family in docker_supported_os_families or ansible_distribution in docker_supported_distributions
+    fail_msg: >-
+      Docker installation is not supported for {{ ansible_distribution }}
+      (OS family {{ ansible_os_family }})
   when: docker_install_enabled | bool
 
 # ========================================
@@ -31,11 +33,11 @@
     - docker_install_enabled | bool
     - ansible_os_family == 'Debian'
 
-- name: Run RedHat Docker installation tasks
-  ansible.builtin.include_tasks: install-redhat.yml
+- name: Run Fedora Docker installation tasks
+  ansible.builtin.include_tasks: install-fedora.yml
   when:
     - docker_install_enabled | bool
-    - ansible_os_family == 'RedHat'
+    - ansible_distribution == 'Fedora'
 
 # ========================================
 # BLOCK 3: Configure and start service

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -15,98 +15,30 @@
     quiet: true
   when: docker_install_enabled | bool
 
+- name: Verify Docker role supports this OS family
+  ansible.builtin.assert:
+    that:
+      - ansible_os_family in docker_supported_os_families
+    fail_msg: "Docker installation is not supported for OS family {{ ansible_os_family }}"
+  when: docker_install_enabled | bool
+
 # ========================================
 # BLOCK 2: Prerequisites and repo setup
 # ========================================
-- name: Update apt cache
-  ansible.builtin.apt:
-    update_cache: true
-    cache_valid_time: 3600
+- name: Run Debian Docker installation tasks
+  ansible.builtin.include_tasks: install-debian.yml
   when:
     - docker_install_enabled | bool
     - ansible_os_family == 'Debian'
 
-- name: Install Docker prerequisites
-  ansible.builtin.apt:
-    name:
-      - ca-certificates
-      - curl
-      - gnupg
-      - lsb-release
-    state: present
+- name: Run RedHat Docker installation tasks
+  ansible.builtin.include_tasks: install-redhat.yml
   when:
     - docker_install_enabled | bool
-    - ansible_os_family == 'Debian'
-
-- name: Create keyrings directory for GPG keys
-  ansible.builtin.file:
-    path: /etc/apt/keyrings
-    state: directory
-    mode: "0755"
-  when:
-    - docker_install_enabled | bool
-    - ansible_os_family == 'Debian'
-
-- name: Download Docker official GPG key
-  ansible.builtin.get_url:
-    url: "{{ docker_repo_base_url }}/gpg"
-    dest: /tmp/docker.gpg.asc
-    mode: "0644"
-    force: true
-  when:
-    - docker_install_enabled | bool
-    - ansible_os_family == 'Debian'
-
-- name: Convert GPG key to dearmor format
-  ansible.builtin.command:
-    cmd: gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg /tmp/docker.gpg.asc
-    creates: /usr/share/keyrings/docker-archive-keyring.gpg
-  when:
-    - docker_install_enabled | bool
-    - ansible_os_family == 'Debian'
-
-- name: Determine architecture for repo
-  ansible.builtin.set_fact:
-    docker_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
-  when:
-    - docker_install_enabled | bool
-    - ansible_os_family == 'Debian'
-
-- name: Add Docker APT repository
-  ansible.builtin.copy:
-    content: |
-      deb [arch={{ docker_arch }} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] {{ docker_repo_base_url }} {{ ansible_distribution_release }} stable
-    dest: /etc/apt/sources.list.d/docker.list
-    mode: "0644"
-  when:
-    - docker_install_enabled | bool
-    - ansible_os_family == 'Debian'
-  notify: Update apt cache
+    - ansible_os_family == 'RedHat'
 
 # ========================================
-# BLOCK 3: Install Docker packages
-# ========================================
-- name: Update apt cache after adding repo
-  ansible.builtin.apt:
-    update_cache: true
-  when:
-    - docker_install_enabled | bool
-    - ansible_os_family == 'Debian'
-
-- name: Install Docker packages (latest stable)
-  ansible.builtin.apt:
-    name:
-      - docker-ce
-      - docker-ce-cli
-      - containerd.io
-      - docker-compose-plugin
-    state: "{{ docker_package_state }}"
-  when:
-    - docker_install_enabled | bool
-    - ansible_os_family == 'Debian'
-
-# ========================================
-# BLOCK 4: Configure and start service
+# BLOCK 3: Configure and start service
 # ========================================
 - name: Create /etc/docker directory
   ansible.builtin.file:
@@ -138,7 +70,7 @@
     - not ansible_check_mode
 
 # ========================================
-# BLOCK 5: User management
+# BLOCK 4: User management
 # ========================================
 - name: Add users to docker group
   ansible.builtin.user:
@@ -160,7 +92,7 @@
     - not ansible_check_mode
 
 # ========================================
-# BLOCK 6: Verification (non-check mode only)
+# BLOCK 5: Verification (non-check mode only)
 # ========================================
 - name: Run Docker hello-world test
   ansible.builtin.command: docker run --rm hello-world


### PR DESCRIPTION
## Summary
- split Docker role package/repo setup into Debian and RedHat task files
- add Fedora/RedHat Docker repository, package, and DNF cache handling
- keep shared Docker service, daemon config, user, and verification tasks in the main role

## Validation
- ansible-playbook playbooks/public_vps.yml --syntax-check
- ansible-playbook playbooks/openclaw.yml --syntax-check
- ansible-playbook playbooks/llm_lxc.yml --syntax-check
- ansible-lint roles/docker playbooks/public_vps.yml playbooks/openclaw.yml playbooks/llm_lxc.yml
- repository pre-commit hooks during commit