### PR TITLE
feat(ansible): enable docker on llm lxc

### DIFF
--- a/ansible/inventories/group_vars/llm_lxc.yml
+++ b/ansible/inventories/group_vars/llm_lxc.yml
@@ -7,3 +7,6 @@ lxc_hardening_sshd_settings:
   KbdInteractiveAuthentication: "no"
   ChallengeResponseAuthentication: "no"
   X11Forwarding: "no"
+
+docker_install_enabled: true
+docker_users: []

--- a/ansible/playbooks/llm_lxc.yml
+++ b/ansible/playbooks/llm_lxc.yml
@@ -5,6 +5,7 @@
   roles:
     - lxc_hardening
     - lxc_bootstrap
+    - docker
     - llm_runtime
     - whisper_runtime
     - llama_swap


### PR DESCRIPTION
## Summary
- add the Docker role to the LLM LXC playbook
- enable Docker for the llm_lxc inventory group
- skip Docker group membership because the container is managed as root

## Validation
- ansible-playbook playbooks/llm_lxc.yml --syntax-check
- ansible-lint playbooks/llm_lxc.yml roles/docker
- git diff --check
- repository pre-commit hooks during commit
- applied the Docker role to ct-llm successfully; Docker 29.5.2 and Compose 5.1.4 are active
- verified a test Fedora container can see /dev/kfd and /dev/dri devices