### PR TITLE
feat(ai): add litellm config file

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: ai
+data:
+  config.yaml: |
+    model_list:
+      - model_name: openai/gpt-5.5
+        model_info:
+          mode: responses
+          max_input_tokens: 272000
+        litellm_params:
+          model: chatgpt/gpt-5.5
+
+      - model_name: openai/gpt-5.4
+        model_info:
+          mode: responses
+          max_input_tokens: 272000
+        litellm_params:
+          model: chatgpt/gpt-5.4
+
+      - model_name: openai/gpt-5.4-mini
+        model_info:
+          mode: responses
+          max_input_tokens: 272000
+        litellm_params:
+          model: chatgpt/gpt-5.4-mini
+
+      - model_name: openai/gpt-5.3-codex
+        model_info:
+          mode: responses
+          max_input_tokens: 272000
+        litellm_params:
+          model: chatgpt/gpt-5.3-codex
+
+      - model_name: openai/gpt-5.3-codex-spark
+        model_info:
+          mode: responses
+          max_input_tokens: 272000
+        litellm_params:
+          model: chatgpt/gpt-5.3-codex-spark
+
+    litellm_settings:
+      cache: true
+      cache_params:
+        type: redis
+        host: litellm-valkey
+        port: "6379"
+        ssl: false
+        ssl_check_hostname: false
+
+    general_settings:
+      store_model_in_db: true
+
+    router_settings:
+      routing_strategy: simple-shuffle
+      num_retries: 2
+      timeout: 6000
+      max_fallbacks: 5
+      allowed_fails: 3
+      cooldown_time: 5
+      retry_after: 0
+      enable_pre_call_checks: false
+      model_group_alias:
+        local/tts: openai/chatterbox
+        local/rerank: hosted_vllm/qwen3-reranker-0.6b
+        local/stt-fast: hosted_vllm/whisper/large-v3-turbo-q5_0
+        local/embedding: hosted_vllm/qwen3-embedding-0.6b
+        local/stt-large: hosted_vllm/whisper/large-v3-q5_0
+        local/automation-lite: hosted_vllm/unsloth/qwen3-4b-instruct-2507
+        local/document-analysis: hosted_vllm/unsloth/qwen3-vl-30b-a3b-instruct
+        chatgpt/latest: openai/gpt-5.5

--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
             env:
               TZ: Europe/Berlin
               STORE_MODEL_IN_DB: "True"
+              CONFIG_FILE_PATH: /etc/litellm/config.yaml
               CHATGPT_TOKEN_DIR: /var/lib/litellm/chatgpt
               CHATGPT_AUTH_FILE: auth.json
               DATABASE_URL:
@@ -195,3 +196,13 @@ spec:
           valkey:
             valkey:
               - path: /data
+      config:
+        enabled: true
+        type: configMap
+        name: litellm-config
+        advancedMounts:
+          main:
+            main:
+              - path: /etc/litellm/config.yaml
+                subPath: config.yaml
+                readOnly: true

--- a/kubernetes/apps/apps/ai/litellm/kustomization.yaml
+++ b/kubernetes/apps/apps/ai/litellm/kustomization.yaml
@@ -5,6 +5,7 @@ components:
   - ../../../../components/ingress/traefik-base
 
 resources:
+  - configmap.yaml
   - litellm-db-secrets.sops.yaml
   - litellm-secrets.sops.yaml
   - cnpg-cluster.yaml


### PR DESCRIPTION
## Summary
- add a LiteLLM config ConfigMap with ChatGPT-backed OpenAI-compatible model names
- mount the config file into the LiteLLM deployment via CONFIG_FILE_PATH
- keep STORE_MODEL_IN_DB enabled so UI-managed entries can still load

## Validation
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/litellm
- pre-commit hooks from git commit passed