### PR TITLE
feat(ai): manage litellm model credentials

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -5,41 +5,71 @@ metadata:
   namespace: ai
 data:
   config.yaml: |
+    # ChatGPT subscription models are disabled until LiteLLM fixes empty
+    # responses output for chatgpt/* models. Track upstream issue #25429.
     model_list:
-      - model_name: openai/gpt-5.5
+      - model_name: openai/chatterbox
         model_info:
-          mode: responses
-          max_input_tokens: 272000
+          mode: audio_speech
         litellm_params:
-          model: chatgpt/gpt-5.5
+          model: openai/chatterbox
+          custom_llm_provider: openai
+          litellm_credential_name: Llama-Swap
+          input_cost_per_token: 0.0
+          output_cost_per_token: 0.0
+          tags:
+            - llama-swap
 
-      - model_name: openai/gpt-5.4
+      - model_name: local/tts
         model_info:
-          mode: responses
-          max_input_tokens: 272000
+          mode: audio_speech
         litellm_params:
-          model: chatgpt/gpt-5.4
+          model: openai/chatterbox
+          custom_llm_provider: openai
+          litellm_credential_name: Llama-Swap
+          input_cost_per_token: 0.0
+          output_cost_per_token: 0.0
+          tags:
+            - llama-swap
 
-      - model_name: openai/gpt-5.4-mini
+      - model_name: hosted_vllm/*
         model_info:
-          mode: responses
-          max_input_tokens: 272000
+          mode: chat
+          health_check_model: unsloth/qwen3-4b-instruct-2507
         litellm_params:
-          model: chatgpt/gpt-5.4-mini
+          model: hosted_vllm/*
+          custom_llm_provider: hosted_vllm
+          litellm_credential_name: Llama-Swap
+          input_cost_per_token: 0.0
+          output_cost_per_token: 0.0
+          tags:
+            - llama-swap
+            - pve3
+          guardrails: []
 
-      - model_name: openai/gpt-5.3-codex
+      - model_name: openrouter/free
         model_info:
-          mode: responses
-          max_input_tokens: 272000
+          mode: chat
         litellm_params:
-          model: chatgpt/gpt-5.3-codex
+          model: openrouter/openrouter/free
+          custom_llm_provider: openrouter
+          litellm_credential_name: Openrouter
+          input_cost_per_token: 0.0
+          output_cost_per_token: 0.0
 
-      - model_name: openai/gpt-5.3-codex-spark
-        model_info:
-          mode: responses
-          max_input_tokens: 272000
-        litellm_params:
-          model: chatgpt/gpt-5.3-codex-spark
+    credential_list:
+      - credential_name: Llama-Swap
+        credential_values:
+          api_base: os.environ/LITELLM_CREDENTIAL_LLAMA_SWAP_API_BASE
+          api_key: os.environ/LITELLM_CREDENTIAL_LLAMA_SWAP_API_KEY
+        credential_info:
+          custom_llm_provider: openai
+
+      - credential_name: Openrouter
+        credential_values:
+          api_key: os.environ/LITELLM_CREDENTIAL_OPENROUTER_API_KEY
+        credential_info:
+          custom_llm_provider: openrouter
 
     litellm_settings:
       cache: true
@@ -70,4 +100,3 @@ data:
         local/stt-large: hosted_vllm/whisper/large-v3-q5_0
         local/automation-lite: hosted_vllm/unsloth/qwen3-4b-instruct-2507
         local/document-analysis: hosted_vllm/unsloth/qwen3-vl-30b-a3b-instruct
-        chatgpt/latest: openai/gpt-5.5

--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -57,6 +57,9 @@ spec:
               PROXY_BASE_URL: https://litellm.lan.${CLUSTER_DOMAIN}
               AUTO_REDIRECT_UI_LOGIN_TO_SSO: "true"
               REDIS_URL: redis://litellm-valkey:6379
+            envFrom:
+              - secretRef:
+                  name: litellm-credentials
             ports:
               - name: http
                 containerPort: 4000

--- a/kubernetes/apps/apps/ai/litellm/kustomization.yaml
+++ b/kubernetes/apps/apps/ai/litellm/kustomization.yaml
@@ -6,6 +6,7 @@ components:
 
 resources:
   - configmap.yaml
+  - litellm-credentials.sops.yaml
   - litellm-db-secrets.sops.yaml
   - litellm-secrets.sops.yaml
   - cnpg-cluster.yaml

--- a/kubernetes/apps/apps/ai/litellm/litellm-credentials.sops.yaml
+++ b/kubernetes/apps/apps/ai/litellm/litellm-credentials.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: litellm-credentials
+    namespace: ai
+type: Opaque
+stringData:
+    LITELLM_CREDENTIAL_LLAMA_SWAP_API_BASE: ENC[AES256_GCM,data:AWtd0LPlq5rfrLGcIMzvMMjyPZ20nxfXaOpkRw==,iv:iKaYuZ698WqbQ/TTtjxVy8ni5RqRA3Q1h+6saUcpwTc=,tag:fv5wqdUHkBa0t4+iagNp9A==,type:str]
+    LITELLM_CREDENTIAL_LLAMA_SWAP_API_KEY: ENC[AES256_GCM,data:jjtyk3fcxXE5PovkCLh+ShGjw3XTOyAWI6VjCTWHnVbfzKdN5N4Lsg7sU0YmBzXonuwzf6xg30LETjgUmlLN7g==,iv:fQwpny3beNolx0gBa/FP20HszSGgacuPPdKwU7ov19g=,tag:D3k8GVnxYjINC4ZHYHcQiA==,type:str]
+    LITELLM_CREDENTIAL_OPENROUTER_API_KEY: ENC[AES256_GCM,data:7sHOFt3T6ZotFDyTVvcpfWFGz0ISlXHOMUxWPqTq8qeRzi7yUdygqwlM/ZQ6cyyIL3xzzDI8O8Pcl3irbSvv8HACDcTSIyevZQ==,iv:W0YVgMz0ExiM3o4+zH8IhB5N2gX+ZM2B9/4EfbsgZtA=,tag:oMxKA+i1m0jqRFxkz101Tw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmNTBPbW51WGF0dURZNUF2
+            SGwwM1A2UzJjTU95eUZtSUZFUlFvSC9jZEVVCkNQUW1xUTBvZk9KZ2Fxc0kzdnpo
+            RGhwMldTbXg1eXJtSFErNCsxVkxJTDgKLS0tIDdUeDZINE9sTVd4UUtuSUVLcUdD
+            WkZWb0JqVHk5ZGFMciszTHN2N2dvclUKrQ6qCE2NTER4y33wGQWLOv1pzNkAzP4R
+            +nGaaJSZwUMdw728mPrba/rPO4ZAhMvryILJkAJz6InOUjWOD0CTAQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-24T00:01:49Z"
+    mac: ENC[AES256_GCM,data:DaTJ77K+KQaPnao3XvvJQ7eUuzpAhIHlnTbtHifVVMTnhDCXmXtdSOD6QMUNjSOXqhW6p3rcI1Rfbgf2bGqnQN98Slfzuo8SKWBucoT9gxu3pDX0ohowlEU0dceozQTnYLIdL4GJsk9piYlPtIlqydsR99peH6xtcSj20ergsng=,iv:BjsTzp2kIA3D0yeKo3GDoC1QsuVd6IC0RhM1YJ2fjds=,tag:b937NrCvcP33hVnhv4mscQ==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## Summary
- migrate existing LiteLLM model definitions into the Git-managed config file
- remove broken ChatGPT subscription models until upstream LiteLLM fixes empty responses output
- add encrypted LiteLLM credential secret and wire named credentials through env vars

## Validation
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/litellm