### PR TITLE
feat(infra): install reloader controller

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -12,9 +12,6 @@ spec:
       main:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          annotations:
-            litellm.lainternetdelpantano.xyz/config-revision: "chatterbox-health-voice"
         containers:
           main:
             image:

--- a/kubernetes/clusters/production/ks/31-reloader-install.yaml
+++ b/kubernetes/clusters/production/ks/31-reloader-install.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: reloader-install
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/infrastructure/automation/reloader/install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: infrastructure
+  wait: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: reloader
+      namespace: flux-system
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-identity

--- a/kubernetes/clusters/production/ks/kustomization.yaml
+++ b/kubernetes/clusters/production/ks/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - 25-external-dns-install.yaml
   - 26-cloudflared-install.yaml
   - 30-kube-replicator-install.yaml
+  - 31-reloader-install.yaml
   - 42-authentik-install.yaml
   - 43-authentik-config.yaml
   - 44-crowdsec-install.yaml

--- a/kubernetes/infrastructure/automation/reloader/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/automation/reloader/install/helmrelease.yaml
@@ -1,0 +1,35 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reloader
+  namespace: flux-system
+spec:
+  interval: 30m
+  targetNamespace: reloader
+  install:
+    createNamespace: true
+  chart:
+    spec:
+      chart: reloader
+      # renovate: datasource=helm depName=reloader registryUrl=https://stakater.github.io/stakater-charts
+      version: "2.2.11"
+      sourceRef:
+        kind: HelmRepository
+        name: stakater
+        namespace: flux-system
+      interval: 1h
+  values:
+    reloader:
+      autoReloadAll: false
+      watchGlobally: true
+      reloadStrategy: annotations
+      ignoreJobs: true
+      ignoreCronJobs: true
+      deployment:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 128Mi
+          limits:
+            cpu: 150m
+            memory: 512Mi

--- a/kubernetes/infrastructure/automation/reloader/install/kustomization.yaml
+++ b/kubernetes/infrastructure/automation/reloader/install/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/infrastructure/config/namespaces.yaml
+++ b/kubernetes/infrastructure/config/namespaces.yaml
@@ -31,6 +31,11 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: reloader
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: external-dns
 ---
 apiVersion: v1

--- a/kubernetes/infrastructure/sources/kustomization.yaml
+++ b/kubernetes/infrastructure/sources/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - metallb.yaml
   - traefik.yaml
   - kube-replicator.yaml
+  - stakater.yaml
   - cert-manager.yaml
   - external-dns.yaml
   - longhorn.yaml

--- a/kubernetes/infrastructure/sources/stakater.yaml
+++ b/kubernetes/infrastructure/sources/stakater.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: stakater
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://stakater.github.io/stakater-charts


### PR DESCRIPTION
## Summary
- add the Stakater Helm repository and install Reloader under infrastructure automation
- wire Reloader into the production Flux ordering
- remove LiteLLM custom config-revision rollout annotation now that Reloader can handle config/secret-triggered rollouts

## Validation
- kubectl apply --dry-run=client -k kubernetes/infrastructure/automation/reloader/install
- kubectl apply --dry-run=client -k kubernetes/clusters/production/ks
- kubectl apply --dry-run=client -k kubernetes/infrastructure
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/litellm
- helm template reloader stakater/reloader --version 2.2.11 ...
- pre-commit run --files <changed files>