### PR TITLE
feat(registry): add harbor proxy cache

### DIFF
--- a/kubernetes/clusters/production/ks/63-harbor-install.yaml
+++ b/kubernetes/clusters/production/ks/63-harbor-install.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: harbor-install
+  namespace: flux-system
+spec:
+  interval: 30m
+  path: ./kubernetes/infrastructure/registry/harbor/install
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: cluster-identity
+    - name: infrastructure
+    - name: longhorn-config
+    - name: authentik-install
+  wait: true
+  timeout: 20m
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: harbor
+      namespace: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-identity

--- a/kubernetes/clusters/production/ks/64-harbor-config.yaml
+++ b/kubernetes/clusters/production/ks/64-harbor-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: harbor-config
+  namespace: flux-system
+spec:
+  interval: 30m
+  path: ./kubernetes/infrastructure/registry/harbor/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: harbor-install
+    - name: authentik-install
+  wait: false
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-identity

--- a/kubernetes/clusters/production/ks/kustomization.yaml
+++ b/kubernetes/clusters/production/ks/kustomization.yaml
@@ -21,6 +21,8 @@ resources:
   - 60-longhorn-install.yaml
   - 61-longhorn-config.yaml
   - 62-cnpg-install.yaml
+  - 63-harbor-install.yaml
+  - 64-harbor-config.yaml
   - 70-observability-kube-prometheus-stack-install.yaml
   - 71-observability-metrics-server-install.yaml
   - 72-observability-loki-install.yaml

--- a/kubernetes/infrastructure/config/namespaces.yaml
+++ b/kubernetes/infrastructure/config/namespaces.yaml
@@ -132,3 +132,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: nextcloud
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: harbor

--- a/kubernetes/infrastructure/registry/harbor/config/bootstrap-configmap.yaml
+++ b/kubernetes/infrastructure/registry/harbor/config/bootstrap-configmap.yaml
@@ -1,0 +1,206 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: harbor-bootstrap
+  namespace: harbor
+data:
+  bootstrap.py: |
+    import base64
+    import json
+    import os
+    import sys
+    import time
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    api = os.environ.get("HARBOR_API", "http://harbor-core/api/v2.0").rstrip("/")
+    username = os.environ.get("HARBOR_USERNAME", "admin")
+    password = os.environ["HARBOR_PASSWORD"]
+
+    def env(name, default=""):
+        return os.environ.get(name, default).strip()
+
+    def auth_header():
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        return {"Authorization": f"Basic {token}"}
+
+    def request(method, path, body=None, ok=(200, 201, 202, 204, 409, 404)):
+        data = None
+        headers = {"Accept": "application/json", **auth_header()}
+        if body is not None:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(api + path, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                content = resp.read().decode()
+                parsed = json.loads(content) if content else None
+                return resp.status, parsed, dict(resp.headers)
+        except urllib.error.HTTPError as exc:
+            content = exc.read().decode()
+            if exc.code in ok:
+                parsed = json.loads(content) if content else None
+                return exc.code, parsed, dict(exc.headers)
+            raise RuntimeError(f"{method} {path} failed with {exc.code}: {content}") from exc
+
+    def wait_for_harbor():
+        for _ in range(90):
+            try:
+                status, _, _ = request("GET", "/health", ok=(200, 503))
+                if status == 200:
+                    return
+            except Exception as exc:
+                print(f"waiting for Harbor: {exc}", flush=True)
+            time.sleep(10)
+        raise TimeoutError("Harbor did not become healthy")
+
+    def configure_oidc():
+        client_id = env("HARBOR_OIDC_CLIENT_ID")
+        client_secret = env("HARBOR_OIDC_CLIENT_SECRET")
+        if not client_id or not client_secret:
+            raise RuntimeError("Harbor OIDC client secret is unavailable")
+
+        oidc_endpoint = env("HARBOR_OIDC_ENDPOINT")
+        payload = {
+            "auth_mode": "oidc_auth",
+            "primary_auth_mode": True,
+            "oidc_name": "Authentik",
+            "oidc_endpoint": oidc_endpoint,
+            "oidc_client_id": client_id,
+            "oidc_client_secret": client_secret,
+            "oidc_groups_claim": "groups",
+            "oidc_admin_group": "Harbor Admin",
+            "oidc_group_filter": "^Harbor (Admin|Users)$",
+            "oidc_scope": "openid,email,profile,offline_access,groups",
+            "oidc_user_claim": "preferred_username",
+            "oidc_verify_cert": True,
+            "oidc_auto_onboard": True,
+            "oidc_logout": True,
+        }
+        request("POST", "/system/oidc/ping", {"url": oidc_endpoint, "verify_cert": True}, ok=(200,))
+        request("PUT", "/configurations", payload, ok=(200,))
+        print("configured Harbor OIDC authentication", flush=True)
+
+    def list_registries():
+        status, body, _ = request("GET", "/registries?page_size=100", ok=(200,))
+        return body or []
+
+    def ensure_registry(spec):
+        for registry in list_registries():
+            if registry.get("name") == spec["name"]:
+                if registry.get("type") != spec["type"] or registry.get("url") != spec["url"]:
+                    raise RuntimeError(f"registry endpoint {spec['name']} exists with unexpected type/url")
+                access_key = spec.get("access_key", "")
+                access_secret = spec.get("access_secret", "")
+                if access_key and access_secret and access_key != "REPLACE_ME" and access_secret != "REPLACE_ME":
+                    request(
+                        "PUT",
+                        f"/registries/{registry['id']}",
+                        {
+                            "name": spec["name"],
+                            "description": spec["description"],
+                            "url": spec["url"],
+                            "credential_type": "basic",
+                            "access_key": access_key,
+                            "access_secret": access_secret,
+                            "insecure": False,
+                        },
+                        ok=(200,),
+                    )
+                print(f"registry endpoint {spec['name']} exists", flush=True)
+                return registry["id"]
+
+        payload = {
+            "name": spec["name"],
+            "description": spec["description"],
+            "type": spec["type"],
+            "url": spec["url"],
+            "insecure": False,
+        }
+        access_key = spec.get("access_key", "")
+        access_secret = spec.get("access_secret", "")
+        if access_key and access_secret and access_key != "REPLACE_ME" and access_secret != "REPLACE_ME":
+            payload["credential"] = {
+                "type": "basic",
+                "access_key": access_key,
+                "access_secret": access_secret,
+            }
+
+        request("POST", "/registries", payload, ok=(201,))
+        for registry in list_registries():
+            if registry.get("name") == spec["name"]:
+                print(f"created registry endpoint {spec['name']}", flush=True)
+                return registry["id"]
+        raise RuntimeError(f"registry endpoint {spec['name']} was not returned after creation")
+
+    def get_project(name):
+        encoded = urllib.parse.quote(name, safe="")
+        status, body, _ = request("GET", f"/projects/{encoded}?is_resource_name=true", ok=(200, 404))
+        return body if status == 200 else None
+
+    def ensure_proxy_project(name, registry_id):
+        project = get_project(name)
+        if project:
+            if project.get("registry_id") != registry_id:
+                raise RuntimeError(f"project {name} exists but is not linked to registry {registry_id}")
+            metadata = project.get("metadata") or {}
+            if metadata.get("public") != "true":
+                encoded = urllib.parse.quote(name, safe="")
+                request("PUT", f"/projects/{encoded}?is_resource_name=true", {"metadata": {"public": "true"}}, ok=(200,))
+            print(f"proxy project {name} exists", flush=True)
+            return
+
+        payload = {
+            "project_name": name,
+            "registry_id": registry_id,
+            "public": True,
+            "metadata": {
+                "public": "true",
+                "auto_scan": "false",
+                "enable_content_trust": "false",
+                "prevent_vul": "false",
+                "reuse_sys_cve_allowlist": "true",
+            },
+            "storage_limit": -1,
+        }
+        request("POST", "/projects", payload, ok=(201,))
+        print(f"created proxy project {name}", flush=True)
+
+    wait_for_harbor()
+    configure_oidc()
+
+    registries = [
+        {
+            "name": "dockerhub",
+            "description": "Docker Hub proxy cache upstream",
+            "type": "docker-hub",
+            "url": "https://hub.docker.com",
+            "access_key": env("DOCKERHUB_USERNAME"),
+            "access_secret": env("DOCKERHUB_TOKEN"),
+        },
+        {
+            "name": "ghcr",
+            "description": "GitHub Container Registry proxy cache upstream",
+            "type": "github-ghcr",
+            "url": "https://ghcr.io",
+        },
+        {
+            "name": "lscr",
+            "description": "LinuxServer registry proxy cache upstream",
+            "type": "docker-registry",
+            "url": "https://lscr.io",
+        },
+        {
+            "name": "quay",
+            "description": "Quay proxy cache upstream",
+            "type": "quay",
+            "url": "https://quay.io",
+        },
+    ]
+
+    for spec in registries:
+        registry_id = ensure_registry(spec)
+        ensure_proxy_project(spec["name"], registry_id)
+
+    print("Harbor bootstrap complete", flush=True)

--- a/kubernetes/infrastructure/registry/harbor/config/bootstrap-cronjob.yaml
+++ b/kubernetes/infrastructure/registry/harbor/config/bootstrap-cronjob.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: harbor-bootstrap
+  namespace: harbor
+spec:
+  schedule: "17 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      activeDeadlineSeconds: 900
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: bootstrap
+              image: docker.io/library/python:3.13-alpine
+              imagePullPolicy: IfNotPresent
+              command:
+                - python
+                - /scripts/bootstrap.py
+              env:
+                - name: HARBOR_API
+                  value: http://harbor-core/api/v2.0
+                - name: HARBOR_USERNAME
+                  value: admin
+                - name: HARBOR_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: harbor-secrets
+                      key: HARBOR_ADMIN_PASSWORD
+                - name: HARBOR_OIDC_ENDPOINT
+                  value: https://sso.${CLUSTER_DOMAIN}/application/o/harbor/
+                - name: HARBOR_OIDC_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: harbor-sso-secret
+                      key: CLIENT_ID
+                - name: HARBOR_OIDC_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: harbor-sso-secret
+                      key: CLIENT_SECRET
+                - name: DOCKERHUB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: harbor-bootstrap-secret
+                      key: DOCKERHUB_USERNAME
+                      optional: true
+                - name: DOCKERHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: harbor-bootstrap-secret
+                      key: DOCKERHUB_TOKEN
+                      optional: true
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 64Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
+          volumes:
+            - name: script
+              configMap:
+                name: harbor-bootstrap

--- a/kubernetes/infrastructure/registry/harbor/config/bootstrap-secret.sops.yaml
+++ b/kubernetes/infrastructure/registry/harbor/config/bootstrap-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: harbor-bootstrap-secret
+    namespace: harbor
+type: Opaque
+stringData:
+    DOCKERHUB_USERNAME: ENC[AES256_GCM,data:bkYhq/xv4e7B,iv:XFKs7iu6AGto4Q3MbCMBPQN3czG5Mhi+3jwtwYwkfTw=,tag:tCG4z+P81JzpFcx+Y28SKw==,type:str]
+    DOCKERHUB_TOKEN: ENC[AES256_GCM,data:ffM+laRNkJdL5oFlHaXYBm3eWOiF3tE1kAAyIVL7BLVEmbBo,iv:KJsEVidwEaG5iPqMpdQ/Mq5UAD7QLZWKTgDB6sTDvPM=,tag:J1kLEjT70oqkRDkZS4oLKQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpTVN2WHg1MnhicTRVNkND
+            cHRmdjRlMXhKKzVIOTlKMUlNQmVmQUU5d1JRCjVFcjhOWFlMTWNyUmxGRGZDQnVX
+            eHRiOTFVdU9lVDhWUk9xa0Z2WVpPMGMKLS0tIHdWOTIvWUpDNFFjSVRFVThmNVZj
+            NGZodmRNVUsxM0UvKzRWNnQ3UG9WUFEKQnKkzkrskbNX9MX9GCy1/1xP5D7H8Uw+
+            Eju9oJadzvJSx5Gh3Ys1hSr/2MO516Y9rVER+h5on6cJulUGLh5dzg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-24T22:46:48Z"
+    mac: ENC[AES256_GCM,data:/aQ6ELn1GHezFXN0O1RTxrrX9TUzsIC6ekDA379xpmdFMI5s4k8tIPcXjqFP2Smbv2Q8JahIbbn8KIkMRPDYFPUNDoBcdGp6VgZfQeEYhsrHNll1CE+772TEPS4Gk4y3yDNxPB6oGqnLoRQXgcHFWVoIcg66od9TVsmx8cdSFG4=,iv:Lc7hOJ1JjVTsY/qDZF6DLZS3Owq9SJFdNtP1azDuvUQ=,tag:Wv9amStd2nxNSaByjsNvkg==,type:str]
+    version: 3.13.1

--- a/kubernetes/infrastructure/registry/harbor/config/kustomization.yaml
+++ b/kubernetes/infrastructure/registry/harbor/config/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bootstrap-secret.sops.yaml
+  - bootstrap-configmap.yaml
+  - bootstrap-cronjob.yaml

--- a/kubernetes/infrastructure/registry/harbor/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/registry/harbor/install/helmrelease.yaml
@@ -1,0 +1,180 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: harbor
+  namespace: flux-system
+spec:
+  interval: 30m
+  timeout: 20m
+  targetNamespace: harbor
+  install:
+    createNamespace: false
+  upgrade:
+    cleanupOnFail: true
+  chart:
+    spec:
+      chart: harbor
+      # renovate: datasource=helm depName=harbor registryUrl=https://helm.goharbor.io
+      version: "1.19.0"
+      sourceRef:
+        kind: HelmRepository
+        name: harbor
+        namespace: flux-system
+      interval: 1h
+  values:
+    externalURL: https://harbor.lan.${CLUSTER_DOMAIN}
+
+    expose:
+      type: ingress
+      tls:
+        enabled: true
+        certSource: none
+      ingress:
+        className: traefik
+        hosts:
+          core: harbor.lan.${CLUSTER_DOMAIN}
+        annotations:
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+          external-dns.alpha.kubernetes.io/hostname: harbor.lan.${CLUSTER_DOMAIN}
+          gethomepage.dev/name: Harbor
+          gethomepage.dev/description: Container registry and proxy cache
+          gethomepage.dev/group: "Kubernetes"
+          gethomepage.dev/icon: harbor.png
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/pod-selector: app=harbor,component=core
+
+    existingSecretAdminPassword: harbor-secrets
+    existingSecretAdminPasswordKey: HARBOR_ADMIN_PASSWORD
+    existingSecretSecretKey: harbor-secrets
+
+    updateStrategy:
+      type: Recreate
+
+    persistence:
+      enabled: true
+      resourcePolicy: keep
+      persistentVolumeClaim:
+        registry:
+          storageClass: longhorn-r2
+          accessMode: ReadWriteOnce
+          size: 100Gi
+        jobservice:
+          jobLog:
+            storageClass: longhorn-r2
+            accessMode: ReadWriteOnce
+            size: 5Gi
+        database:
+          storageClass: longhorn-r2
+          accessMode: ReadWriteOnce
+          size: 10Gi
+        redis:
+          storageClass: longhorn-r2
+          accessMode: ReadWriteOnce
+          size: 2Gi
+        trivy:
+          storageClass: longhorn-r2
+          accessMode: ReadWriteOnce
+          size: 10Gi
+
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          release: observability-kube-prometheus-stack
+
+    cache:
+      enabled: true
+
+    portal:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 300m
+          memory: 512Mi
+
+    core:
+      existingSecret: harbor-secrets
+      existingXsrfSecret: harbor-secrets
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 1536Mi
+
+    jobservice:
+      existingSecret: harbor-secrets
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 1024Mi
+
+    registry:
+      existingSecret: harbor-secrets
+      credentials:
+        username: harbor_registry_user
+        existingSecret: harbor-secrets
+      registry:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 1024Mi
+      controller:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+    trivy:
+      enabled: true
+      resources:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 1536Mi
+
+    database:
+      type: internal
+      internal:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 1024Mi
+
+    redis:
+      type: internal
+      internal:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+    exporter:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi

--- a/kubernetes/infrastructure/registry/harbor/install/kustomization.yaml
+++ b/kubernetes/infrastructure/registry/harbor/install/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.sops.yaml
+  - helmrelease.yaml

--- a/kubernetes/infrastructure/registry/harbor/install/secret.sops.yaml
+++ b/kubernetes/infrastructure/registry/harbor/install/secret.sops.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: harbor-secrets
+    namespace: harbor
+type: Opaque
+stringData:
+    HARBOR_ADMIN_PASSWORD: ENC[AES256_GCM,data:yaaHzobEiUCKDek3oDRm/zuIqKOtOznESlE5v1SweZo=,iv:QIYLgcQaIuBkRvzL6xXzyWKOLRCu6jqCsTDooZCuyFo=,tag:q2vphlZMbu5i0mJDrPWDKQ==,type:str]
+    secretKey: ENC[AES256_GCM,data:Nv4NzJx9nikA1X8uwz/bug==,iv:2GNSuYY+GdiNjZ/iS/Jol8tiLINUVC8Q/hOJBBBBwdI=,tag:/fXJ12Fg3WvkxfmCAY4jQw==,type:str]
+    secret: ENC[AES256_GCM,data:z2R9LI4FgZOlZR8z8ktwwQ==,iv:SAymbfSABer4BIqaulwj9UeldfSh172iatsQNNYWn0g=,tag:sQHs8SaCkGh8YLnzdf4mvA==,type:str]
+    JOBSERVICE_SECRET: ENC[AES256_GCM,data:Aiv5SGSAt8D4UK5c00CzJw==,iv:TbYDQWVS1jwTi54zF0JAwJMIvEZ+0IcvApUNMRYXb5U=,tag:YF2Cr3Qg95fn/Go2bfx60A==,type:str]
+    REGISTRY_HTTP_SECRET: ENC[AES256_GCM,data:utAMsWlY3IGrv3hrqISrrg==,iv:vqE6srzLLrC9KOUylO9zQ4l0i25AgF+JNufK71s1fLc=,tag:qOdxmA3IphhhJezRubNtgQ==,type:str]
+    CSRF_KEY: ENC[AES256_GCM,data:0WVfIZz/789Xl9sRAA8FFcmdvLXjcQZEAJ0C5OCGzls=,iv:4cAjmB0GmlFUdhby8xk5lO1wloQjdDBbEXCMnj2LYo0=,tag:BEapmZhgFHGqQYxEtEkQ0w==,type:str]
+    REGISTRY_PASSWD: ENC[AES256_GCM,data:DdCn+FngifqPk7TkKisY69q6oLCPQxbd25KhraNN7qc=,iv:V1D+OjxCBhKv9SdlY6VN/MJJwi9rG5VQKwWFKxzMPOg=,tag:MTZmkqx1bKBZLJk4kosySg==,type:str]
+    REGISTRY_HTPASSWD: ENC[AES256_GCM,data:zgtyct9KY/ZFR6M1oKLyjcvqicW15fRZdnp05BYIxj042CwacjcTpbOoSY5mMs1EcVJxnCi94934z++mIUX4sikbvHyU4aaSE8eqQtcSKHBI,iv:epbxmSOqT3209My2JkAN68I1KDA/zSGa80PKY72A1mA=,tag:CCiykq4uBtF2J2SzR5ARMg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkQ2NNMHpGc0RlaUJ6R2hj
+            RENxM292eXBPNi8rczZhV1lSa2hlcUlIZmhRCm1NZmdsU1ZiYmx2dVFFOEttMEFB
+            N3RzL2xtZ0ZRZFRrcytrZFZVZUNRNWcKLS0tIHQxQVNSWStxM25jc0k4WUJCWTN5
+            Zm1OV3VCa0FiN2RZUFFTeDZaeHk5ZWMK/b3ZvSIAzuL+orben5ieO834G10hzwf+
+            yaLeLRtUhwrpvuDIa5grguqA+8Vj8TWnm0v/0oiL0xziPRaf2CUwKQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-24T22:52:01Z"
+    mac: ENC[AES256_GCM,data:rc10LAx1uQaFxy0Vbs5tIIp+1ualC2hC5eP4HemWg2nCKpGdeFkJ5kIoG5ESNtgFLtNh4St1NJkEor1Be4P4M3c+9PtGEmupWz74IUGAMUEyMxVHlwMGXse28Es9cpQfmqVJ/N1UVsAJpzE0H7S/Rt7AvPkQo5JRI4BmEU4De60=,iv:cIUC1HktjYj9K5BmHB3PuvPe3XgbK0mYPzr8t2mj1wg=,tag:eOwjHJdll1Q2g09ENuUWng==,type:str]
+    version: 3.13.1

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -375,6 +375,84 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "gitadmin"]]
 
+  245-harbor.yaml: |
+    version: 1
+    metadata:
+      name: harbor-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Harbor Admin"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Harbor Users"
+        attrs:
+          is_superuser: false
+          parent: null
+
+      - model: authentik_providers_oauth2.scopemapping
+        id: harbor-groups-scope
+        identifiers:
+          name: "Harbor Groups Scope"
+        attrs:
+          scope_name: groups
+          description: "Harbor group membership claim"
+          expression: |
+            groups = [group.name for group in request.user.ak_groups.filter(name__startswith="Harbor ")]
+            return {"groups": groups}
+
+      - model: authentik_providers_oauth2.oauth2provider
+        id: harbor-provider
+        identifiers:
+          name: "Harbor"
+        attrs:
+          client_id: !Env HARBOR_CLIENT_ID
+          client_secret: !Env HARBOR_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          client_type: confidential
+          client_authentication_method: client_secret_basic
+          redirect_uris:
+            - url: "https://harbor.lan.${CLUSTER_DOMAIN}/c/oidc/callback"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !KeyOf harbor-groups-scope
+
+      - model: authentik_core.application
+        identifiers:
+          slug: "harbor"
+        attrs:
+          name: "Harbor"
+          provider: !KeyOf harbor-provider
+          group: "Infrastructure"
+
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "harbor"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Harbor Admin"]]
+
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "harbor"]]
+          order: 1
+        attrs:
+          group: !Find [authentik_core.group, [name, "Harbor Users"]]
+
   250-paperless.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/harbor-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/harbor-sso-secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: harbor-sso-secret
+    namespace: authentik
+    annotations:
+        replicator.v1.mittwald.de/replicate-to: harbor
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:d1pZvyeX,iv:Pw95C+n1IyaIXDPBwqa6ytSZ/WpOaCQF/IlycMH5ci0=,tag:mb9JT5kT0SooH/t0dnm7Iw==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:dek7ZWmgat/aKUqeKblCWRhs2AAbV64Yt4ByDPdBvNt2+3FI1RGMvBup95sKMQ9VLsce3hNj9J5VLTh86Tnwk60gCW3T7xqQJ1oJXWjykKWOinmxZq/DlTD8vMeyDfyk,iv:0tpMETdEV8a5NNmk4zQSgckPyVHHudtvMotbjylBbyY=,tag:kxpmbUQbFHOrPKAWWJSfZg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjY2NJN0VXVXREL1JGaDhj
+            S3VqYlhJSUhVNEg1UkpFWERmTjZUTGpOQURzCmVCYzgrNUdsT3hSYkF4MGIxMmtR
+            M3ZTYUdDRWNIbkkrSm9VMnJhTWVmZW8KLS0tIHVqcVBDWExHdzhFSzRGb1RnUjZW
+            ZkxrNjhZTUxxYy9VVi9WN1JhbEYrUkEKfeTT3jkgsYkONCcg1Oi+qm4cQBwiXGij
+            eht+HVqNxjsulv5ppKZ+AmERyZCzE9YU3d56Jw1jMwozQE4wzujwZA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-24T22:40:00Z"
+    mac: ENC[AES256_GCM,data:GmUARUB9CXqJeTxTWJOOYRCREF/v5AJo1uB3iVVXFExOBOiHPtt62GyjsfEXUiREktId6V4jLpqfEdLGzFM0GeM7cDJ7vWO/+5rB943GwLSLVaSblP3qoqWYiyIL5rMFeq71Jn2GcH5AFOu7g7baX8cA3qFzFcTScElmdw+f3dY=,iv:qb+ZksTuuV6cIi4TYSYCSSsyKS1jyZXaG+PsG/BmbxA=,tag:pRqebPXpkv7PLisG3TwDJA==,type:str]
+    version: 3.13.1

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -126,6 +126,16 @@ spec:
             secretKeyRef:
               name: litellm-sso-secret
               key: CLIENT_SECRET
+        - name: HARBOR_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: harbor-sso-secret
+              key: CLIENT_ID
+        - name: HARBOR_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: harbor-sso-secret
+              key: CLIENT_SECRET
         - name: DISCORD_BASIC_AUTH
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - paperless-sso-secret.sops.yaml
   - nextcloud-sso-secret.sops.yaml
   - litellm-sso-secret.sops.yaml
+  - harbor-sso-secret.sops.yaml
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml
   - llama-auth-secret.sops.yaml

--- a/kubernetes/infrastructure/sources/harbor.yaml
+++ b/kubernetes/infrastructure/sources/harbor.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: harbor
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://helm.goharbor.io

--- a/kubernetes/infrastructure/sources/kustomization.yaml
+++ b/kubernetes/infrastructure/sources/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - crowdsec.yaml
   - nfd.yaml
   - intel.yaml
+  - harbor.yaml


### PR DESCRIPTION
## Summary
- add Authentik OIDC app, groups, replicated client secret, and Harbor OIDC bootstrap wiring
- deploy Harbor via Flux/Helm with Longhorn-backed persistence, Trivy, metrics, and stable SOPS-managed internal secrets
- add idempotent Harbor bootstrap CronJob for OIDC configuration and proxy-cache projects for Docker Hub, GHCR, LSCR, and Quay

## Validation
- kubectl apply --dry-run=client -k kubernetes/infrastructure/registry/harbor/install
- kubectl apply --dry-run=client -k kubernetes/infrastructure/registry/harbor/config
- kubectl apply --dry-run=client -k kubernetes/infrastructure/security/authentik/install
- kubectl apply --dry-run=client -k kubernetes/clusters/production/ks
- pre-commit run --all-files
- git log --show-signature --oneline origin/master..HEAD