### PR TITLE
feat(k3s): use harbor registry mirrors

### DIFF
--- a/ansible/roles/k3s/defaults/main.yml
+++ b/ansible/roles/k3s/defaults/main.yml
@@ -5,8 +5,32 @@ k3s_cluster_init: false
 k3s_server_args: ""
 k3s_agent_args: ""
 k3s_embedded_registry_enabled: true
+k3s_cluster_domain: "{{ lookup('ansible.builtin.env', 'CLUSTER_DOMAIN') | default('', true) }}"
+k3s_harbor_registry_endpoint: "https://harbor.lan.{{ k3s_cluster_domain }}"
+# Keep K3s/containerd's default endpoint fallback enabled. On first cluster
+# bootstrap Harbor will not exist yet, so nodes must still pull from upstream.
 k3s_registry_mirrors:
   "*": {}
+  docker.io:
+    endpoint:
+      - "{{ k3s_harbor_registry_endpoint }}"
+    rewrite:
+      "^(.*)$": "dockerhub/$1"
+  ghcr.io:
+    endpoint:
+      - "{{ k3s_harbor_registry_endpoint }}"
+    rewrite:
+      "^(.*)$": "ghcr/$1"
+  lscr.io:
+    endpoint:
+      - "{{ k3s_harbor_registry_endpoint }}"
+    rewrite:
+      "^(.*)$": "lscr/$1"
+  quay.io:
+    endpoint:
+      - "{{ k3s_harbor_registry_endpoint }}"
+    rewrite:
+      "^(.*)$": "quay/$1"
 
 # Virtual IP set up in OPNSense for K3s API load balancing
 k3s_api_vip: 192.168.10.10

--- a/ansible/roles/k3s/tasks/main.yml
+++ b/ansible/roles/k3s/tasks/main.yml
@@ -91,6 +91,12 @@
       - (k3s_iface | default('')) | length > 0
     fail_msg: "k3s_iface is empty; set it to the interface carrying k3s_node_ip"
 
+- name: Ensure Harbor registry mirror domain is set
+  ansible.builtin.assert:
+    that:
+      - (k3s_cluster_domain | default('')) | length > 0
+    fail_msg: "Set CLUSTER_DOMAIN in the shell environment before rendering Harbor registry mirrors"
+
 - name: Create K3s installation directory
   ansible.builtin.file:
     path: /usr/local/bin

--- a/ansible/roles/k3s/templates/registries.yaml.j2
+++ b/ansible/roles/k3s/templates/registries.yaml.j2
@@ -1,5 +1,9 @@
 mirrors:
 {% for registry, config in k3s_registry_mirrors.items() %}
-  "{{ registry }}":{% if config %}
-{{ config | to_nice_yaml(indent=2) | indent(4, true) }}{% endif %}
+  "{{ registry }}":
+{% if config %}
+{{ config | to_nice_yaml(indent=2) | indent(4, true) }}
+{% else %}
+    {}
+{% endif %}
 {% endfor %}

--- a/kubernetes/apps/apps/paperless/helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/helmrelease.yaml
@@ -58,7 +58,7 @@ spec:
                   secretKeyRef:
                     name: paperless-oidc-secrets
                     key: PAPERLESS_SOCIALACCOUNT_PROVIDERS
-              PAPERLESS_LOGOUT_REDIRECT_URL: "https://sso.lainternetdelpantano.xyz/application/o/paperless/end-session/"
+              PAPERLESS_LOGOUT_REDIRECT_URL: "https://sso.${CLUSTER_DOMAIN}/application/o/paperless/end-session/"
               PAPERLESS_SOCIAL_AUTO_SIGNUP: "false"
               PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "true"
               PAPERLESS_DISABLE_REGULAR_LOGIN: "true"


### PR DESCRIPTION
## Summary
- configure K3s/containerd mirrors for Docker Hub, GHCR, LSCR, and Quay through Harbor proxy-cache projects
- keep default upstream fallback enabled for first-cluster bootstrap safety
- source the cluster domain from the shell CLUSTER_DOMAIN environment variable instead of committing it
- replace the remaining plaintext Paperless SSO domain with \

## Validation
- kubectl apply --dry-run=client -k kubernetes/apps/apps/paperless
- CLUSTER_DOMAIN=example.invalid ansible-playbook playbooks/k3s_cluster.yml --syntax-check
- ansible-lint playbooks/k3s_cluster.yml roles/k3s
- rendered registries.yaml parses with Harbor mirror rewrites
- pre-commit run check-yaml --files ansible/roles/k3s/defaults/main.yml ansible/roles/k3s/tasks/main.yml ansible/roles/k3s/templates/registries.yaml.j2 kubernetes/apps/apps/paperless/helmrelease.yaml
- pre-commit run yamllint --files ansible/roles/k3s/defaults/main.yml ansible/roles/k3s/tasks/main.yml ansible/roles/k3s/templates/registries.yaml.j2 kubernetes/apps/apps/paperless/helmrelease.yaml
- git diff --check
- verified live node registries.yaml has Harbor mirrors on all K3s nodes
- verified fresh GHCR image pull is handled by Harbor proxy-cache logs