### PR TITLE
fix(renovate): use harbor proxy cache

### DIFF
--- a/ansible/roles/k3s/defaults/main.yml
+++ b/ansible/roles/k3s/defaults/main.yml
@@ -31,6 +31,16 @@ k3s_registry_mirrors:
       - "{{ k3s_harbor_registry_endpoint }}"
     rewrite:
       "^(.*)$": "quay/$1"
+  docker.n8n.io:
+    endpoint:
+      - "{{ k3s_harbor_registry_endpoint }}"
+    rewrite:
+      "^(.*)$": "n8n/$1"
+  docker.gitea.com:
+    endpoint:
+      - "{{ k3s_harbor_registry_endpoint }}"
+    rewrite:
+      "^(.*)$": "gitea/$1"
 
 # Virtual IP set up in OPNSense for K3s API load balancing
 k3s_api_vip: 192.168.10.10

--- a/kubernetes/infrastructure/automation/renovate/configmap.yaml
+++ b/kubernetes/infrastructure/automation/renovate/configmap.yaml
@@ -7,5 +7,53 @@ data:
   config.json: |
     {
       "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-      "repositories": ["nreymundo/home-lab-iac"]
+      "repositories": ["nreymundo/home-lab-iac"],
+      "packageRules": [
+        {
+          "description": "Use Harbor proxy cache for Docker Hub default lookups",
+          "matchDatasources": ["docker"],
+          "defaultRegistryUrls": ["https://harbor.lan.${CLUSTER_DOMAIN}/dockerhub"]
+        },
+        {
+          "description": "Use Harbor proxy cache for Docker Hub lookups",
+          "matchDatasources": ["docker"],
+          "matchRegistryUrls": [
+            "https://docker.io",
+            "https://hub.docker.com",
+            "https://index.docker.io",
+            "https://registry-1.docker.io"
+          ],
+          "registryUrls": ["https://harbor.lan.${CLUSTER_DOMAIN}/dockerhub"]
+        },
+        {
+          "description": "Use Harbor proxy cache for GitHub Container Registry lookups",
+          "matchDatasources": ["docker"],
+          "matchRegistryUrls": ["https://ghcr.io"],
+          "registryUrls": ["https://harbor.lan.${CLUSTER_DOMAIN}/ghcr"]
+        },
+        {
+          "description": "Use Harbor proxy cache for LinuxServer registry lookups",
+          "matchDatasources": ["docker"],
+          "matchRegistryUrls": ["https://lscr.io"],
+          "registryUrls": ["https://harbor.lan.${CLUSTER_DOMAIN}/lscr"]
+        },
+        {
+          "description": "Use Harbor proxy cache for Quay lookups",
+          "matchDatasources": ["docker"],
+          "matchRegistryUrls": ["https://quay.io"],
+          "registryUrls": ["https://harbor.lan.${CLUSTER_DOMAIN}/quay"]
+        },
+        {
+          "description": "Use Harbor proxy cache for n8n registry lookups",
+          "matchDatasources": ["docker"],
+          "matchRegistryUrls": ["https://docker.n8n.io"],
+          "registryUrls": ["https://harbor.lan.${CLUSTER_DOMAIN}/n8n"]
+        },
+        {
+          "description": "Use Harbor proxy cache for Gitea registry lookups",
+          "matchDatasources": ["docker"],
+          "matchRegistryUrls": ["https://docker.gitea.com"],
+          "registryUrls": ["https://harbor.lan.${CLUSTER_DOMAIN}/gitea"]
+        }
+      ]
     }

--- a/kubernetes/infrastructure/automation/renovate/configmap.yaml
+++ b/kubernetes/infrastructure/automation/renovate/configmap.yaml
@@ -10,9 +10,9 @@ data:
       "repositories": ["nreymundo/home-lab-iac"],
       "packageRules": [
         {
-          "description": "Use Harbor proxy cache for Docker Hub default lookups",
+          "description": "Use Harbor proxy cache for default Docker Hub lookups",
           "matchDatasources": ["docker"],
-          "defaultRegistryUrls": ["https://harbor.lan.${CLUSTER_DOMAIN}/dockerhub"]
+          "registryUrls": ["https://harbor.lan.${CLUSTER_DOMAIN}/dockerhub"]
         },
         {
           "description": "Use Harbor proxy cache for Docker Hub lookups",

--- a/kubernetes/infrastructure/registry/harbor/config/bootstrap-configmap.yaml
+++ b/kubernetes/infrastructure/registry/harbor/config/bootstrap-configmap.yaml
@@ -320,6 +320,20 @@ data:
             "url": "https://quay.io",
             "storage_limit": 10 * gib,
         },
+        {
+            "name": "n8n",
+            "description": "n8n registry proxy cache upstream",
+            "type": "docker-registry",
+            "url": "https://docker.n8n.io",
+            "storage_limit": 10 * gib,
+        },
+        {
+            "name": "gitea",
+            "description": "Gitea registry proxy cache upstream",
+            "type": "docker-registry",
+            "url": "https://docker.gitea.com",
+            "storage_limit": 10 * gib,
+        },
     ]
 
     for spec in registries:

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":disableDependencyDashboard",
-    ":disableRateLimiting"
+    ":disableDependencyDashboard"
   ],
   "enabledManagers": ["flux", "helm-values", "dockerfile", "kubernetes", "custom.regex"],
   "timezone": "UTC",


### PR DESCRIPTION
## Summary
- route Renovate Docker lookups through Harbor proxy-cache projects using CLUSTER_DOMAIN substitution
- add Harbor proxy projects and K3s mirror rewrites for n8n and Gitea registries
- restore Renovate rate limiting by removing :disableRateLimiting

## Validation
- pre-commit hooks during commit
- jq empty renovate.json
- kubectl apply --dry-run=client -f kubernetes/infrastructure/automation/renovate/configmap.yaml -f kubernetes/infrastructure/registry/harbor/config/bootstrap-configmap.yaml