### PR TITLE
feat(ansible): add headless laptop provisioning

### DIFF
--- a/ansible/inventories/baremetal.yml
+++ b/ansible/inventories/baremetal.yml
@@ -14,6 +14,9 @@ all:
     pve3:
       ansible_host: 192.168.1.6
       ansible_user: root
+    g14-2022:
+      ansible_host: 192.168.10.11
+      ansible_user: alx0s
 
 # Here we group the hosts defined above based on type/functionality
   children:
@@ -25,3 +28,6 @@ all:
         pve1: {}
         pve2: {}
         pve3: {}
+    headless_laptops:
+      hosts:
+        g14-2022: {}

--- a/ansible/inventories/group_vars/all.yml
+++ b/ansible/inventories/group_vars/all.yml
@@ -3,7 +3,7 @@
 ssh_hardening_authorized_keys:
   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICuRNLs/Xvp/uNKF13JF0NNNDVS37bc72e47Y4yF0xSr desktop"
   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK7zi2/TiNLXy9MtIVrChiXTHw5jlMFAAkHiJXPaFrMn laptop"
-  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOKnc8+Hx6sb2jzxMNRkultwBfIBa2ZfXv6WkIE2Zcjd dev-vm"
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC21JbTch4KCvWvMqNHP2WMWHGI9OrSvuibZuMEc8J7O dev-laptop"
 
 common_timezone: "Europe/Berlin"
 

--- a/ansible/inventories/host_vars/g14-2022.yml
+++ b/ansible/inventories/host_vars/g14-2022.yml
@@ -10,6 +10,8 @@ common_enable_fstrim: true
 
 docker_install_enabled: true
 
+swapfile_enabled: true
+
 ssh_hardening_sshd_settings:
   PermitRootLogin: "no"
   PasswordAuthentication: "no"

--- a/ansible/inventories/host_vars/g14-2022.yml
+++ b/ansible/inventories/host_vars/g14-2022.yml
@@ -1,12 +1,19 @@
 ---
 common_user: "{{ ansible_user }}"
 
-# Keep the first bare-metal baseline conservative; enable upgrades deliberately later.
+# Keep interactive playbook runs from doing a full dist-upgrade.
 common_run_upgrade: false
-common_enable_unattended_upgrades: false
+common_enable_unattended_upgrades: true
+common_unattended_upgrades_auto_reboot: true
+common_unattended_upgrades_reboot_time: "06:00"
+common_enable_fstrim: true
 
 ssh_hardening_sshd_settings:
   PermitRootLogin: "no"
   PasswordAuthentication: "no"
   ChallengeResponseAuthentication: "no"
   UsePAM: "yes"
+
+headless_laptop_power_profile: power-saver
+headless_laptop_gpu_users:
+  - "{{ ansible_user }}"

--- a/ansible/inventories/host_vars/g14-2022.yml
+++ b/ansible/inventories/host_vars/g14-2022.yml
@@ -26,7 +26,7 @@ ssh_hardening_sshd_settings:
 
 headless_laptop_power_profile: power-saver
 headless_laptop_battery_charge_limit: 60
-headless_laptop_asus_quiet_fan_percent: 25
+headless_laptop_asus_quiet_fan_percent: 20
 headless_laptop_extra_packages:
   # System diagnostics
   - htop

--- a/ansible/inventories/host_vars/g14-2022.yml
+++ b/ansible/inventories/host_vars/g14-2022.yml
@@ -7,6 +7,12 @@ common_enable_unattended_upgrades: true
 common_unattended_upgrades_auto_reboot: true
 common_unattended_upgrades_reboot_time: "06:00"
 common_enable_fstrim: true
+common_manage_journald: true
+common_journald_system_max_use: 1G
+common_journald_system_keep_free: 2G
+common_journald_system_max_file_size: 128M
+common_journald_max_retention_sec: 30day
+common_journald_max_file_sec: 1week
 
 docker_install_enabled: true
 

--- a/ansible/inventories/host_vars/g14-2022.yml
+++ b/ansible/inventories/host_vars/g14-2022.yml
@@ -20,6 +20,7 @@ ssh_hardening_sshd_settings:
 
 headless_laptop_power_profile: power-saver
 headless_laptop_battery_charge_limit: 60
+headless_laptop_asus_quiet_fan_percent: 25
 headless_laptop_extra_packages:
   # System diagnostics
   - htop

--- a/ansible/inventories/host_vars/g14-2022.yml
+++ b/ansible/inventories/host_vars/g14-2022.yml
@@ -15,5 +15,6 @@ ssh_hardening_sshd_settings:
   UsePAM: "yes"
 
 headless_laptop_power_profile: power-saver
+headless_laptop_battery_charge_limit: 60
 headless_laptop_gpu_users:
   - "{{ ansible_user }}"

--- a/ansible/inventories/host_vars/g14-2022.yml
+++ b/ansible/inventories/host_vars/g14-2022.yml
@@ -1,0 +1,12 @@
+---
+common_user: "{{ ansible_user }}"
+
+# Keep the first bare-metal baseline conservative; enable upgrades deliberately later.
+common_run_upgrade: false
+common_enable_unattended_upgrades: false
+
+ssh_hardening_sshd_settings:
+  PermitRootLogin: "no"
+  PasswordAuthentication: "no"
+  ChallengeResponseAuthentication: "no"
+  UsePAM: "yes"

--- a/ansible/inventories/host_vars/g14-2022.yml
+++ b/ansible/inventories/host_vars/g14-2022.yml
@@ -20,5 +20,64 @@ ssh_hardening_sshd_settings:
 
 headless_laptop_power_profile: power-saver
 headless_laptop_battery_charge_limit: 60
+headless_laptop_extra_packages:
+  # System diagnostics
+  - htop
+  - btop
+  - sysstat
+  - iotop
+  - iftop
+  - nethogs
+  - lsof
+  - strace
+  - pciutils
+  - usbutils
+  - dmidecode
+  - ethtool
+
+  # Storage diagnostics
+  - smartmontools
+  - nvme-cli
+
+  # Network/debug tooling
+  - bind9-dnsutils
+  - iperf3
+  - mtr-tiny
+  - tcpdump
+  - net-tools
+
+  # Developer/build tooling
+  - git
+  - build-essential
+  - pkg-config
+  - cmake
+  - ninja-build
+  - python3-venv
+  - python3-pip
+  - pipx
+  - unzip
+  - jq
+  - yq
+  - ripgrep
+  - fd-find
+  - gh
+
+  # Remote/admin convenience
+  - tmux
+  - tree
+  - rsync
+  - restic
+
+  # Performance profiling
+  - linux-tools-generic
+  - linux-cloud-tools-generic
+  - perf-tools-unstable
+
+  # Host firewall tooling
+  - ufw
+
+  # Laptop telemetry and power tooling
+  - power-profiles-daemon
+  - fastfetch
 headless_laptop_gpu_users:
   - "{{ ansible_user }}"

--- a/ansible/inventories/host_vars/g14-2022.yml
+++ b/ansible/inventories/host_vars/g14-2022.yml
@@ -8,6 +8,8 @@ common_unattended_upgrades_auto_reboot: true
 common_unattended_upgrades_reboot_time: "06:00"
 common_enable_fstrim: true
 
+docker_install_enabled: true
+
 ssh_hardening_sshd_settings:
   PermitRootLogin: "no"
   PasswordAuthentication: "no"

--- a/ansible/playbooks/headless_laptops.yml
+++ b/ansible/playbooks/headless_laptops.yml
@@ -5,4 +5,5 @@
   roles:
     - common
     - ssh_hardening
+    - docker
     - headless_laptop

--- a/ansible/playbooks/headless_laptops.yml
+++ b/ansible/playbooks/headless_laptops.yml
@@ -6,4 +6,5 @@
     - common
     - ssh_hardening
     - docker
+    - swapfile
     - headless_laptop

--- a/ansible/playbooks/headless_laptops.yml
+++ b/ansible/playbooks/headless_laptops.yml
@@ -5,3 +5,4 @@
   roles:
     - common
     - ssh_hardening
+    - headless_laptop

--- a/ansible/playbooks/headless_laptops.yml
+++ b/ansible/playbooks/headless_laptops.yml
@@ -1,0 +1,7 @@
+---
+- name: Provision headless laptop hosts
+  hosts: headless_laptops
+  become: true
+  roles:
+    - common
+    - ssh_hardening

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -12,6 +12,15 @@ common_fstrim_timer_schedule: "04:00:00"
 
 common_extra_packages: []
 
+common_manage_journald: false
+common_journald_storage: persistent
+common_journald_compress: true
+common_journald_system_max_use: 1G
+common_journald_system_keep_free: 2G
+common_journald_system_max_file_size: 128M
+common_journald_max_retention_sec: 30day
+common_journald_max_file_sec: 1week
+
 common_packages:
   - curl
   - vim

--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -25,3 +25,9 @@
 - name: Reload systemd daemon
   ansible.builtin.systemd:
     daemon_reload: true
+
+- name: Restart systemd-journald
+  ansible.builtin.systemd:
+    name: systemd-journald
+    state: restarted
+  when: not ansible_check_mode

--- a/ansible/roles/common/tasks/journald.yml
+++ b/ansible/roles/common/tasks/journald.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure logrotate is installed
+  ansible.builtin.package:
+    name: logrotate
+    state: present
+
+- name: Ensure journald drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/systemd/journald.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Configure journald retention limits
+  ansible.builtin.template:
+    src: journald-retention.conf.j2
+    dest: /etc/systemd/journald.conf.d/20-retention.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart systemd-journald

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -7,6 +7,10 @@
 - name: Run common identity tasks
   ansible.builtin.include_tasks: identity.yml
 
+- name: Configure system log retention
+  ansible.builtin.include_tasks: journald.yml
+  when: common_manage_journald | bool
+
 - name: Run Debian/Ubuntu specific tasks
   ansible.builtin.include_tasks: os-debian.yml
   when: ansible_os_family == 'Debian'

--- a/ansible/roles/common/templates/journald-retention.conf.j2
+++ b/ansible/roles/common/templates/journald-retention.conf.j2
@@ -1,0 +1,8 @@
+[Journal]
+Storage={{ common_journald_storage }}
+Compress={{ 'yes' if common_journald_compress | bool else 'no' }}
+SystemMaxUse={{ common_journald_system_max_use }}
+SystemKeepFree={{ common_journald_system_keep_free }}
+SystemMaxFileSize={{ common_journald_system_max_file_size }}
+MaxRetentionSec={{ common_journald_max_retention_sec }}
+MaxFileSec={{ common_journald_max_file_sec }}

--- a/ansible/roles/headless_laptop/defaults/main.yml
+++ b/ansible/roles/headless_laptop/defaults/main.yml
@@ -19,6 +19,10 @@ headless_laptop_sleep_targets:
 headless_laptop_power_profile: power-saver
 headless_laptop_battery_charge_limit: 80
 
+headless_laptop_grub_cmdline_dropin_path: /etc/default/grub.d/99-headless-laptop.cfg
+headless_laptop_grub_cmdline_linux_default:
+  - crashkernel=0
+
 headless_laptop_packages:
   - alsa-utils
   - mesa-utils

--- a/ansible/roles/headless_laptop/defaults/main.yml
+++ b/ansible/roles/headless_laptop/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+headless_laptop_logind_conf_path: /etc/systemd/logind.conf.d/ignore-lid.conf
+
+headless_laptop_logind_settings:
+  HandleLidSwitch: ignore
+  HandleLidSwitchExternalPower: ignore
+  HandleLidSwitchDocked: ignore
+  IdleAction: ignore
+  IdleActionSec: "0"
+
+headless_laptop_mask_sleep_targets: true
+headless_laptop_sleep_targets:
+  - sleep.target
+  - suspend.target
+  - hibernate.target
+  - hybrid-sleep.target
+  - suspend-then-hibernate.target
+
+headless_laptop_power_profile: power-saver
+
+headless_laptop_packages:
+  - alsa-utils
+  - mesa-utils
+  - vulkan-tools
+  - mesa-vulkan-drivers
+  - radeontop
+  - clinfo
+  - lm-sensors
+  - power-profiles-daemon
+
+headless_laptop_gpu_users: []
+headless_laptop_gpu_groups:
+  - render
+  - video
+
+headless_laptop_validate_gpu: true
+headless_laptop_validate_dri_prime: true

--- a/ansible/roles/headless_laptop/defaults/main.yml
+++ b/ansible/roles/headless_laptop/defaults/main.yml
@@ -17,6 +17,7 @@ headless_laptop_sleep_targets:
   - suspend-then-hibernate.target
 
 headless_laptop_power_profile: power-saver
+headless_laptop_battery_charge_limit: 80
 
 headless_laptop_packages:
   - alsa-utils

--- a/ansible/roles/headless_laptop/defaults/main.yml
+++ b/ansible/roles/headless_laptop/defaults/main.yml
@@ -34,6 +34,7 @@ headless_laptop_packages:
   - clinfo
   - lm-sensors
   - power-profiles-daemon
+headless_laptop_extra_packages: []
 
 headless_laptop_gpu_users: []
 headless_laptop_gpu_groups:

--- a/ansible/roles/headless_laptop/defaults/main.yml
+++ b/ansible/roles/headless_laptop/defaults/main.yml
@@ -19,7 +19,9 @@ headless_laptop_sleep_targets:
 headless_laptop_power_profile: power-saver
 headless_laptop_battery_charge_limit: 80
 
-headless_laptop_grub_cmdline_dropin_path: /etc/default/grub.d/99-headless-laptop.cfg
+headless_laptop_grub_cmdline_dropin_path: /etc/default/grub.d/zz-headless-laptop.cfg
+headless_laptop_grub_cmdline_legacy_dropins:
+  - /etc/default/grub.d/99-headless-laptop.cfg
 headless_laptop_grub_cmdline_linux_default:
   - crashkernel=0
 

--- a/ansible/roles/headless_laptop/defaults/main.yml
+++ b/ansible/roles/headless_laptop/defaults/main.yml
@@ -19,6 +19,11 @@ headless_laptop_sleep_targets:
 headless_laptop_power_profile: power-saver
 headless_laptop_battery_charge_limit: 80
 
+headless_laptop_asus_quiet_fan_policy_enabled: true
+headless_laptop_asus_quiet_fan_percent: 30
+headless_laptop_asus_quiet_fan_platform_profile: quiet
+headless_laptop_asus_quiet_fan_policy_interval: 10s
+
 headless_laptop_grub_cmdline_dropin_path: /etc/default/grub.d/zz-headless-laptop.cfg
 headless_laptop_grub_cmdline_legacy_dropins:
   - /etc/default/grub.d/99-headless-laptop.cfg

--- a/ansible/roles/headless_laptop/handlers/main.yml
+++ b/ansible/roles/headless_laptop/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart systemd-logind
+  ansible.builtin.systemd:
+    name: systemd-logind
+    state: restarted
+  when: not ansible_check_mode

--- a/ansible/roles/headless_laptop/handlers/main.yml
+++ b/ansible/roles/headless_laptop/handlers/main.yml
@@ -4,3 +4,8 @@
     name: systemd-logind
     state: restarted
   when: not ansible_check_mode
+
+- name: Update grub
+  ansible.builtin.command: update-grub
+  changed_when: true
+  when: not ansible_check_mode

--- a/ansible/roles/headless_laptop/tasks/amd_gpu.yml
+++ b/ansible/roles/headless_laptop/tasks/amd_gpu.yml
@@ -1,0 +1,75 @@
+---
+- name: Ensure GPU users are configured when GPU groups are configured
+  ansible.builtin.assert:
+    that:
+      - headless_laptop_gpu_users is sequence
+      - headless_laptop_gpu_users is not string
+      - headless_laptop_gpu_groups is sequence
+      - headless_laptop_gpu_groups is not string
+    fail_msg: "Set headless_laptop_gpu_users and headless_laptop_gpu_groups as lists"
+    quiet: true
+
+- name: Add GPU users to render and video groups
+  ansible.builtin.user:
+    name: "{{ item }}"
+    groups: "{{ headless_laptop_gpu_groups | join(',') }}"
+    append: true
+  loop: "{{ headless_laptop_gpu_users }}"
+  when:
+    - headless_laptop_gpu_users | length > 0
+    - headless_laptop_gpu_groups | length > 0
+
+- name: Report GPU group membership session requirement
+  ansible.builtin.debug:
+    msg: "User {{ item }} must log out and back in before new GPU group membership is active."
+  loop: "{{ headless_laptop_gpu_users }}"
+  when:
+    - not ansible_check_mode
+    - headless_laptop_gpu_users | length > 0
+    - headless_laptop_gpu_groups | length > 0
+
+- name: Check AMD GPU kernel module
+  ansible.builtin.command: lsmod
+  register: headless_laptop_lsmod
+  changed_when: false
+  check_mode: false
+  when: headless_laptop_validate_gpu | bool
+
+- name: Assert amdgpu kernel module is loaded
+  ansible.builtin.assert:
+    that:
+      - headless_laptop_lsmod.stdout_lines | select('match', '^amdgpu\s') | list | length > 0
+    fail_msg: "AMD GPU validation is enabled, but the amdgpu kernel module is not loaded."
+    quiet: true
+  when: headless_laptop_validate_gpu | bool
+
+- name: Check DRI device directory
+  ansible.builtin.stat:
+    path: /dev/dri
+  register: headless_laptop_dri_dir
+  when: headless_laptop_validate_gpu | bool
+
+- name: Assert DRI device directory exists
+  ansible.builtin.assert:
+    that:
+      - headless_laptop_dri_dir.stat.isdir | default(false)
+    fail_msg: "AMD GPU validation is enabled, but /dev/dri is missing."
+    quiet: true
+  when: headless_laptop_validate_gpu | bool
+
+- name: Validate Vulkan can inspect default GPU
+  ansible.builtin.command: vulkaninfo --summary
+  changed_when: false
+  when:
+    - headless_laptop_validate_gpu | bool
+    - not ansible_check_mode
+
+- name: Validate Vulkan can inspect DRI_PRIME GPU
+  ansible.builtin.command: vulkaninfo --summary
+  changed_when: false
+  environment:
+    DRI_PRIME: "1"
+  when:
+    - headless_laptop_validate_gpu | bool
+    - headless_laptop_validate_dri_prime | bool
+    - not ansible_check_mode

--- a/ansible/roles/headless_laptop/tasks/asus_quiet_fan_policy.yml
+++ b/ansible/roles/headless_laptop/tasks/asus_quiet_fan_policy.yml
@@ -1,0 +1,80 @@
+---
+- name: Validate ASUS quiet fan percentage
+  ansible.builtin.assert:
+    that:
+      - headless_laptop_asus_quiet_fan_percent | int >= 0
+      - headless_laptop_asus_quiet_fan_percent | int <= 100
+    fail_msg: "headless_laptop_asus_quiet_fan_percent must be between 0 and 100"
+    quiet: true
+
+- name: Check ASUS quiet fan policy sysfs support
+  ansible.builtin.shell: |
+    set -eu
+
+    [ -r /sys/firmware/acpi/platform_profile ] || exit 1
+
+    for hwmon in /sys/class/hwmon/hwmon*; do
+      [ -r "$hwmon/name" ] || continue
+      if [ "$(cat "$hwmon/name")" = "asus_custom_fan_curve" ]; then
+        printf "%s\n" "$hwmon"
+        exit 0
+      fi
+    done
+
+    exit 1
+  args:
+    executable: /bin/sh
+  register: headless_laptop_asus_quiet_fan_sysfs
+  changed_when: false
+  failed_when: false
+  check_mode: false
+
+- name: Report missing ASUS quiet fan policy support
+  ansible.builtin.debug:
+    msg: >-
+      ASUS quiet fan policy is enabled, but this host does not expose both
+      /sys/firmware/acpi/platform_profile and an asus_custom_fan_curve hwmon
+      device. Skipping fan policy installation.
+  when: headless_laptop_asus_quiet_fan_sysfs.rc != 0
+
+- name: Install ASUS quiet fan policy
+  when: headless_laptop_asus_quiet_fan_sysfs.rc == 0
+  block:
+    - name: Install ASUS quiet fan policy helper
+      ansible.builtin.template:
+        src: asus-quiet-fan-policy.j2
+        dest: /usr/local/sbin/asus-quiet-fan-policy
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Configure ASUS quiet fan policy service
+      ansible.builtin.template:
+        src: asus-quiet-fan-policy.service.j2
+        dest: /etc/systemd/system/asus-quiet-fan-policy.service
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Configure ASUS quiet fan policy timer
+      ansible.builtin.template:
+        src: asus-quiet-fan-policy.timer.j2
+        dest: /etc/systemd/system/asus-quiet-fan-policy.timer
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Enable ASUS quiet fan policy timer
+      ansible.builtin.systemd:
+        name: asus-quiet-fan-policy.timer
+        enabled: true
+        state: started
+        daemon_reload: true
+      when: not ansible_check_mode
+
+    - name: Apply ASUS quiet fan policy
+      ansible.builtin.systemd:
+        name: asus-quiet-fan-policy.service
+        state: started
+      changed_when: false
+      when: not ansible_check_mode

--- a/ansible/roles/headless_laptop/tasks/battery_charge_limit.yml
+++ b/ansible/roles/headless_laptop/tasks/battery_charge_limit.yml
@@ -1,0 +1,51 @@
+---
+- name: Validate battery charge limit
+  ansible.builtin.assert:
+    that:
+      - headless_laptop_battery_charge_limit | int >= 1
+      - headless_laptop_battery_charge_limit | int <= 100
+    fail_msg: "headless_laptop_battery_charge_limit must be between 1 and 100"
+    quiet: true
+
+- name: Install battery charge limit helper
+  ansible.builtin.copy:
+    dest: /usr/local/sbin/set-battery-charge-limit
+    owner: root
+    group: root
+    mode: "0755"
+    content: |
+      #!/bin/sh
+      set -eu
+
+      limit="$1"
+
+      for threshold in /sys/class/power_supply/BAT*/charge_control_end_threshold; do
+        [ -e "$threshold" ] || continue
+        printf "%s\n" "$limit" > "$threshold"
+      done
+
+- name: Configure battery charge limit service
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/battery-charge-limit.service
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=Set battery charge limit
+      ConditionPathExistsGlob=/sys/class/power_supply/BAT*/charge_control_end_threshold
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/sbin/set-battery-charge-limit {{ headless_laptop_battery_charge_limit | int }}
+
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Enable and apply battery charge limit
+  ansible.builtin.systemd:
+    name: battery-charge-limit.service
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: not ansible_check_mode

--- a/ansible/roles/headless_laptop/tasks/bootloader.yml
+++ b/ansible/roles/headless_laptop/tasks/bootloader.yml
@@ -1,0 +1,11 @@
+---
+- name: Configure headless laptop GRUB kernel parameters
+  ansible.builtin.copy:
+    dest: "{{ headless_laptop_grub_cmdline_dropin_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT {{ headless_laptop_grub_cmdline_linux_default | join(' ') }}"
+  notify: Update grub
+  when: headless_laptop_grub_cmdline_linux_default | length > 0

--- a/ansible/roles/headless_laptop/tasks/bootloader.yml
+++ b/ansible/roles/headless_laptop/tasks/bootloader.yml
@@ -1,4 +1,11 @@
 ---
+- name: Remove legacy headless laptop GRUB drop-ins
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: "{{ headless_laptop_grub_cmdline_legacy_dropins }}"
+  notify: Update grub
+
 - name: Configure headless laptop GRUB kernel parameters
   ansible.builtin.copy:
     dest: "{{ headless_laptop_grub_cmdline_dropin_path }}"
@@ -6,6 +13,14 @@
     group: root
     mode: "0644"
     content: |
-      GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT {{ headless_laptop_grub_cmdline_linux_default | join(' ') }}"
+      headless_laptop_cmdline=""
+      for token in $GRUB_CMDLINE_LINUX_DEFAULT; do
+        case "$token" in
+          crashkernel=*) ;;
+          *) headless_laptop_cmdline="${headless_laptop_cmdline:+$headless_laptop_cmdline }$token" ;;
+        esac
+      done
+      GRUB_CMDLINE_LINUX_DEFAULT="$headless_laptop_cmdline {{ headless_laptop_grub_cmdline_linux_default | join(' ') }}"
+      unset headless_laptop_cmdline token
   notify: Update grub
   when: headless_laptop_grub_cmdline_linux_default | length > 0

--- a/ansible/roles/headless_laptop/tasks/logind.yml
+++ b/ansible/roles/headless_laptop/tasks/logind.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure systemd-logind override directory exists
+  ansible.builtin.file:
+    path: "{{ headless_laptop_logind_conf_path | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Configure systemd-logind for headless laptop use
+  ansible.builtin.copy:
+    dest: "{{ headless_laptop_logind_conf_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # Managed by Ansible. Do not edit manually.
+      [Login]
+      {% for key, value in headless_laptop_logind_settings.items() %}
+      {{ key }}={{ value }}
+      {% endfor %}
+  notify: Restart systemd-logind

--- a/ansible/roles/headless_laptop/tasks/main.yml
+++ b/ansible/roles/headless_laptop/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure headless laptop supports this OS family
+  ansible.builtin.assert:
+    that:
+      - ansible_os_family == 'Debian'
+    fail_msg: "headless_laptop currently supports Debian/Ubuntu hosts only"
+    quiet: true
+
+- name: Configure lid and idle behavior
+  ansible.builtin.include_tasks: logind.yml
+
+- name: Disable sleep states
+  ansible.builtin.include_tasks: sleep.yml
+
+- name: Install headless laptop packages
+  ansible.builtin.include_tasks: packages.yml
+
+- name: Configure power profile
+  ansible.builtin.include_tasks: power_profile.yml
+
+- name: Configure AMD GPU userspace
+  ansible.builtin.include_tasks: amd_gpu.yml

--- a/ansible/roles/headless_laptop/tasks/main.yml
+++ b/ansible/roles/headless_laptop/tasks/main.yml
@@ -18,5 +18,8 @@
 - name: Configure power profile
   ansible.builtin.include_tasks: power_profile.yml
 
+- name: Configure battery charge limit
+  ansible.builtin.include_tasks: battery_charge_limit.yml
+
 - name: Configure AMD GPU userspace
   ansible.builtin.include_tasks: amd_gpu.yml

--- a/ansible/roles/headless_laptop/tasks/main.yml
+++ b/ansible/roles/headless_laptop/tasks/main.yml
@@ -12,6 +12,9 @@
 - name: Disable sleep states
   ansible.builtin.include_tasks: sleep.yml
 
+- name: Configure bootloader settings
+  ansible.builtin.include_tasks: bootloader.yml
+
 - name: Install headless laptop packages
   ansible.builtin.include_tasks: packages.yml
 

--- a/ansible/roles/headless_laptop/tasks/main.yml
+++ b/ansible/roles/headless_laptop/tasks/main.yml
@@ -21,6 +21,10 @@
 - name: Configure power profile
   ansible.builtin.include_tasks: power_profile.yml
 
+- name: Configure ASUS quiet fan policy
+  ansible.builtin.include_tasks: asus_quiet_fan_policy.yml
+  when: headless_laptop_asus_quiet_fan_policy_enabled | bool
+
 - name: Configure battery charge limit
   ansible.builtin.include_tasks: battery_charge_limit.yml
 

--- a/ansible/roles/headless_laptop/tasks/packages.yml
+++ b/ansible/roles/headless_laptop/tasks/packages.yml
@@ -1,0 +1,8 @@
+---
+- name: Install headless laptop packages
+  ansible.builtin.apt:
+    name: "{{ headless_laptop_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: headless_laptop_packages | length > 0

--- a/ansible/roles/headless_laptop/tasks/packages.yml
+++ b/ansible/roles/headless_laptop/tasks/packages.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install headless laptop packages
   ansible.builtin.apt:
-    name: "{{ headless_laptop_packages }}"
+    name: "{{ (headless_laptop_packages + headless_laptop_extra_packages) | unique }}"
     state: present
     update_cache: true
     cache_valid_time: 3600
-  when: headless_laptop_packages | length > 0
+  when: (headless_laptop_packages + headless_laptop_extra_packages) | length > 0

--- a/ansible/roles/headless_laptop/tasks/power_profile.yml
+++ b/ansible/roles/headless_laptop/tasks/power_profile.yml
@@ -1,0 +1,20 @@
+---
+- name: Enable power-profiles-daemon service
+  ansible.builtin.systemd:
+    name: power-profiles-daemon
+    enabled: true
+    state: started
+  when: not ansible_check_mode
+
+- name: Check current power profile
+  ansible.builtin.command: powerprofilesctl get
+  register: headless_laptop_current_power_profile
+  changed_when: false
+  when: not ansible_check_mode
+
+- name: Set active power profile
+  ansible.builtin.command: "powerprofilesctl set {{ headless_laptop_power_profile }}"
+  changed_when: true
+  when:
+    - not ansible_check_mode
+    - headless_laptop_current_power_profile.stdout != headless_laptop_power_profile

--- a/ansible/roles/headless_laptop/tasks/sleep.yml
+++ b/ansible/roles/headless_laptop/tasks/sleep.yml
@@ -1,0 +1,14 @@
+---
+- name: Mask sleep-related systemd targets
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    masked: true
+  loop: "{{ headless_laptop_sleep_targets }}"
+  when: headless_laptop_mask_sleep_targets | bool
+
+- name: Unmask sleep-related systemd targets when sleep masking is disabled
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    masked: false
+  loop: "{{ headless_laptop_sleep_targets }}"
+  when: not headless_laptop_mask_sleep_targets | bool

--- a/ansible/roles/headless_laptop/templates/asus-quiet-fan-policy.j2
+++ b/ansible/roles/headless_laptop/templates/asus-quiet-fan-policy.j2
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+PROFILE_FILE=/sys/firmware/acpi/platform_profile
+QUIET_PROFILE="{{ headless_laptop_asus_quiet_fan_platform_profile }}"
+PERCENT={{ headless_laptop_asus_quiet_fan_percent | int }}
+PWM_VALUE=$(((PERCENT * 255 + 50) / 100))
+
+find_curve_dir() {
+  for hwmon in /sys/class/hwmon/hwmon*; do
+    [ -r "$hwmon/name" ] || continue
+    if [ "$(cat "$hwmon/name")" = "asus_custom_fan_curve" ]; then
+      printf "%s\n" "$hwmon"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+[ -r "$PROFILE_FILE" ] || exit 0
+read -r profile < "$PROFILE_FILE"
+
+curve_dir=$(find_curve_dir || true)
+[ -n "$curve_dir" ] || exit 0
+
+if [ "$profile" = "$QUIET_PROFILE" ]; then
+  for fan in 1 2; do
+    set -- 20 30 40 50 60 70 80 98
+    point=1
+
+    for temp in "$@"; do
+      printf "%s" "$temp" > "$curve_dir/pwm${fan}_auto_point${point}_temp"
+      point=$((point + 1))
+    done
+
+    for point in 6 7 8 5 4 3 2 1; do
+      printf "%s" "$PWM_VALUE" > "$curve_dir/pwm${fan}_auto_point${point}_pwm"
+    done
+
+    printf "%s" 1 > "$curve_dir/pwm${fan}_enable"
+  done
+else
+  for fan in 1 2; do
+    printf "%s" 2 > "$curve_dir/pwm${fan}_enable"
+  done
+fi

--- a/ansible/roles/headless_laptop/templates/asus-quiet-fan-policy.service.j2
+++ b/ansible/roles/headless_laptop/templates/asus-quiet-fan-policy.service.j2
@@ -1,0 +1,7 @@
+[Unit]
+Description=Apply ASUS quiet fan policy
+ConditionPathExists=/sys/firmware/acpi/platform_profile
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/asus-quiet-fan-policy

--- a/ansible/roles/headless_laptop/templates/asus-quiet-fan-policy.timer.j2
+++ b/ansible/roles/headless_laptop/templates/asus-quiet-fan-policy.timer.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Reapply ASUS quiet fan policy after profile changes
+ConditionPathExists=/sys/firmware/acpi/platform_profile
+
+[Timer]
+OnBootSec={{ headless_laptop_asus_quiet_fan_policy_interval }}
+OnUnitActiveSec={{ headless_laptop_asus_quiet_fan_policy_interval }}
+AccuracySec=1s
+Unit=asus-quiet-fan-policy.service
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/ssh_hardening/tasks/ssh.yml
+++ b/ansible/roles/ssh_hardening/tasks/ssh.yml
@@ -43,12 +43,12 @@
     mode: "0755"
   when: ssh_hardening_user_effective | lower != 'root'
 
-- name: Ensure authorized SSH keys are present
+- name: Ensure authorized SSH keys are authoritative
   ansible.posix.authorized_key:
     user: "{{ ssh_hardening_user_effective }}"
     state: present
-    key: "{{ item }}"
-  loop: "{{ ssh_hardening_authorized_keys_effective }}"
+    key: "{{ ssh_hardening_authorized_keys_effective | join('\n') }}"
+    exclusive: true
   when: ssh_hardening_authorized_keys_effective | length > 0
 
 - name: Ensure hush login file exists

--- a/ansible/roles/swapfile/defaults/main.yml
+++ b/ansible/roles/swapfile/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+swapfile_enabled: false
+swapfile_path: /swapfile
+swapfile_size: 16G
+swapfile_size_bytes: 17179869184
+swapfile_swappiness: 10

--- a/ansible/roles/swapfile/tasks/main.yml
+++ b/ansible/roles/swapfile/tasks/main.yml
@@ -1,0 +1,148 @@
+---
+- name: Check if swapfile exists
+  ansible.builtin.stat:
+    path: "{{ swapfile_path }}"
+  register: swapfile_stat
+  when: swapfile_enabled | bool
+
+- name: Detect swapfile filesystem
+  ansible.builtin.command:
+    argv:
+      - findmnt
+      - --noheadings
+      - --output
+      - FSTYPE
+      - --target
+      - "{{ swapfile_path | dirname }}"
+  register: swapfile_findmnt
+  changed_when: false
+  check_mode: false
+  when: swapfile_enabled | bool
+
+- name: Check swapfile attributes
+  ansible.builtin.command:
+    argv:
+      - lsattr
+      - "{{ swapfile_path }}"
+  register: swapfile_attributes
+  changed_when: false
+  check_mode: false
+  when:
+    - swapfile_enabled | bool
+    - swapfile_stat.stat.exists
+
+- name: Determine if swapfile needs recreation
+  ansible.builtin.set_fact:
+    swapfile_recreate: >-
+      {{
+        not swapfile_stat.stat.exists or
+        swapfile_stat.stat.size | int != swapfile_size_bytes | int or
+        (swapfile_findmnt.stdout | trim == 'btrfs' and 'C' not in swapfile_attr_flags)
+      }}
+    swapfile_fstype: "{{ swapfile_findmnt.stdout | trim }}"
+  vars:
+    swapfile_attr_flags: >-
+      {{ swapfile_attributes.stdout.split()[0]
+         if swapfile_attributes.stdout is defined else '' }}
+  when: swapfile_enabled | bool
+
+- name: Remove invalid swapfile
+  when:
+    - swapfile_enabled | bool
+    - swapfile_recreate
+    - not ansible_check_mode
+  block:
+    - name: Disable swapfile
+      ansible.builtin.command:
+        argv:
+          - swapoff
+          - "{{ swapfile_path }}"
+      failed_when: false
+      changed_when: false
+
+    - name: Remove swapfile
+      ansible.builtin.file:
+        path: "{{ swapfile_path }}"
+        state: absent
+
+- name: Create swapfile
+  when:
+    - swapfile_enabled | bool
+    - swapfile_recreate
+    - not ansible_check_mode
+  block:
+    - name: Create empty swapfile
+      ansible.builtin.file:
+        path: "{{ swapfile_path }}"
+        state: touch
+        owner: root
+        group: root
+        mode: "0600"
+
+    - name: Set BTRFS NoCOW attribute
+      ansible.builtin.command:
+        argv:
+          - chattr
+          - +C
+          - "{{ swapfile_path }}"
+      changed_when: false
+      when: swapfile_fstype == 'btrfs'
+
+    - name: Allocate swapfile
+      ansible.builtin.command:
+        argv:
+          - fallocate
+          - -l
+          - "{{ swapfile_size }}"
+          - "{{ swapfile_path }}"
+      changed_when: true
+
+    - name: Format swapfile
+      ansible.builtin.command:
+        argv:
+          - mkswap
+          - "{{ swapfile_path }}"
+      changed_when: true
+
+- name: Check active swap devices
+  ansible.builtin.command:
+    argv:
+      - swapon
+      - --show=NAME
+      - --noheadings
+  register: swapfile_active_devices
+  changed_when: false
+  check_mode: false
+  when: swapfile_enabled | bool
+
+- name: Enable swapfile
+  ansible.builtin.command:
+    argv:
+      - swapon
+      - "{{ swapfile_path }}"
+  changed_when: true
+  when:
+    - swapfile_enabled | bool
+    - not ansible_check_mode
+    - swapfile_path not in swapfile_active_devices.stdout_lines
+
+- name: Ensure swapfile persists
+  ansible.posix.mount:
+    path: none
+    src: "{{ swapfile_path }}"
+    fstype: swap
+    opts: sw
+    state: present
+  when: swapfile_enabled | bool
+
+- name: Configure vm.swappiness
+  ansible.posix.sysctl:
+    name: vm.swappiness
+    value: "{{ swapfile_swappiness }}"
+    sysctl_file: /etc/sysctl.d/99-swappiness.conf
+    sysctl_set: true
+    reload: true
+    state: present
+  when:
+    - swapfile_enabled | bool
+    - not ansible_check_mode

--- a/kubernetes/infrastructure/automation/renovate/configmap.yaml
+++ b/kubernetes/infrastructure/automation/renovate/configmap.yaml
@@ -8,6 +8,17 @@ data:
     {
       "$schema": "https://docs.renovatebot.com/renovate-schema.json",
       "repositories": ["nreymundo/home-lab-iac"],
+      "hostRules": [
+        {
+          "description": "Throttle Harbor proxy-cache lookups to avoid upstream registry rate limits",
+          "matchHost": "harbor.lan.${CLUSTER_DOMAIN}",
+          "concurrentRequestLimit": 1,
+          "maxRequestsPerSecond": 1,
+          "maxRetryAfter": 180,
+          "timeout": 180000,
+          "abortOnError": false
+        }
+      ],
       "registryAliases": {
         "docker.io": "harbor.lan.${CLUSTER_DOMAIN}/dockerhub",
         "index.docker.io": "harbor.lan.${CLUSTER_DOMAIN}/dockerhub",

--- a/kubernetes/infrastructure/automation/renovate/configmap.yaml
+++ b/kubernetes/infrastructure/automation/renovate/configmap.yaml
@@ -8,17 +8,6 @@ data:
     {
       "$schema": "https://docs.renovatebot.com/renovate-schema.json",
       "repositories": ["nreymundo/home-lab-iac"],
-      "hostRules": [
-        {
-          "description": "Throttle Harbor proxy-cache lookups to avoid upstream registry rate limits",
-          "matchHost": "harbor.lan.${CLUSTER_DOMAIN}",
-          "concurrentRequestLimit": 1,
-          "maxRequestsPerSecond": 1,
-          "maxRetryAfter": 180,
-          "timeout": 180000,
-          "abortOnError": false
-        }
-      ],
       "registryAliases": {
         "docker.io": "harbor.lan.${CLUSTER_DOMAIN}/dockerhub",
         "index.docker.io": "harbor.lan.${CLUSTER_DOMAIN}/dockerhub",

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
   "timezone": "UTC",
   "labels": ["dependencies", "renovate"],
   "commitMessagePrefix": "chore(deps):",
-  "rebaseWhen": "conflicted",
   "ignorePaths": ["kubernetes/clusters/production/flux-system/**"],
 
   "separateMajorMinor": true,
@@ -16,7 +15,7 @@
     "enabled": true,
     "automerge": true,
     "automergeType": "pr",
-    "automergeSchedule": ["at any time"]
+    "automergeSchedule": ["on Sunday after 9pm"]
   },
 
   "packageRules": [
@@ -48,7 +47,7 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
       "automergeType": "pr",
-      "automergeSchedule": ["at any time"]
+      "automergeSchedule": ["on Sunday after 9pm"]
     },
     {
       "description": "Kubernetes major updates require manual review",
@@ -69,7 +68,7 @@
       "automergeSchedule": ["at any time"]
     },
     {
-      "description": "Kubernetes 0.x updates auto-merge after stability checks",
+      "description": "Kubernetes 0.x updates follow scheduled auto-merge",
       "matchPaths": ["kubernetes/**"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "matchCurrentVersion": "/^0/",
@@ -77,7 +76,7 @@
       "automerge": true,
       "platformAutomerge": false,
       "automergeType": "pr",
-      "automergeSchedule": ["at any time"]
+      "automergeSchedule": ["on Sunday after 9pm"]
     },
     {
       "description": "Group Observability Stack",

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "timezone": "UTC",
   "labels": ["dependencies", "renovate"],
   "commitMessagePrefix": "chore(deps):",
+  "rebaseWhen": "conflicted",
   "ignorePaths": ["kubernetes/clusters/production/flux-system/**"],
 
   "separateMajorMinor": true,
@@ -15,7 +16,7 @@
     "enabled": true,
     "automerge": true,
     "automergeType": "pr",
-    "automergeSchedule": ["on Sunday after 9pm"]
+    "automergeSchedule": ["at any time"]
   },
 
   "packageRules": [
@@ -47,7 +48,7 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
       "automergeType": "pr",
-      "automergeSchedule": ["on Sunday after 9pm"]
+      "automergeSchedule": ["at any time"]
     },
     {
       "description": "Kubernetes major updates require manual review",
@@ -68,7 +69,7 @@
       "automergeSchedule": ["at any time"]
     },
     {
-      "description": "Kubernetes 0.x updates follow scheduled auto-merge",
+      "description": "Kubernetes 0.x updates auto-merge after stability checks",
       "matchPaths": ["kubernetes/**"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "matchCurrentVersion": "/^0/",
@@ -76,7 +77,7 @@
       "automerge": true,
       "platformAutomerge": false,
       "automergeType": "pr",
-      "automergeSchedule": ["on Sunday after 9pm"]
+      "automergeSchedule": ["at any time"]
     },
     {
       "description": "Group Observability Stack",


### PR DESCRIPTION
## Summary
- add g14-2022 to bare-metal inventory as a headless laptop host
- add a headless_laptops playbook and g14-2022 host vars
- add headless_laptop role for lid/sleep behavior, power profile, AMD GPU userspace, fstrim, and unattended upgrades
- replace dev-vm SSH key with dev-laptop key

## Validation
- ansible-playbook -i inventories/baremetal.yml playbooks/headless_laptops.yml --syntax-check
- ansible-lint playbooks/headless_laptops.yml roles/headless_laptop roles/common roles/ssh_hardening
- ansible-playbook -i inventories/baremetal.yml playbooks/headless_laptops.yml --limit g14-2022