### PR TITLE
fix(renovate): reduce registry and automerge failures

### DIFF
--- a/kubernetes/infrastructure/automation/renovate/configmap.yaml
+++ b/kubernetes/infrastructure/automation/renovate/configmap.yaml
@@ -8,6 +8,17 @@ data:
     {
       "$schema": "https://docs.renovatebot.com/renovate-schema.json",
       "repositories": ["nreymundo/home-lab-iac"],
+      "hostRules": [
+        {
+          "description": "Throttle Harbor proxy-cache lookups to avoid upstream registry rate limits",
+          "matchHost": "harbor.lan.${CLUSTER_DOMAIN}",
+          "concurrentRequestLimit": 1,
+          "maxRequestsPerSecond": 1,
+          "maxRetryAfter": 180,
+          "timeout": 180000,
+          "abortOnError": false
+        }
+      ],
       "registryAliases": {
         "docker.io": "harbor.lan.${CLUSTER_DOMAIN}/dockerhub",
         "index.docker.io": "harbor.lan.${CLUSTER_DOMAIN}/dockerhub",

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
   "timezone": "UTC",
   "labels": ["dependencies", "renovate"],
   "commitMessagePrefix": "chore(deps):",
-  "rebaseWhen": "conflicted",
   "ignorePaths": ["kubernetes/clusters/production/flux-system/**"],
 
   "separateMajorMinor": true,

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "timezone": "UTC",
   "labels": ["dependencies", "renovate"],
   "commitMessagePrefix": "chore(deps):",
+  "rebaseWhen": "conflicted",
   "ignorePaths": ["kubernetes/clusters/production/flux-system/**"],
 
   "separateMajorMinor": true,
@@ -15,7 +16,7 @@
     "enabled": true,
     "automerge": true,
     "automergeType": "pr",
-    "automergeSchedule": ["on Sunday after 9pm"]
+    "automergeSchedule": ["at any time"]
   },
 
   "packageRules": [
@@ -47,7 +48,7 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
       "automergeType": "pr",
-      "automergeSchedule": ["on Sunday after 9pm"]
+      "automergeSchedule": ["at any time"]
     },
     {
       "description": "Kubernetes major updates require manual review",
@@ -68,7 +69,7 @@
       "automergeSchedule": ["at any time"]
     },
     {
-      "description": "Kubernetes 0.x updates follow scheduled auto-merge",
+      "description": "Kubernetes 0.x updates auto-merge after stability checks",
       "matchPaths": ["kubernetes/**"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "matchCurrentVersion": "/^0/",
@@ -76,7 +77,7 @@
       "automerge": true,
       "platformAutomerge": false,
       "automergeType": "pr",
-      "automergeSchedule": ["on Sunday after 9pm"]
+      "automergeSchedule": ["at any time"]
     },
     {
       "description": "Group Observability Stack",


### PR DESCRIPTION
## Summary
- throttle Renovate requests to Harbor proxy cache to reduce upstream registry rate-limit failures
- stop single Harbor lookup failures from aborting the whole Renovate run
- allow eligible automerge PRs to merge outside the old Sunday-only window and avoid unnecessary rebases

## Validation
- kubectl apply --dry-run=client -k kubernetes/infrastructure/automation/renovate