### PR TITLE
feat(kubernetes): add bambuddy deployment

### DIFF
--- a/kubernetes/apps/apps/utils/bambuddy/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/bambuddy/helmrelease.yaml
@@ -1,0 +1,78 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bambuddy
+  namespace: utils
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    controllers:
+      main:
+        strategy: Recreate
+        containers:
+          main:
+            image:
+              # renovate: datasource=docker depName=maziggy/bambuddy registryUrl=https://ghcr.io
+              repository: ghcr.io/maziggy/bambuddy
+              tag: 0.2.4.3
+            env:
+              TZ: Europe/Berlin
+              PUID: "1000"
+              PGID: "1000"
+              PORT: "8000"
+              VIRTUAL_PRINTER_PASV_ADDRESS: ${BAMBUDDY_LB_IP}
+            securityContext:
+              capabilities:
+                add:
+                  - NET_BIND_SERVICE
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: "2"
+                memory: 2Gi
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 8000
+    ingress:
+      main:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: bambuddy.lan.${CLUSTER_DOMAIN}
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Bambuddy
+          gethomepage.dev/description: Bambu Lab printer command center
+          gethomepage.dev/group: "Kubernetes"
+          gethomepage.dev/icon: bambulab.png
+        hosts:
+          - host: bambuddy.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+    persistence:
+      data:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: bambuddy-data
+        globalMounts:
+          - path: /app/data
+      logs:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: bambuddy-logs
+        globalMounts:
+          - path: /app/logs

--- a/kubernetes/apps/apps/utils/bambuddy/kustomization.yaml
+++ b/kubernetes/apps/apps/utils/bambuddy/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+  - ../../../../components/ingress/traefik-base
+  - ../../../../components/ingress/auth-guard
+resources:
+  - helmrelease.yaml
+  - service-virtual-printer.yaml

--- a/kubernetes/apps/apps/utils/bambuddy/service-virtual-printer.yaml
+++ b/kubernetes/apps/apps/utils/bambuddy/service-virtual-printer.yaml
@@ -1,0 +1,455 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bambuddy-virtual-printer
+  namespace: utils
+spec:
+  type: LoadBalancer
+  loadBalancerIP: ${BAMBUDDY_LB_IP}
+  loadBalancerSourceRanges:
+    - 192.168.0.0/16
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: bambuddy
+    app.kubernetes.io/name: bambuddy
+  ports:
+    - name: vp-bind-3000
+      port: 3000
+      targetPort: 3000
+      protocol: TCP
+    - name: vp-bind-3002
+      port: 3002
+      targetPort: 3002
+      protocol: TCP
+    - name: mqtt
+      port: 8883
+      targetPort: 8883
+      protocol: TCP
+    - name: ftps
+      port: 990
+      targetPort: 990
+      protocol: TCP
+    - name: tunnel
+      port: 6000
+      targetPort: 6000
+      protocol: TCP
+    - name: rtsp
+      port: 322
+      targetPort: 322
+      protocol: TCP
+    - name: vp-2024
+      port: 2024
+      targetPort: 2024
+      protocol: TCP
+    - name: vp-2025
+      port: 2025
+      targetPort: 2025
+      protocol: TCP
+    - name: vp-2026
+      port: 2026
+      targetPort: 2026
+      protocol: TCP
+    - name: p50000
+      port: 50000
+      targetPort: 50000
+      protocol: TCP
+    - name: p50001
+      port: 50001
+      targetPort: 50001
+      protocol: TCP
+    - name: p50002
+      port: 50002
+      targetPort: 50002
+      protocol: TCP
+    - name: p50003
+      port: 50003
+      targetPort: 50003
+      protocol: TCP
+    - name: p50004
+      port: 50004
+      targetPort: 50004
+      protocol: TCP
+    - name: p50005
+      port: 50005
+      targetPort: 50005
+      protocol: TCP
+    - name: p50006
+      port: 50006
+      targetPort: 50006
+      protocol: TCP
+    - name: p50007
+      port: 50007
+      targetPort: 50007
+      protocol: TCP
+    - name: p50008
+      port: 50008
+      targetPort: 50008
+      protocol: TCP
+    - name: p50009
+      port: 50009
+      targetPort: 50009
+      protocol: TCP
+    - name: p50010
+      port: 50010
+      targetPort: 50010
+      protocol: TCP
+    - name: p50011
+      port: 50011
+      targetPort: 50011
+      protocol: TCP
+    - name: p50012
+      port: 50012
+      targetPort: 50012
+      protocol: TCP
+    - name: p50013
+      port: 50013
+      targetPort: 50013
+      protocol: TCP
+    - name: p50014
+      port: 50014
+      targetPort: 50014
+      protocol: TCP
+    - name: p50015
+      port: 50015
+      targetPort: 50015
+      protocol: TCP
+    - name: p50016
+      port: 50016
+      targetPort: 50016
+      protocol: TCP
+    - name: p50017
+      port: 50017
+      targetPort: 50017
+      protocol: TCP
+    - name: p50018
+      port: 50018
+      targetPort: 50018
+      protocol: TCP
+    - name: p50019
+      port: 50019
+      targetPort: 50019
+      protocol: TCP
+    - name: p50020
+      port: 50020
+      targetPort: 50020
+      protocol: TCP
+    - name: p50021
+      port: 50021
+      targetPort: 50021
+      protocol: TCP
+    - name: p50022
+      port: 50022
+      targetPort: 50022
+      protocol: TCP
+    - name: p50023
+      port: 50023
+      targetPort: 50023
+      protocol: TCP
+    - name: p50024
+      port: 50024
+      targetPort: 50024
+      protocol: TCP
+    - name: p50025
+      port: 50025
+      targetPort: 50025
+      protocol: TCP
+    - name: p50026
+      port: 50026
+      targetPort: 50026
+      protocol: TCP
+    - name: p50027
+      port: 50027
+      targetPort: 50027
+      protocol: TCP
+    - name: p50028
+      port: 50028
+      targetPort: 50028
+      protocol: TCP
+    - name: p50029
+      port: 50029
+      targetPort: 50029
+      protocol: TCP
+    - name: p50030
+      port: 50030
+      targetPort: 50030
+      protocol: TCP
+    - name: p50031
+      port: 50031
+      targetPort: 50031
+      protocol: TCP
+    - name: p50032
+      port: 50032
+      targetPort: 50032
+      protocol: TCP
+    - name: p50033
+      port: 50033
+      targetPort: 50033
+      protocol: TCP
+    - name: p50034
+      port: 50034
+      targetPort: 50034
+      protocol: TCP
+    - name: p50035
+      port: 50035
+      targetPort: 50035
+      protocol: TCP
+    - name: p50036
+      port: 50036
+      targetPort: 50036
+      protocol: TCP
+    - name: p50037
+      port: 50037
+      targetPort: 50037
+      protocol: TCP
+    - name: p50038
+      port: 50038
+      targetPort: 50038
+      protocol: TCP
+    - name: p50039
+      port: 50039
+      targetPort: 50039
+      protocol: TCP
+    - name: p50040
+      port: 50040
+      targetPort: 50040
+      protocol: TCP
+    - name: p50041
+      port: 50041
+      targetPort: 50041
+      protocol: TCP
+    - name: p50042
+      port: 50042
+      targetPort: 50042
+      protocol: TCP
+    - name: p50043
+      port: 50043
+      targetPort: 50043
+      protocol: TCP
+    - name: p50044
+      port: 50044
+      targetPort: 50044
+      protocol: TCP
+    - name: p50045
+      port: 50045
+      targetPort: 50045
+      protocol: TCP
+    - name: p50046
+      port: 50046
+      targetPort: 50046
+      protocol: TCP
+    - name: p50047
+      port: 50047
+      targetPort: 50047
+      protocol: TCP
+    - name: p50048
+      port: 50048
+      targetPort: 50048
+      protocol: TCP
+    - name: p50049
+      port: 50049
+      targetPort: 50049
+      protocol: TCP
+    - name: p50050
+      port: 50050
+      targetPort: 50050
+      protocol: TCP
+    - name: p50051
+      port: 50051
+      targetPort: 50051
+      protocol: TCP
+    - name: p50052
+      port: 50052
+      targetPort: 50052
+      protocol: TCP
+    - name: p50053
+      port: 50053
+      targetPort: 50053
+      protocol: TCP
+    - name: p50054
+      port: 50054
+      targetPort: 50054
+      protocol: TCP
+    - name: p50055
+      port: 50055
+      targetPort: 50055
+      protocol: TCP
+    - name: p50056
+      port: 50056
+      targetPort: 50056
+      protocol: TCP
+    - name: p50057
+      port: 50057
+      targetPort: 50057
+      protocol: TCP
+    - name: p50058
+      port: 50058
+      targetPort: 50058
+      protocol: TCP
+    - name: p50059
+      port: 50059
+      targetPort: 50059
+      protocol: TCP
+    - name: p50060
+      port: 50060
+      targetPort: 50060
+      protocol: TCP
+    - name: p50061
+      port: 50061
+      targetPort: 50061
+      protocol: TCP
+    - name: p50062
+      port: 50062
+      targetPort: 50062
+      protocol: TCP
+    - name: p50063
+      port: 50063
+      targetPort: 50063
+      protocol: TCP
+    - name: p50064
+      port: 50064
+      targetPort: 50064
+      protocol: TCP
+    - name: p50065
+      port: 50065
+      targetPort: 50065
+      protocol: TCP
+    - name: p50066
+      port: 50066
+      targetPort: 50066
+      protocol: TCP
+    - name: p50067
+      port: 50067
+      targetPort: 50067
+      protocol: TCP
+    - name: p50068
+      port: 50068
+      targetPort: 50068
+      protocol: TCP
+    - name: p50069
+      port: 50069
+      targetPort: 50069
+      protocol: TCP
+    - name: p50070
+      port: 50070
+      targetPort: 50070
+      protocol: TCP
+    - name: p50071
+      port: 50071
+      targetPort: 50071
+      protocol: TCP
+    - name: p50072
+      port: 50072
+      targetPort: 50072
+      protocol: TCP
+    - name: p50073
+      port: 50073
+      targetPort: 50073
+      protocol: TCP
+    - name: p50074
+      port: 50074
+      targetPort: 50074
+      protocol: TCP
+    - name: p50075
+      port: 50075
+      targetPort: 50075
+      protocol: TCP
+    - name: p50076
+      port: 50076
+      targetPort: 50076
+      protocol: TCP
+    - name: p50077
+      port: 50077
+      targetPort: 50077
+      protocol: TCP
+    - name: p50078
+      port: 50078
+      targetPort: 50078
+      protocol: TCP
+    - name: p50079
+      port: 50079
+      targetPort: 50079
+      protocol: TCP
+    - name: p50080
+      port: 50080
+      targetPort: 50080
+      protocol: TCP
+    - name: p50081
+      port: 50081
+      targetPort: 50081
+      protocol: TCP
+    - name: p50082
+      port: 50082
+      targetPort: 50082
+      protocol: TCP
+    - name: p50083
+      port: 50083
+      targetPort: 50083
+      protocol: TCP
+    - name: p50084
+      port: 50084
+      targetPort: 50084
+      protocol: TCP
+    - name: p50085
+      port: 50085
+      targetPort: 50085
+      protocol: TCP
+    - name: p50086
+      port: 50086
+      targetPort: 50086
+      protocol: TCP
+    - name: p50087
+      port: 50087
+      targetPort: 50087
+      protocol: TCP
+    - name: p50088
+      port: 50088
+      targetPort: 50088
+      protocol: TCP
+    - name: p50089
+      port: 50089
+      targetPort: 50089
+      protocol: TCP
+    - name: p50090
+      port: 50090
+      targetPort: 50090
+      protocol: TCP
+    - name: p50091
+      port: 50091
+      targetPort: 50091
+      protocol: TCP
+    - name: p50092
+      port: 50092
+      targetPort: 50092
+      protocol: TCP
+    - name: p50093
+      port: 50093
+      targetPort: 50093
+      protocol: TCP
+    - name: p50094
+      port: 50094
+      targetPort: 50094
+      protocol: TCP
+    - name: p50095
+      port: 50095
+      targetPort: 50095
+      protocol: TCP
+    - name: p50096
+      port: 50096
+      targetPort: 50096
+      protocol: TCP
+    - name: p50097
+      port: 50097
+      targetPort: 50097
+      protocol: TCP
+    - name: p50098
+      port: 50098
+      targetPort: 50098
+      protocol: TCP
+    - name: p50099
+      port: 50099
+      targetPort: 50099
+      protocol: TCP
+    - name: p50100
+      port: 50100
+      targetPort: 50100
+      protocol: TCP

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../apps/external-observability/omada-exporter
   - ../apps/automation/n8n
   - ../apps/utils/homepage
+  - ../apps/utils/bambuddy
   - ../apps/utils/it-tools
   - ../apps/utils/searxng
   - ../apps/nextcloud

--- a/kubernetes/apps/storage/pvcs/utils/bambuddy-data-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/utils/bambuddy-data-pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bambuddy-data
+  namespace: utils
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/apps/storage/pvcs/utils/bambuddy-logs-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/utils/bambuddy-logs-pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bambuddy-logs
+  namespace: utils
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/storage/pvcs/utils/kustomization.yaml
+++ b/kubernetes/apps/storage/pvcs/utils/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - bambuddy-data-pvc.yaml
+  - bambuddy-logs-pvc.yaml
   - discord-presence-alternate-pvc.yaml
   - discord-presence-main-pvc.yaml
   - searxng-pvc.yaml

--- a/kubernetes/clusters/production/identity/cluster-identity.sops.yaml
+++ b/kubernetes/clusters/production/identity/cluster-identity.sops.yaml
@@ -24,6 +24,7 @@ data:
     EMQX_IP: ENC[AES256_GCM,data:uXOYPolrEX48fPaS,iv:vRMwkWpp9Ejthw3noXHlVEeBb6cMRiY20nBVuvYbN2c=,tag:vd5Whosq5TwS954e+P4wQw==,type:str]
     ZIGBEE2MQTT_IP: ENC[AES256_GCM,data:xwgVzC9BYNv/FsyH,iv:SQPNlAFphd64faMyN8O+ANFt2XReZkzQwebgcitSmCA=,tag:IbAV/g5/scrWkgnocbZ4yQ==,type:str]
     HOME_ASSISTANT_IP: ENC[AES256_GCM,data:+RsDJNbK0AKCdfu2FQ==,iv:8mVVf4JOmdZ5azmppzzoHzMJsV+4mEWSdVbPaAYiFtE=,tag:yL8V+zc0sKkKQMpGalsvKQ==,type:str]
+    BAMBUDDY_LB_IP: ENC[AES256_GCM,data:SFRhT8EstVwgv7Oz1jc=,iv:ZkELPZXOmPcz/Bj2YLX0dNJdM1G7qsTXNKDZzl2ZIwM=,tag:EjETAU/gaI+msuz8qGAbFA==,type:str]
 sops:
     age:
         - enc: |
@@ -36,6 +37,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-24T01:16:05Z"
-    mac: ENC[AES256_GCM,data:C92X48C3+OZNN98xPBE28k15jT7jjdHkAghSaI7JYAAQz8NRS72mr+tvAXg3AmTaUoXMoNVXx9jqYeCZg4CVmNe/1Cnoio8t/sSqej8oQ50q3QCQRAii1TSJuEqxwZnk5K2fLYKK1qhxnpJ97QrPTKqq0xl6gm9nCsyICsxK9x0=,iv:z2TDvz4sXywSlipI9C3a/ucYySa63mCLuyZ9Fq2fGrU=,tag:+VDHFHrzriBZQm+UDrVH3w==,type:str]
+    lastmodified: "2026-05-28T20:08:01Z"
+    mac: ENC[AES256_GCM,data:v/I++sXLIKl9BBvRgfRQrKKs4HZnhtbSuhdEYYXf1RKxGGvLVaaovDb3xXRZ4300edm9W45xLiVTTNpjbCNeLr9R9B3e3xc9zNPpAc1SS2ASTLlv/c0mKrF0eTqLI07kMXUdEPp1YlGOV1+nkZKmy+q2ED1JlBWfJjBJJgtjbE4=,iv:cm/s9ZNt5qtjcwrO5wUiHxIDq1NaouVNqu3i8riSO5k=,tag:4YBhq2fGlut09Og4yws25g==,type:str]
     version: 3.13.1


### PR DESCRIPTION
## Summary
- add Bambuddy app-template deployment in the utils namespace
- expose the UI through Traefik and virtual-printer ports through MetalLB
- add Longhorn-backed data/log PVCs and encrypted BAMBUDDY_LB_IP

## Validation
- kubectl apply --dry-run=client -k kubernetes/apps/apps/utils/bambuddy
- kubectl apply --dry-run=server with substituted Bambuddy values
- kubectl apply --dry-run=server -k kubernetes/apps/storage/pvcs/utils
- kubectl apply --dry-run=client -k kubernetes/apps/production
- pre-commit hooks during commit