### PR TITLE
feat(kubernetes): add Z.AI LiteLLM provider

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -46,6 +46,14 @@ data:
           input_cost_per_token: 0.0
           output_cost_per_token: 0.0
 
+      - model_name: zai/*
+        model_info:
+          mode: chat
+        litellm_params:
+          model: zai/*
+          custom_llm_provider: zai
+          litellm_credential_name: zai
+
     credential_list:
       - credential_name: llama-swap
         credential_values:
@@ -59,6 +67,12 @@ data:
           api_key: os.environ/LITELLM_CREDENTIAL_OPENROUTER_API_KEY
         credential_info:
           custom_llm_provider: openrouter
+
+      - credential_name: zai
+        credential_values:
+          api_key: os.environ/LITELLM_CREDENTIAL_ZAI_API_KEY
+        credential_info:
+          custom_llm_provider: zai
 
     litellm_settings:
       callbacks:

--- a/kubernetes/apps/apps/ai/litellm/litellm-credentials.sops.yaml
+++ b/kubernetes/apps/apps/ai/litellm/litellm-credentials.sops.yaml
@@ -5,21 +5,22 @@ metadata:
     namespace: ai
 type: Opaque
 stringData:
-    LITELLM_CREDENTIAL_LLAMA_SWAP_API_BASE: ENC[AES256_GCM,data:AWtd0LPlq5rfrLGcIMzvMMjyPZ20nxfXaOpkRw==,iv:iKaYuZ698WqbQ/TTtjxVy8ni5RqRA3Q1h+6saUcpwTc=,tag:fv5wqdUHkBa0t4+iagNp9A==,type:str]
-    LITELLM_CREDENTIAL_LLAMA_SWAP_API_KEY: ENC[AES256_GCM,data:jjtyk3fcxXE5PovkCLh+ShGjw3XTOyAWI6VjCTWHnVbfzKdN5N4Lsg7sU0YmBzXonuwzf6xg30LETjgUmlLN7g==,iv:fQwpny3beNolx0gBa/FP20HszSGgacuPPdKwU7ov19g=,tag:D3k8GVnxYjINC4ZHYHcQiA==,type:str]
-    LITELLM_CREDENTIAL_OPENROUTER_API_KEY: ENC[AES256_GCM,data:7sHOFt3T6ZotFDyTVvcpfWFGz0ISlXHOMUxWPqTq8qeRzi7yUdygqwlM/ZQ6cyyIL3xzzDI8O8Pcl3irbSvv8HACDcTSIyevZQ==,iv:W0YVgMz0ExiM3o4+zH8IhB5N2gX+ZM2B9/4EfbsgZtA=,tag:oMxKA+i1m0jqRFxkz101Tw==,type:str]
+    LITELLM_CREDENTIAL_LLAMA_SWAP_API_BASE: ENC[AES256_GCM,data:VthU/z02FJjUUMWDo/sGZVf5SXkLM5k1wQKEKg==,iv:hiLzZ5K6LcYcH9QhmjCnhBVlRUZ0H4iX9KjzIUSHmoM=,tag:KnfYx+r8qm35vwGpei4W1A==,type:str]
+    LITELLM_CREDENTIAL_LLAMA_SWAP_API_KEY: ENC[AES256_GCM,data:Xy0AqV9tcvE+i0Is8WY17slmGyXdtW01sPA+8Wwla5101CvD4QbAuLI7K4iwwTF0B6MiHicCaHksNFNbUr/T+Q==,iv:4FqSzejgw76OhJ5s8kXsUZnQwS1xCgDlgxp8ODaJV/Q=,tag:AVUo3vZXZY2gpqML91IxhQ==,type:str]
+    LITELLM_CREDENTIAL_OPENROUTER_API_KEY: ENC[AES256_GCM,data:1w4scyFbApKpwOwmEenPOxWSvlxQe/CiJC6VYwkPlGZIK3ngOvpNbx/vmMyabavAlURhXrOAMIh/EjHvoZ3h44avS2TAFKeXkg==,iv:Ll9M2utNc6OdSdtjFvV/DJiZbIFDUDFXIR5VAex7afg=,tag:l310F3mBge6xQZBdIJvW3g==,type:str]
+    LITELLM_CREDENTIAL_ZAI_API_KEY: ENC[AES256_GCM,data:YxHRFNd5TbNHAJlmWso1Cz9mEMJhXe4GsG8YJr+Dcqd8fWS/iYiV3M1u/rw8r7UsPg==,iv:8mnwqlig9OPWr+VviPkd/vbrRznToEn5Nagq2iPLZtc=,tag:2XsKfO1o/iIM6YsTzX6g/w==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmNTBPbW51WGF0dURZNUF2
-            SGwwM1A2UzJjTU95eUZtSUZFUlFvSC9jZEVVCkNQUW1xUTBvZk9KZ2Fxc0kzdnpo
-            RGhwMldTbXg1eXJtSFErNCsxVkxJTDgKLS0tIDdUeDZINE9sTVd4UUtuSUVLcUdD
-            WkZWb0JqVHk5ZGFMciszTHN2N2dvclUKrQ6qCE2NTER4y33wGQWLOv1pzNkAzP4R
-            +nGaaJSZwUMdw728mPrba/rPO4ZAhMvryILJkAJz6InOUjWOD0CTAQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTR1h6aVNQcGtKNlFIc3pG
+            K05hdThBV0dvQUhrY2Jwb1gwd0l5a0VoWndrClg5R2ptUkFMYkhTTGVZcFJFU1Qr
+            V0dodnZ3ZkxsbDlBSkFwc2dVVUF3N1kKLS0tIHozdGZDUHJmcVdRZXJvM0tGNENI
+            SmFDUHpoRzgvZWxQR3ZKZHNXWEczRVUKbqtw3ePnOvlX9+nDSrxlEQXjPBckhyPW
+            Tmu1MMtvaXjtSh1riBA9Cc0YWWC5Oxm9Oywhvrzx43VmB6wnR3rpvw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-24T00:01:49Z"
-    mac: ENC[AES256_GCM,data:DaTJ77K+KQaPnao3XvvJQ7eUuzpAhIHlnTbtHifVVMTnhDCXmXtdSOD6QMUNjSOXqhW6p3rcI1Rfbgf2bGqnQN98Slfzuo8SKWBucoT9gxu3pDX0ohowlEU0dceozQTnYLIdL4GJsk9piYlPtIlqydsR99peH6xtcSj20ergsng=,iv:BjsTzp2kIA3D0yeKo3GDoC1QsuVd6IC0RhM1YJ2fjds=,tag:b937NrCvcP33hVnhv4mscQ==,type:str]
+    lastmodified: "2026-05-28T22:57:15Z"
+    mac: ENC[AES256_GCM,data:dB5BbCe/MrQEWiI9xUuaKUWzlRueWhdFcu2GXBTODcXccZa+otTG+dlhRAL9R8r2278GFU0osFXCsSbOK9caQBcVFYxnkuBot/LGjWT7E2o+kqWNlpa7a3I0Jw7t2nu9NAWi9pXkWP8w7jQwla05wkO0tC0rCKXpagLV1sRsTYU=,iv:pBMtzSTKYNG63QXL5VpPcU7dZUNLjYh1o+NnlAnvFaw=,tag:Jygg/OmCj0VIgtTwApjpPg==,type:str]
     version: 3.13.1


### PR DESCRIPTION
## Summary
- add a LiteLLM wildcard route for Z.AI models via `zai/*`
- wire the route to the encrypted `LITELLM_CREDENTIAL_ZAI_API_KEY` credential

## Validation
- `kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/litellm`
- `git diff --check`