### PR TITLE
fix(kubernetes): patch litellm chatgpt streaming

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -40,6 +40,7 @@ data:
         model_info:
           mode: responses
           max_input_tokens: 272000
+          supports_xhigh_reasoning_effort: true
         litellm_params:
           model: chatgpt/gpt-5.3-codex
           # Synthetic OpenAI API-equivalent Standard pricing, in USD/token.
@@ -50,6 +51,7 @@ data:
         model_info:
           mode: responses
           max_input_tokens: 272000
+          supports_xhigh_reasoning_effort: true
         litellm_params:
           model: chatgpt/gpt-5.3-codex-spark
           # Priced as gpt-5.3-codex; OpenAI does not list a separate Spark API rate.
@@ -186,6 +188,216 @@ data:
 
 
     proxy_handler_instance = CacheBypassHandler()
+
+  chatgpt_responses_streaming_patch.py: |
+    import json
+
+    import httpx
+    import litellm
+    from litellm._logging import verbose_logger
+    from litellm.llms.chatgpt.responses.transformation import (
+        ChatGPTResponsesAPIConfig,
+        record_output_item_chunk,
+        record_output_text_chunk,
+    )
+    from litellm.llms.custom_httpx.llm_http_handler import (
+        BaseLLMHTTPHandler,
+        get_async_httpx_client,
+    )
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+    from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+    from litellm.types.llms.openai import ResponsesAPIStreamEvents
+    from litellm.types.utils import CallTypes
+    from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
+
+
+    _original_async_response_api_handler = BaseLLMHTTPHandler.async_response_api_handler
+
+
+    class ChatGPTResponsesStreamingIterator(ResponsesAPIStreamingIterator):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._streamed_output_items = {}
+            self._text_only_output_items = {}
+
+        def _process_chunk(self, chunk):
+            if not chunk or chunk == "[DONE]":
+                return super()._process_chunk(chunk)
+
+            try:
+                parsed_chunk = json.loads(chunk)
+            except json.JSONDecodeError:
+                return super()._process_chunk(chunk)
+
+            if not isinstance(parsed_chunk, dict):
+                return super()._process_chunk(chunk)
+
+            event_type = parsed_chunk.get("type")
+            if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+                record_output_item_chunk(
+                    parsed_chunk=parsed_chunk,
+                    output_items=self._streamed_output_items,
+                )
+            elif event_type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE:
+                record_output_text_chunk(
+                    parsed_chunk=parsed_chunk,
+                    output_items=self._streamed_output_items,
+                    text_only_items=self._text_only_output_items,
+                )
+            elif event_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
+                response_payload = parsed_chunk.get("response")
+                if isinstance(response_payload, dict) and not response_payload.get("output"):
+                    merged_items = {**self._text_only_output_items}
+                    merged_items.update(self._streamed_output_items)
+                    if merged_items:
+                        parsed_chunk = dict(parsed_chunk)
+                        parsed_chunk["response"] = dict(response_payload)
+                        parsed_chunk["response"]["output"] = [
+                            item for _, item in sorted(merged_items.items())
+                        ]
+
+            return super()._process_chunk(json.dumps(parsed_chunk))
+
+
+    async def _chatgpt_streaming_response_api_handler(
+        self,
+        model,
+        input,
+        responses_api_provider_config,
+        response_api_optional_request_params,
+        custom_llm_provider,
+        litellm_params,
+        logging_obj,
+        extra_headers=None,
+        extra_body=None,
+        timeout=None,
+        client=None,
+        fake_stream=False,
+        litellm_metadata=None,
+        shared_session=None,
+    ):
+        stream = response_api_optional_request_params.get("stream", False)
+        if (
+            custom_llm_provider != "chatgpt"
+            or stream is not True
+            or not isinstance(responses_api_provider_config, ChatGPTResponsesAPIConfig)
+        ):
+            return await _original_async_response_api_handler(
+                self,
+                model=model,
+                input=input,
+                responses_api_provider_config=responses_api_provider_config,
+                response_api_optional_request_params=response_api_optional_request_params,
+                custom_llm_provider=custom_llm_provider,
+                litellm_params=litellm_params,
+                logging_obj=logging_obj,
+                extra_headers=extra_headers,
+                extra_body=extra_body,
+                timeout=timeout,
+                client=client,
+                fake_stream=fake_stream,
+                litellm_metadata=litellm_metadata,
+                shared_session=shared_session,
+            )
+
+        if client is None or not isinstance(client, AsyncHTTPHandler):
+            async_httpx_client = get_async_httpx_client(
+                llm_provider=litellm.LlmProviders(custom_llm_provider),
+                params={"ssl_verify": litellm_params.get("ssl_verify", None)},
+                shared_session=shared_session,
+            )
+        else:
+            async_httpx_client = client
+
+        headers = responses_api_provider_config.validate_environment(
+            headers=response_api_optional_request_params.get("extra_headers", {}) or {},
+            model=model,
+            litellm_params=litellm_params,
+        )
+        headers.setdefault("Accept", "text/event-stream")
+        if extra_headers:
+            headers.update(extra_headers)
+
+        api_base = responses_api_provider_config.get_complete_url(
+            api_base=litellm_params.api_base,
+            litellm_params=dict(litellm_params),
+        )
+        data = responses_api_provider_config.transform_responses_api_request(
+            model=model,
+            input=input,
+            response_api_optional_request_params=response_api_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        data = BaseResponsesAPIConfig.normalize_responses_api_request_dict(data)
+        data["stream"] = True
+        if extra_body:
+            data.update(extra_body)
+
+        request_context = {"input": input}
+        try:
+            request_context.update(response_api_optional_request_params)
+        except Exception:
+            pass
+        request_context["litellm_params"] = dict(litellm_params)
+
+        logging_obj.pre_call(
+            input=input,
+            api_key="",
+            additional_args={
+                "complete_input_dict": data,
+                "api_base": api_base,
+                "headers": headers,
+            },
+        )
+
+        try:
+            req = async_httpx_client.client.build_request(
+                "POST",
+                api_base,
+                headers=headers,
+                json=data,
+                timeout=timeout or float(response_api_optional_request_params.get("timeout", 0)),
+            )
+            response = await async_httpx_client.client.send(req, stream=True)
+            response.raise_for_status()
+        except Exception as exc:
+            raise self._handle_error(
+                e=exc,
+                provider_config=responses_api_provider_config,
+            )
+
+        verbose_logger.debug("Using local ChatGPT Responses streaming patch")
+        return ChatGPTResponsesStreamingIterator(
+            response=response,
+            model=model,
+            logging_obj=logging_obj,
+            responses_api_provider_config=responses_api_provider_config,
+            litellm_metadata=litellm_metadata,
+            custom_llm_provider=custom_llm_provider,
+            request_data=request_context,
+            call_type=CallTypes.responses.value,
+        )
+
+
+    def patch_chatgpt_responses_streaming():
+        if getattr(BaseLLMHTTPHandler.async_response_api_handler, "_chatgpt_streaming_patch", False):
+            return
+        _chatgpt_streaming_response_api_handler._chatgpt_streaming_patch = True
+        BaseLLMHTTPHandler.async_response_api_handler = _chatgpt_streaming_response_api_handler
+
+
+    def worker_startup_hook():
+        patch_chatgpt_responses_streaming()
+
+  litellm_startup.py: |
+    import chatgpt_responses_streaming_patch
+    import vllm_model_discovery
+
+
+    def worker_startup_hook():
+        vllm_model_discovery.worker_startup_hook()
+        chatgpt_responses_streaming_patch.worker_startup_hook()
 
   vllm_model_discovery.py: |
     import os

--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
             env:
               TZ: Europe/Berlin
               PYTHONPATH: /etc/litellm
-              LITELLM_WORKER_STARTUP_HOOKS: vllm_model_discovery:worker_startup_hook
+              LITELLM_WORKER_STARTUP_HOOKS: litellm_startup:worker_startup_hook
               STORE_MODEL_IN_DB: "True"
               CONFIG_FILE_PATH: /etc/litellm/config.yaml
               CHATGPT_TOKEN_DIR: /var/lib/litellm/chatgpt
@@ -216,4 +216,10 @@ spec:
                 readOnly: true
               - path: /etc/litellm/vllm_model_discovery.py
                 subPath: vllm_model_discovery.py
+                readOnly: true
+              - path: /etc/litellm/chatgpt_responses_streaming_patch.py
+                subPath: chatgpt_responses_streaming_patch.py
+                readOnly: true
+              - path: /etc/litellm/litellm_startup.py
+                subPath: litellm_startup.py
                 readOnly: true

--- a/renovate.json
+++ b/renovate.json
@@ -97,6 +97,15 @@
       "matchUpdateTypes": ["major"],
       "matchCurrentVersion": "/^0/",
       "automerge": false
+    },
+    {
+      "description": "LiteLLM image updates require manual review while local monkey patches are active",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["berriai/litellm"],
+      "matchPackageNames": ["berriai/litellm", "ghcr.io/berriai/litellm"],
+      "matchPaths": ["kubernetes/apps/apps/ai/litellm/helmrelease.yaml"],
+      "automerge": false,
+      "platformAutomerge": false
     }
   ],
 


### PR DESCRIPTION
## Summary
- add a LiteLLM startup monkey patch for chatgpt /v1/responses streaming output assembly
- mark ChatGPT Codex model aliases as supporting xhigh reasoning effort
- disable Renovate automerge for LiteLLM image updates while local patches are active

## Validation
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/litellm
- python -m json.tool renovate.json
- compiled embedded ConfigMap Python patches
- pre-commit run --files kubernetes/apps/apps/ai/litellm/configmap.yaml kubernetes/apps/apps/ai/litellm/helmrelease.yaml renovate.json