### PR TITLE
feat(kubernetes): add librechat deployment

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/configmap.yaml
+++ b/kubernetes/apps/apps/ai/librechat/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: librechat-config
+  namespace: ai
+data:
+  librechat.yaml: |
+    version: 1.3.5
+    cache: true
+
+    interface:
+      endpointsMenu: true
+      modelSelect: true
+      parameters: true
+
+    endpoints:
+      custom:
+        - name: LiteLLM
+          apiKey: "${LITELLM_API_KEY}"
+          baseURL: "http://litellm.ai.svc.cluster.local:4000/v1"
+          models:
+            fetch: true
+          modelDisplayLabel: LiteLLM

--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -1,0 +1,444 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: librechat
+  namespace: ai
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-permissions:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.36.1
+            command:
+              - /bin/sh
+              - -c
+              - mkdir -p /app/uploads /app/logs /app/client/public/images && chown -R 1000:1000 /app/uploads /app/logs /app/client/public/images
+            securityContext:
+              runAsUser: 0
+        containers:
+          main:
+            image:
+              # renovate: datasource=docker depName=danny-avila/librechat registryUrl=https://registry.librechat.ai
+              repository: registry.librechat.ai/danny-avila/librechat
+              tag: v0.8.6-rc1
+            env:
+              TZ: Europe/Berlin
+              HOST: 0.0.0.0
+              PORT: "3080"
+              NODE_ENV: production
+              CONFIG_PATH: /app/librechat.yaml
+              LOG_TO_FILE: "false"
+              DOMAIN_CLIENT: https://chat.lan.${CLUSTER_DOMAIN}
+              DOMAIN_SERVER: https://chat.lan.${CLUSTER_DOMAIN}
+              TRUST_PROXY: "1"
+              NO_INDEX: "true"
+              ENDPOINTS: custom
+              MONGO_URI: mongodb://librechat-mongodb:27017/LibreChat
+              SEARCH: "true"
+              MEILI_HOST: http://librechat-meilisearch:7700
+              MEILI_NO_ANALYTICS: "true"
+              RAG_API_URL: http://librechat-rag-api:8000
+              ALLOW_EMAIL_LOGIN: "false"
+              ALLOW_REGISTRATION: "false"
+              ALLOW_SOCIAL_LOGIN: "true"
+              ALLOW_SOCIAL_REGISTRATION: "true"
+              ALLOW_PASSWORD_RESET: "false"
+              OPENID_ISSUER: https://sso.${CLUSTER_DOMAIN}/application/o/librechat/
+              OPENID_CALLBACK_URL: /oauth/openid/callback
+              OPENID_SCOPE: openid profile email librechat
+              OPENID_BUTTON_LABEL: Authentik
+              OPENID_REQUIRED_ROLE: librechat-user,librechat-admin
+              OPENID_REQUIRED_ROLE_TOKEN_KIND: id
+              OPENID_REQUIRED_ROLE_PARAMETER_PATH: roles
+              OPENID_ADMIN_ROLE: librechat-admin
+              OPENID_ADMIN_ROLE_TOKEN_KIND: id
+              OPENID_ADMIN_ROLE_PARAMETER_PATH: roles
+              OPENID_USE_END_SESSION_ENDPOINT: "true"
+              OPENID_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: librechat-sso-secret
+                    key: CLIENT_ID
+              OPENID_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: librechat-sso-secret
+                    key: CLIENT_SECRET
+            envFrom:
+              - secretRef:
+                  name: librechat-secrets
+            ports:
+              - name: http
+                containerPort: 3080
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 3080
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 3080
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 3080
+                  failureThreshold: 60
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 250m
+                memory: 1Gi
+              limits:
+                cpu: 2
+                memory: 4Gi
+
+      mongodb:
+        containers:
+          mongodb:
+            image:
+              # renovate: datasource=docker depName=mongo registryUrl=https://docker.io
+              repository: docker.io/library/mongo
+              tag: 8.0.20
+            args:
+              - --noauth
+              - --bind_ip_all
+            env:
+              TZ: Europe/Berlin
+              MONGO_INITDB_DATABASE: LibreChat
+            ports:
+              - name: mongodb
+                containerPort: 27017
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - mongosh
+                      - --quiet
+                      - --eval
+                      - db.adminCommand('ping')
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - mongosh
+                      - --quiet
+                      - --eval
+                      - db.adminCommand('ping')
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 1
+                memory: 2Gi
+
+      meilisearch:
+        initContainers:
+          init-permissions:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.36.1
+            command:
+              - /bin/sh
+              - -c
+              - mkdir -p /meili_data && chown -R 1000:1000 /meili_data
+            securityContext:
+              runAsUser: 0
+        containers:
+          meilisearch:
+            image:
+              # renovate: datasource=docker depName=getmeili/meilisearch registryUrl=https://docker.io
+              repository: docker.io/getmeili/meilisearch
+              tag: v1.35.1
+            env:
+              TZ: Europe/Berlin
+              MEILI_ENV: production
+              MEILI_NO_ANALYTICS: "true"
+              MEILI_MASTER_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: librechat-secrets
+                    key: MEILI_MASTER_KEY
+            ports:
+              - name: http
+                containerPort: 7700
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 7700
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 7700
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 1
+                memory: 2Gi
+
+      vectordb:
+        containers:
+          vectordb:
+            image:
+              # renovate: datasource=docker depName=pgvector/pgvector registryUrl=https://docker.io
+              repository: docker.io/pgvector/pgvector
+              tag: 0.8.0-pg15-trixie
+            env:
+              TZ: Europe/Berlin
+              POSTGRES_DB: librechat-vectordb
+              POSTGRES_USER: librechat
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: librechat-vectordb-secrets
+                    key: POSTGRES_PASSWORD
+            ports:
+              - name: postgresql
+                containerPort: 5432
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - pg_isready
+                      - -U
+                      - librechat
+                      - -d
+                      - librechat-vectordb
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - pg_isready
+                      - -U
+                      - librechat
+                      - -d
+                      - librechat-vectordb
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 1
+                memory: 2Gi
+
+      rag-api:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          rag-api:
+            image:
+              # renovate: datasource=docker depName=danny-avila/librechat-rag-api-dev-lite registryUrl=https://registry.librechat.ai
+              repository: registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite
+              tag: latest
+            env:
+              TZ: Europe/Berlin
+              RAG_HOST: 0.0.0.0
+              RAG_PORT: "8000"
+              DB_HOST: librechat-vectordb
+              DB_PORT: "5432"
+              POSTGRES_DB: librechat-vectordb
+              POSTGRES_USER: librechat
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: librechat-vectordb-secrets
+                    key: POSTGRES_PASSWORD
+              EMBEDDINGS_PROVIDER: openai
+              EMBEDDINGS_MODEL: local/embedding
+              RAG_OPENAI_BASEURL: http://litellm.ai.svc.cluster.local:4000/v1
+              RAG_OPENAI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: librechat-secrets
+                    key: LITELLM_API_KEY
+              OPENAI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: librechat-secrets
+                    key: LITELLM_API_KEY
+            ports:
+              - name: http
+                containerPort: 8000
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 1
+                memory: 2Gi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 3080
+      mongodb:
+        controller: mongodb
+        ports:
+          mongodb:
+            port: 27017
+      meilisearch:
+        controller: meilisearch
+        ports:
+          http:
+            port: 7700
+      vectordb:
+        controller: vectordb
+        ports:
+          postgresql:
+            port: 5432
+      rag-api:
+        controller: rag-api
+        ports:
+          http:
+            port: 8000
+
+    ingress:
+      main:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: chat.lan.${CLUSTER_DOMAIN}
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: LibreChat
+          gethomepage.dev/description: AI chat interface
+          gethomepage.dev/group: "Kubernetes"
+          gethomepage.dev/icon: librechat.png
+          gethomepage.dev/href: https://chat.lan.${CLUSTER_DOMAIN}
+        hosts:
+          - host: chat.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+
+    persistence:
+      data:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: librechat-data
+        advancedMounts:
+          main:
+            init-permissions:
+              - path: /app/uploads
+                subPath: uploads
+              - path: /app/client/public/images
+                subPath: images
+            main:
+              - path: /app/uploads
+                subPath: uploads
+              - path: /app/client/public/images
+                subPath: images
+      config:
+        enabled: true
+        type: configMap
+        name: librechat-config
+        advancedMounts:
+          main:
+            main:
+              - path: /app/librechat.yaml
+                subPath: librechat.yaml
+                readOnly: true
+      mongodb-data:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: librechat-mongodb
+        advancedMounts:
+          mongodb:
+            mongodb:
+              - path: /data/db
+      meilisearch-data:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: librechat-meilisearch
+        advancedMounts:
+          meilisearch:
+            init-permissions:
+              - path: /meili_data
+            meilisearch:
+              - path: /meili_data
+      vectordb-data:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: librechat-vectordb
+        advancedMounts:
+          vectordb:
+            vectordb:
+              - path: /var/lib/postgresql/data

--- a/kubernetes/apps/apps/ai/librechat/kustomization.yaml
+++ b/kubernetes/apps/apps/ai/librechat/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+  - ../../../../components/ingress/traefik-base
+
+resources:
+  - configmap.yaml
+  - librechat-secrets.sops.yaml
+  - librechat-vectordb-secrets.sops.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/apps/ai/librechat/librechat-secrets.sops.yaml
+++ b/kubernetes/apps/apps/ai/librechat/librechat-secrets.sops.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: librechat-secrets
+    namespace: ai
+type: Opaque
+stringData:
+    CREDS_KEY: ENC[AES256_GCM,data:u1pMLOLUiCg2zRwgv7BhN+jXWAPwrFZWISrxL2adIzvAkZMBcRN/vwa5q8HNrWrNFO/xPdajkpZXlNRgtPX97Q==,iv:mzoWQSU3Tp80WNXyfjpP5cSy34trmetf09KsbC5rri4=,tag:mCA8Xibw2Li2TzuHtaZQYw==,type:str]
+    CREDS_IV: ENC[AES256_GCM,data:wCxwxTdBIFnoICPWPaUv+hRxb76eMK0BaEDhHOZrs7Y=,iv:/LUfQSXBN5/3sufyjtysIbMPCL9LQeiulzc3K5RIOTw=,tag:4EDXKdsTLpywGBSMdzPB0w==,type:str]
+    JWT_SECRET: ENC[AES256_GCM,data:CrDD/1FQ3KIThFpTQ4hSlVoYtzzjL47TDuFIdErVtdLp8NHkN51Y9CKcZdhPLDK/fFgKbLatKXf9kUWLrbKCeQ==,iv:wEQhBOhcStCFaLcJW/WeMsnzuoJ2RS1DXsj6JPQours=,tag:3TNThHfje9iBo1P/Wgsmdw==,type:str]
+    JWT_REFRESH_SECRET: ENC[AES256_GCM,data:nPMPrhEBIJkvunCCKXXhGDDgYYC09dy0nleY0nHOUSwS7O9/lbrnHWxgw67x2PkSLf0gNX30xcHzL02wAnN6Wg==,iv:UV2CBaXdEnnpESkZGSSbhDgXd078IyK+JJTGE5aZXhw=,tag:GzMH5iy1MkcRIrqRJRuirw==,type:str]
+    MEILI_MASTER_KEY: ENC[AES256_GCM,data:n0c5g30Gqbh0Ln9wjfJPvwgC8fDEeHq5sITJ5VpeyFIqkSNuTgm0jq+HstLnnjlnO781Blk/UXPtSxef7n9lrw==,iv:tgYBttxd01k+u26psFK9N9s5VdUdeK8q+2HDM90s2wE=,tag:Z4+jLpZTlv3A6jbkO2/PXw==,type:str]
+    OPENID_SESSION_SECRET: ENC[AES256_GCM,data:DwcbWsoyADveHtS3KvADbev5w0gPumEOJqVuUiUjw5Hj/s5mSBF00Cvc7HuHi+h9uw/tt1aaY69E5C/CxYtcOA==,iv:QyMMskBAVJ+KrfNQSibURdr0rr1/dWdDGYaXcOtRXkA=,tag:KqMr2tPaf43HNJZ9b+TWIA==,type:str]
+    LITELLM_API_KEY: ENC[AES256_GCM,data:vi7koqI9liRphK7He3RpT32W7P0ulBbl6Q==,iv:tjq0IZvijTGssJsjN5K+y9qM4b74W7vLYqZ1vrPafnI=,tag:2Kngbf3s5BOTixEP2Eal5Q==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBcFl4dW5UOVowWWppcGF3
+            bXF2cVNGSit3Q1NiNnNBakpuOTNvMHlKVkNvCkl2MEkxQ0pKZ1BuWnVUa0FwNVFH
+            SGJrQ04zdG1wUkUxT3BiM2FwVUxlZk0KLS0tIFVsMmVzV2R1WXZJend4TFFEUHA2
+            ek14aFgrOTU0eHV0L2xrYjF2U3hPRHcKeLO9iXbSkrlN1fdz4UqRzyPnswCWGfg7
+            rAuheo7JsQnjSGU7ZFiipcqMeDT8W6usbqVHTHBOV8tXmtAJ8ImVJQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-30T02:07:01Z"
+    mac: ENC[AES256_GCM,data:prBsjomUp5EmD6xI31Key0EBocXIilKHKCT34Be90TdBUxRZQRc+ZaALjTLCQ+X5vyr5sN4CuOMDvlOiVHjycirmRv1ykgTAlp/WIXf+4IEhzsCggl1hwwAnXyYt9lMUSSOn8zx88ppAi55i0VDJduspBVk/pG6Oex4SI5yDEtU=,iv:+FfKMIsI7K78V3A690l+dMqk0qw1F07rMTZzGR43JEg=,tag:/AwNbmrylWtz8dSzf7xlIw==,type:str]
+    version: 3.13.1

--- a/kubernetes/apps/apps/ai/librechat/librechat-vectordb-secrets.sops.yaml
+++ b/kubernetes/apps/apps/ai/librechat/librechat-vectordb-secrets.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: librechat-vectordb-secrets
+    namespace: ai
+type: Opaque
+stringData:
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:09+vKU6ih/trI1rUgkkMz02DJTsh1nXLRznNE/KnlvgrRDCp73QCWnfrh/SiYxomNhconKfAcNIh82j3FHmMdw==,iv:OwC+an1WwJsHpla06USLrEKPtHDeUpuDcQ47uZE2Bqs=,tag:snH+MGgRgmdG5Xnu8z2wtw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByN3VTUnQ4dVMzU0JIc01F
+            NUEwR0RaM2ZHMW9vaDE0M09xSTV3TEtnbUI0ClBMUDJpSHZzaHFoMEFnY0Q1RGhs
+            T1JKaXE5cmVTalNmcnVyTk1nYXVjK1EKLS0tIHRLM29TZEt6aWR0cG11ZlM5OGpa
+            SjBzNTBxVlZhWGhHc21aRVdDL2lPblEKK2rv9jBy8r4PettYHL6imo4d4/pdAjyy
+            FD8PBlXv4PrJPKK+GNypb/TQYYtMtVMHT9ceeLfO0UjY6fW+iT/ULg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-30T01:48:09Z"
+    mac: ENC[AES256_GCM,data:RxZJw5395tfviFuwi/NOQaAPZp6f08VYpUixM+rLqTnAPWyTwsku8qXOvMtASrly3QoTw2SSU0k2E3oBgsawJ6tLQ0CkbEy33U3KxQN+lt25jQR/OoooA7PsvmiToVFNWElsZ9EYTdE6dXdE16uy+k8b4I+r2NeXR5FXO7KodDE=,iv:9mp1fVC3vfZej2ub3BzRjZ20qJ1iQJZe3wcttUxM4i0=,tag:fBQu+5GmoFrpc15pk5EW/A==,type:str]
+    version: 3.13.1

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - ../apps/ai/sillytavern
   - ../apps/ai/vane
   - ../apps/ai/litellm
+  - ../apps/ai/librechat
   - ../apps/security/frigate
   - ../apps/immich
   - ../apps/media/jellyplex-watched

--- a/kubernetes/apps/storage/pvcs/ai/kustomization.yaml
+++ b/kubernetes/apps/storage/pvcs/ai/kustomization.yaml
@@ -4,3 +4,7 @@ resources:
   - vane-pvc.yaml
   - sillytavern-pvc.yaml
   - litellm-pvc.yaml
+  - librechat-data-pvc.yaml
+  - librechat-mongodb-pvc.yaml
+  - librechat-meilisearch-pvc.yaml
+  - librechat-vectordb-pvc.yaml

--- a/kubernetes/apps/storage/pvcs/ai/librechat-data-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/ai/librechat-data-pvc.yaml
@@ -15,4 +15,4 @@ spec:
   storageClassName: longhorn-r2
   resources:
     requests:
-      storage: 25Gi
+      storage: 10Gi

--- a/kubernetes/apps/storage/pvcs/ai/librechat-data-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/ai/librechat-data-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: librechat-data
+  namespace: ai
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 25Gi

--- a/kubernetes/apps/storage/pvcs/ai/librechat-meilisearch-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/ai/librechat-meilisearch-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: librechat-meilisearch
+  namespace: ai
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/storage/pvcs/ai/librechat-mongodb-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/ai/librechat-mongodb-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: librechat-mongodb
+  namespace: ai
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/apps/storage/pvcs/ai/librechat-mongodb-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/ai/librechat-mongodb-pvc.yaml
@@ -15,4 +15,4 @@ spec:
   storageClassName: longhorn-r2
   resources:
     requests:
-      storage: 20Gi
+      storage: 10Gi

--- a/kubernetes/apps/storage/pvcs/ai/librechat-vectordb-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/ai/librechat-vectordb-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: librechat-vectordb
+  namespace: ai
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -997,6 +997,92 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "LiteLLM Admin"]]
 
+  526-librechat.yaml: |
+    version: 1
+    metadata:
+      name: librechat-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "librechat-admin"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "librechat-user"
+        attrs:
+          is_superuser: false
+          parent: null
+
+      - model: authentik_providers_oauth2.scopemapping
+        id: librechat-role-scope
+        identifiers:
+          name: "LibreChat Role Scope"
+        attrs:
+          scope_name: librechat
+          description: "LibreChat roles based on Authentik group membership"
+          expression: |
+            roles = []
+            if request.user.ak_groups.filter(name="librechat-admin").exists():
+                roles.append("librechat-admin")
+                roles.append("librechat-user")
+            elif request.user.ak_groups.filter(name="librechat-user").exists():
+                roles.append("librechat-user")
+            return {"roles": roles}
+
+      - model: authentik_providers_oauth2.oauth2provider
+        id: librechat-provider
+        identifiers:
+          name: "LibreChat"
+        attrs:
+          client_id: !Env LIBRECHAT_CLIENT_ID
+          client_secret: !Env LIBRECHAT_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          client_type: confidential
+          client_authentication_method: client_secret_post
+          redirect_uris:
+            - url: "https://chat.lan.${CLUSTER_DOMAIN}/oauth/openid/callback"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !KeyOf librechat-role-scope
+
+      - model: authentik_core.application
+        identifiers:
+          slug: "librechat"
+        attrs:
+          name: "LibreChat"
+          provider: !KeyOf librechat-provider
+          group: "AI"
+          meta_launch_url: "https://chat.lan.${CLUSTER_DOMAIN}"
+
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "librechat"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "librechat-user"]]
+
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "librechat"]]
+          order: 1
+        attrs:
+          group: !Find [authentik_core.group, [name, "librechat-admin"]]
+
   527-llama.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -126,6 +126,16 @@ spec:
             secretKeyRef:
               name: litellm-sso-secret
               key: CLIENT_SECRET
+        - name: LIBRECHAT_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: librechat-sso-secret
+              key: CLIENT_ID
+        - name: LIBRECHAT_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: librechat-sso-secret
+              key: CLIENT_SECRET
         - name: HARBOR_CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - paperless-sso-secret.sops.yaml
   - nextcloud-sso-secret.sops.yaml
   - litellm-sso-secret.sops.yaml
+  - librechat-sso-secret.sops.yaml
   - harbor-sso-secret.sops.yaml
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml

--- a/kubernetes/infrastructure/security/authentik/install/librechat-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/librechat-sso-secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: librechat-sso-secret
+    namespace: authentik
+    annotations:
+        replicator.v1.mittwald.de/replicate-to: ai
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:zi1yoLW8Cj4cOuzMQ+Uc012qXLnYRAv5l7cC7Nipfr3uHhL3o+EbEdd9d0dBlN/a,iv:krvZq/2mX9dByM5H1Kk3Lwmt8TIF4EjR7hXwfkWj5wk=,tag:SjZJYJAJ/rfwTwydAeQjYw==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:8E3DiOVN4sfaIFKdoO3IT4rhshX2hnUG5rZFKZxSOo0VYGHyIHhKaMGBapN69qR3iTuaq9pWV8YYcQ/Mk7X2+RmKIDhhVOv+S/OVjjKSS7XZuWILhoApViFHcOGPBqGIQw==,iv:sw4xVvNsi4x/hrTyXQBly743f675lWYCom12nRz8mts=,tag:gqy2Vz3IO4ro0xfWq52o2A==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyRlc2Z1B1Vm5zMTlWT082
+            bE5yZVowNmJ2T3NpdGE2L2VzbmFjbElrc0ZBCkZTSmhGK2RUZUprK3B5aW9aWmND
+            enJITzJQQlRlRjhEYU4yaDR4bDBWWlkKLS0tIE00aEE1VTF0enJYMjg5aHpvSmJj
+            dHM4YXlMYkUyUTN3aDBYakIwK0tqT1kKWtbnHWV+COPbysVCmqDK283yY+0LPiNw
+            NHKFH7dMfALTIEnP5h7GWRS9nPFxXTA5pUEe7TFjZZgTcn/tZPMuJw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-30T01:48:19Z"
+    mac: ENC[AES256_GCM,data:AEY0K41uncazRk5R+CpxW06zA3VxfFw8fpyr+AgxWODtHHPmGX22xznNShl2N8ZHjJqfhxTy2db+LKucN0exWkrNhsekomodRiZMvRd/Qv+xx7/BCcP658SMPaQCej9XYJQ5bgb3D9oPn9dKPuImqqno7v1pfvh1vP0CeBLJRA0=,iv:pbom5hxdrREBCNSVAxm0utBcn5jb3qy7UIBKemoAvBc=,tag:pVcwHtGKNjERqffb0WiA3Q==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## Summary
- add LibreChat app manifests with MongoDB, Meilisearch, RAG API, and pgvector
- wire LibreChat into production apps and AI storage PVC catalog
- add Authentik OIDC app, groups, role scope mapping, and replicated SSO secret

## Validation
- git diff --check
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/librechat
- kubectl apply --dry-run=client -k kubernetes/apps/storage/pvcs/ai
- kubectl apply --dry-run=client -k kubernetes/infrastructure/security/authentik/install
- pre-commit run check-yaml --files <changed yaml files>
- pre-commit run yamllint --files <changed yaml files>
- pre-commit run prevent-plaintext-k8s-secrets --files <new sops secret files>
- pre-commit run forbid-sensitive-files --files <new sops secret files>

## Notes
- LibreChat uses a placeholder LITELLM_API_KEY in its own SOPS secret. Replace it with a dedicated LiteLLM virtual key before relying on the LiteLLM endpoint.
- Dry-run emitted existing-resource kubectl last-applied-configuration warnings for already-live resources.