### PR TITLE
fix(kubernetes): add missing models.default to librechat config

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/configmap.yaml
+++ b/kubernetes/apps/apps/ai/librechat/configmap.yaml
@@ -19,5 +19,6 @@ data:
           apiKey: "${LITELLM_API_KEY}"
           baseURL: "http://litellm.ai.svc.cluster.local:4000/v1"
           models:
+            default: []
             fetch: true
           modelDisplayLabel: LiteLLM


### PR DESCRIPTION
LibreChat v0.8.6-rc1 requires endpoints.custom[].models.default to be an array. Without it, the pod crashes on startup with a ZodError validation failure, causing CrashLoopBackOff.