### PR TITLE
fix(kubernetes): provide actual models in librechat default list

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/configmap.yaml
+++ b/kubernetes/apps/apps/ai/librechat/configmap.yaml
@@ -19,6 +19,9 @@ data:
           apiKey: "${LITELLM_API_KEY}"
           baseURL: "http://litellm.ai.svc.cluster.local:4000/v1"
           models:
-            default: []
+            default:
+              - openai/gpt-5.5
+              - openai/gpt-5.4
+              - openai/gpt-5.4-mini
             fetch: true
           modelDisplayLabel: LiteLLM


### PR DESCRIPTION
LibreChat v0.8.6-rc1 requires models.default to contain at least one element. Added the main LiteLLM models as defaults; fetch: true will still discover the full list at runtime.