### PR TITLE
fix(kubernetes): restore LibreChat OIDC grant types

### DIFF
--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1050,6 +1050,9 @@ data:
           jwt_algorithm: RS256
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
           client_type: confidential
+          grant_types:
+            - authorization_code
+            - refresh_token
           client_authentication_method: client_secret_post
           redirect_uris:
             - url: "https://chat.lan.${CLUSTER_DOMAIN}/oauth/openid/callback"


### PR DESCRIPTION
## Summary
- restore authorization_code and refresh_token grant types on the authentik LibreChat OAuth provider blueprint
- fixes authentik rejecting LibreChat authorization requests with invalid_request / invalid grant_type

## Validation
- kubectl logs showed authentik warning: Invalid grant_type for provider, grant_type=authorization_code
- kubectl dry-run succeeded for the authentik blueprint ConfigMap and LibreChat HelmRelease
- pre-commit run check-yaml --files kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
- pre-commit run yamllint --files kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml