### PR TITLE
fix(kubernetes): use OIDC name for LibreChat users

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -55,6 +55,8 @@ spec:
               OPENID_CALLBACK_URL: /oauth/openid/callback
               OPENID_SCOPE: openid profile email librechat
               OPENID_BUTTON_LABEL: Authentik
+              OPENID_NAME_CLAIM: name
+              OPENID_USERNAME_CLAIM: name
               OPENID_REQUIRED_ROLE: librechat-user,librechat-admin
               OPENID_REQUIRED_ROLE_TOKEN_KIND: id
               OPENID_REQUIRED_ROLE_PARAMETER_PATH: roles


### PR DESCRIPTION
## Summary
- configure LibreChat to use the OIDC name claim for both display name and username
- keeps Authentik as the source of truth for the account name shown by LibreChat

## Validation
- kubectl apply --dry-run=client -f kubernetes/apps/apps/ai/librechat/helmrelease.yaml
- pre-commit run check-yaml --files kubernetes/apps/apps/ai/librechat/helmrelease.yaml
- pre-commit run yamllint --files kubernetes/apps/apps/ai/librechat/helmrelease.yaml