### PR TITLE
fix(kubernetes): configure LibreChat admin and auth

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/configmap.yaml
+++ b/kubernetes/apps/apps/ai/librechat/configmap.yaml
@@ -16,7 +16,7 @@ data:
     endpoints:
       custom:
         - name: LiteLLM
-          apiKey: "${LITELLM_API_KEY}"
+          apiKey: "$${LITELLM_API_KEY}"
           baseURL: "http://litellm.ai.svc.cluster.local:4000/v1"
           models:
             default:

--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
               DOMAIN_SERVER: https://chat.lan.${CLUSTER_DOMAIN}
               TRUST_PROXY: "1"
               NO_INDEX: "true"
-              ENDPOINTS: custom
+              ENDPOINTS: custom,agents
               MONGO_URI: mongodb://librechat-mongodb:27017/LibreChat
               SEARCH: "true"
               MEILI_HOST: http://librechat-meilisearch:7700
@@ -119,6 +119,37 @@ spec:
               limits:
                 cpu: 2
                 memory: 4Gi
+
+      admin-panel:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          admin-panel:
+            image:
+              # renovate: datasource=docker depName=clickhouse/librechat-admin-panel registryUrl=https://ghcr.io
+              repository: ghcr.io/clickhouse/librechat-admin-panel
+              tag: latest
+            env:
+              TZ: Europe/Berlin
+              PORT: "3000"
+              VITE_API_BASE_URL: https://chat.lan.${CLUSTER_DOMAIN}
+              API_SERVER_URL: http://librechat-main.ai.svc.cluster.local:3080
+              ADMIN_SSO_ONLY: "true"
+              SESSION_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: librechat-secrets
+                    key: ADMIN_PANEL_SESSION_SECRET
+            ports:
+              - name: http
+                containerPort: 3000
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
 
       mongodb:
         containers:
@@ -345,6 +376,11 @@ spec:
         ports:
           http:
             port: 3080
+      admin-panel:
+        controller: admin-panel
+        ports:
+          http:
+            port: 3000
       mongodb:
         controller: mongodb
         ports:
@@ -382,6 +418,22 @@ spec:
               - path: /
                 service:
                   identifier: main
+                  port: http
+      admin-panel:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: chat-admin.lan.${CLUSTER_DOMAIN}
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: LibreChat - Admin Panel
+          gethomepage.dev/description: LibreChat administration interface
+          gethomepage.dev/group: "Kubernetes"
+          gethomepage.dev/icon: librechat.png
+          gethomepage.dev/href: https://chat-admin.lan.${CLUSTER_DOMAIN}
+        hosts:
+          - host: chat-admin.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: admin-panel
                   port: http
 
     persistence:

--- a/kubernetes/apps/apps/ai/librechat/librechat-secrets.sops.yaml
+++ b/kubernetes/apps/apps/ai/librechat/librechat-secrets.sops.yaml
@@ -12,6 +12,7 @@ stringData:
     MEILI_MASTER_KEY: ENC[AES256_GCM,data:n0c5g30Gqbh0Ln9wjfJPvwgC8fDEeHq5sITJ5VpeyFIqkSNuTgm0jq+HstLnnjlnO781Blk/UXPtSxef7n9lrw==,iv:tgYBttxd01k+u26psFK9N9s5VdUdeK8q+2HDM90s2wE=,tag:Z4+jLpZTlv3A6jbkO2/PXw==,type:str]
     OPENID_SESSION_SECRET: ENC[AES256_GCM,data:DwcbWsoyADveHtS3KvADbev5w0gPumEOJqVuUiUjw5Hj/s5mSBF00Cvc7HuHi+h9uw/tt1aaY69E5C/CxYtcOA==,iv:QyMMskBAVJ+KrfNQSibURdr0rr1/dWdDGYaXcOtRXkA=,tag:KqMr2tPaf43HNJZ9b+TWIA==,type:str]
     LITELLM_API_KEY: ENC[AES256_GCM,data:vi7koqI9liRphK7He3RpT32W7P0ulBbl6Q==,iv:tjq0IZvijTGssJsjN5K+y9qM4b74W7vLYqZ1vrPafnI=,tag:2Kngbf3s5BOTixEP2Eal5Q==,type:str]
+    ADMIN_PANEL_SESSION_SECRET: ENC[AES256_GCM,data:lGaAFTugbAhsC39n0i2UPZv8n75J3Zr/VolY+Wqg7XG/RfiS0O0gBKSm0o4cJS7910wZoVobRZg202h4VJS5eA==,iv:cnSCCwQL9OknAQU3KumJOjDb9ulbgyJXPY2M7ox31u8=,tag:vJysklUwN/01t8+44ZubVQ==,type:str]
 sops:
     age:
         - enc: |
@@ -24,6 +25,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-30T02:07:01Z"
-    mac: ENC[AES256_GCM,data:prBsjomUp5EmD6xI31Key0EBocXIilKHKCT34Be90TdBUxRZQRc+ZaALjTLCQ+X5vyr5sN4CuOMDvlOiVHjycirmRv1ykgTAlp/WIXf+4IEhzsCggl1hwwAnXyYt9lMUSSOn8zx88ppAi55i0VDJduspBVk/pG6Oex4SI5yDEtU=,iv:+FfKMIsI7K78V3A690l+dMqk0qw1F07rMTZzGR43JEg=,tag:/AwNbmrylWtz8dSzf7xlIw==,type:str]
+    lastmodified: "2026-05-30T19:26:35Z"
+    mac: ENC[AES256_GCM,data:DjZkzzDBGiH0HbTxzn0KdLsti/PesO7kBJ2HlMpsWTZ1Cga0Q9u0n2kfPjOjA3fXvUv4Pb018s3PAS/QKRvID21ZUus4p+raDoAE4iTh3DQkkRONgcV3CE4beMq/BrSZiKpk37hp9PVmzJUVWEk95sDeZRFFPmUvLRx3RhocSF0=,iv:1gfFJNkxZJ2pkK9Z09OfWzAz+vKZwHLHNUbLDPtisaQ=,tag:r4/vOWrlBjGhv3oA8AZo5w==,type:str]
     version: 3.13.1

--- a/kubernetes/infrastructure/security/authentik/install/authentik-env.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/authentik-env.sops.yaml
@@ -5,30 +5,32 @@ metadata:
     namespace: authentik
 type: Opaque
 stringData:
-    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:RhfHVd/I29+axQXyUu9Gwlgj6Ry62oB6V2k/UO5YB059YJLB6/EMl77BFPjUTIaHY+9ePBq7nLzTCoNM0roXCg==,iv:62+jkEK8eSx7bM7Lt6la+Rxhauw8Yk1WBGTicq//l6I=,tag:eFnT3qXF5r2KZIcoAXLB7Q==,type:str]
-    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:WOq4qnlE4Gy13g1pURf6g3dBxP5mG2fzP3kjKR93PHkHz5mk9l0FHxWL4XET1RFh,iv:BsgTvFvUCE5dYbMXQ+MI3LXzRsCsIaeDdYurUFAQM+o=,tag:hVlkIOA/xZt4BKbjic4aSQ==,type:str]
-    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:bH/xf4Cr6RoCe/alV10oEH+gtIsZYlJ9O+Si4zq9kT0zoBZWKCp3hd1cRkBi+xaMeLMeHQXwxhZB6jl8ObhRW7LHSbkQOj0ujym58x3SKAGuKME5kw4tTA==,iv:J/7pjfj5jmcRmusytqziENpuxB04KQoGuSQpa+bb/Jc=,tag:FafwvKhwbS0jmRyFa7kGJA==,type:str]
-    AK_BLUEPRINT_USER_PASSWORD: ENC[AES256_GCM,data:+TCTAEb3mOcSy+5eOJ3Vs+fqzUNxkMzPydctYExPIRP/25XUFdx1EyBN6cpOhauQv9ey,iv:TcSq2Hvd1vYn1JGCNAsF/wNbVfTxC1LAhLVjTL6l02c=,tag:9DoJaXAxQYr7jIn1GphS9w==,type:str]
-    AK_OPENCLAW_USERNAME: ENC[AES256_GCM,data:BPCx8g==,iv:rdzT+Rqq3ur/RCccJQ5VjZQAqCZWFP/RNS9BJam6Wz0=,tag:nvq5FuWuH62i3my84LWl2A==,type:str]
-    AK_OPENCLAW_NAME: ENC[AES256_GCM,data:N9pGeFWOdjWUI+1QnFXMig==,iv:PZOHgbfwieY405zwOR6UMUx2NsvfFrRKBTBr9WWqKRw=,tag:VrnJpQWLSwwGAFiacPZKSg==,type:str]
-    AK_OPENCLAW_EMAIL: ENC[AES256_GCM,data:JOKafrkMoukDRp6ii9yI5L9aW7n8ufbtYSvMqHE=,iv:YEEzPezF765GWN0By3Jh/ci1w5tOc4JZhplenOA/Yyw=,tag:nLQgQJmgtH5i9L8eLVyBCg==,type:str]
-    AK_OPENCLAW_PASSWORD: ENC[AES256_GCM,data:QowWYYp6pztQXm4nuvybuCXNrYSeBHUlpxi70u6fbUjSe0k=,iv:4/mGEWNo5w0okx0KHAPJ94lkUYmU5juRtL/0jL+Qj9E=,tag:Cgn4ZYmse0z5ta1QXrymWA==,type:str]
-    AK_OPENCLAW_AVATAR: ENC[AES256_GCM,data:tepqVoFV6LX5DuTZg/DKnAJYcLLOpAWS4U1I61TBJcs=,iv:ml2Xqi7dlTPJB8YYBKxa2r2+rtGYlFYrE33ab4cFmeg=,tag:D0MDdAMlWzy8PRWeCVLtKA==,type:str]
-    AK_BLUEPRINT_USER: ENC[AES256_GCM,data:Bl67i19DnKEJ,iv:dLaTuII2eD0sAcOmBhltY8CwrHt0UbqCRRUcc/bKGvQ=,tag:z4YvPy2J8FFzgscO9h8dtQ==,type:str]
-    AUTHENTIK_EMAIL__USERNAME: ENC[AES256_GCM,data:9MVmi/kPwD1YBv73Aj1EAYXBDb5JMiYPbVnODKEWpy17CQ==,iv:6IbD4YwZnxr2x5TI6GxRdBknJ7gpl4Bgdp2JV5RQziI=,tag:amGZbxNIGE5rMN6NShLFTg==,type:str]
-    AUTHENTIK_EMAIL__PASSWORD: ENC[AES256_GCM,data:jXn/jE57RjkZyIrA10jfRA==,iv:A8NxhMDR74Ab2jj1iMmjshk6fuzQnQZNp3EJk6tVZ0I=,tag:x0QaQG+kjkkLexE5BjrRyw==,type:str]
+    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:BZ53vd/CJjQNP3NZEdYT9y4nGvJkziZMmaOUT83pBWxbojS4lcGDKsq01Q7Hu3qp+mKV/ew5s3tx3hJytSyv8g==,iv:0VhUkDM9+Z6t/aGerM7s8hGi/tcdgPDz9ko3zsNUsfM=,tag:ySzaMdq7mDKvdgbhhWANgQ==,type:str]
+    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:zGxbOMGxpUPjHHkojHWdWhqQfQK55ESIl6BExSECoNlz0F8wNHpKbgglNUQx8M4T,iv:pprKW4x0i+XHVPfukHYYNgep4sigdMVfMtC0Ew6c6ec=,tag:v6i374yMbYyXWd+w2uKXmw==,type:str]
+    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:gcrWgnxzHDwlKbWrnoIX0WFK8v+ZR+TZXaPkvDyPEMgaA7MFjKPbJxyyi3OeKC1BSGKnwwLIIhVz9BccP8yuP9dNunFL0kEhTNrZiPwGMzZRRIC/DyBoNg==,iv:faPVsJzeZ71PsU/5HmHThzhhpO7V9UPSLjoP6WOwrgU=,tag:hZMhSFr+iNIgvrj4wUbQJg==,type:str]
+    AK_BLUEPRINT_USERNAME: ENC[AES256_GCM,data:a5rIxcelN90K,iv:sxeuxfk4T2qovsZCFuSNPYoY3TcdOmCfvrvtEal5dUk=,tag:FKEQyJum3zt6b22idalAkA==,type:str]
+    AK_BLUEPRINT_NAME: ENC[AES256_GCM,data:PpdSd1d1IlnEE9CgAz0niA==,iv:ErLoUVCzjYyUyc8ZGiCwt1d0Agu9goNQUMCfo/cGrjM=,tag:4xdfoC6UN2s8hIg8gk8nfA==,type:str]
+    AK_BLUEPRINT_EMAIL: ENC[AES256_GCM,data:aEgciZm9USDsZnuy3YL24tvIqTSTA+xAW4OfvA==,iv:ra/Z+uy66wAn0QnCGsrVj3i91GphflweFvBQPupWJqM=,tag:7jPc+eccdwDqyjzX7tRR3g==,type:str]
+    AK_BLUEPRINT_USER_PASSWORD: ENC[AES256_GCM,data:+p1ixuCKXwqw66T8D56Nzq7MDOzfw2/XRzQoq8wSRbiys0qmuUQmSeMluKIEY7DsKc0e,iv:di9/yZztOYTLsH11lmmDq+050oJsUtMWj7SDhoYOgbA=,tag:ccKkaCN5zie6Dea4W0vc3Q==,type:str]
+    AK_OPENCLAW_USERNAME: ENC[AES256_GCM,data:hR2QyQ==,iv:VYoLjUO94TBy0nsxr3phW1KIGXucmwuUr0ZlOPfqFJ4=,tag:Y3/ow+zGLsp5ghZcgNDT0A==,type:str]
+    AK_OPENCLAW_NAME: ENC[AES256_GCM,data:JpkY6XE8U2tCsQamffJT+A==,iv:vw12beVogkiiBFH0zeqikjzyiadi7IslxfUv0rw86d8=,tag:O54w8IzWSls5+/VM9VWtVw==,type:str]
+    AK_OPENCLAW_EMAIL: ENC[AES256_GCM,data:KWLJd0xzySzJibkawQqgm2JMCetids+rZ4YQg5c=,iv:54qIWNGtWss7idIaj+Eai+cGwC4bznuuoehaXxsm5aE=,tag:lHDeZQ1wTSX3WdCIxAje/w==,type:str]
+    AK_OPENCLAW_PASSWORD: ENC[AES256_GCM,data:/9uytFQExV+f3yAQtMkkNAH/e3PRbqCkbd/Yr3rn8Sx3sfM=,iv:ASzGNdUcS9XUO+VAg/WqcS5KIbetskWuirs0UcKp0aQ=,tag:gKWRWmFibDx5CTrOnWqIWg==,type:str]
+    AK_OPENCLAW_AVATAR: ENC[AES256_GCM,data:UunKB9Avbek05dKJ8Xg5FKJSWX6CO+IcVFnYaMwkTsw=,iv:im65I1pZYINCzVbn5Jegrx/GMKP0yDFGGrW7f3YkxUw=,tag:c4xbG0BlcHCPPC3xQH5biQ==,type:str]
+    AUTHENTIK_EMAIL__USERNAME: ENC[AES256_GCM,data:LNYXMb1RCkR9bRV5HGtaQ5KY7JgBGyriSac3/yqYNmVylA==,iv:z1NfjhJyuM0VkZeHS2kxqkezqklMcHAYnxnVshyDOzc=,tag:IXSAj6cLeIcQcpQwTllw5A==,type:str]
+    AUTHENTIK_EMAIL__PASSWORD: ENC[AES256_GCM,data:eM5f7Qlh7urrozyD+OCFUg==,iv:1jLBP9rvb8J926cOAOO7OWRQTTrJMUCf5KYxfMYxjoM=,tag:lWLh7MwRd6Z2AIj7qGS+4w==,type:str]
 sops:
     age:
-        - recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMbTZKWkZvYWo4M3hqZHZn
-            OU5pUThhZnR2RDhGRWhQK1B0bjZ6TWpSN0NrClhxVDRHNDgvOWdseWZBZW1SU0ZR
-            czMzeENGTHdPZC9iRklua3gwbklWVm8KLS0tIHBXUmZ5ZWZNcnRJaEt3d05RNDY2
-            aWpzRElTT0pkVndCVHhVRWVCc29ndG8KrfKE8t3lqLKe73vwSFNLcE/E8yi62hgS
-            KtY9oVP4wjBMpk7wxokCG9XzXC9eRD8JQkuOA8NRqwf4PXuGXHWulQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArNGhJOVBuRGRCaXhwWXVs
+            Tm5Lb0l3dEJKUGZUOCtmZURJVldhRklTUUFvCk16TjRtU0Y1NzB4cDk1TGxzcmEy
+            QkN1V3FFUC9OMHNEQ2g2Ujd6M2ZMNmsKLS0tIFF3VGZVNXptbGkybkxxRy9ValRx
+            aSt2OUtMaTRkL0I5ampSL1hZY1RRSUkKodCVBAeBAqhTGZt70/sI6/eN3pZRRKpr
+            kKh0LoDPSbxIltbXpSEZGD6KJ2girU2neVOnCVmpD0KE7JPDnsAIqA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-26T23:41:43Z"
-    mac: ENC[AES256_GCM,data:aKXGPtfw5UtUJZSZtevnhdabSLr19MtxBlKpK2Snmy/Nce+uQML+aXjAVIphnMlZVmAlxwpE0QLsgNfMvlmVMhAaNWwfB18Ya6VSIQUYORjNA/uk6v04Q7MYkqBmkjpAeWcMqi3wIPX3AbCZS/LHyKjmszu3rX8/x9DU/23Wkh8=,iv:AZ3bPFRChrNZIu6Q1lUvSbQd71ABIKl55e1lNAv/TkQ=,tag:0kAqPJHOnEVBQSW05VzIIA==,type:str]
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
     encrypted_regex: ^(data|stringData)$
-    version: 3.12.2
+    lastmodified: "2026-05-30T19:12:35Z"
+    mac: ENC[AES256_GCM,data:EPsvJR07SZnClwBJlkEe6Mhh70YfObTlpM84+qu57vek/K6/mz+jc8icKdrOZZTXGh097pnDNiy5AeyZkMdHwc3lt0viVWkKc3adNWXkTAIduW3VPgmkBK8mrFNfydQPvP1unNXEQnqOiZiBHxMU0+Dr3yUrlyA4D12yS311GmQ=,iv:ojyNg/Jxx/xcC+ThOXClR4LxZ0zaqtOeN2o4osOJAKU=,tag:rPNBAvvh1SzN99TqipsXew==,type:str]
+    version: 3.13.1

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -15,10 +15,10 @@ data:
       - model: authentik_core.user
         state: present
         identifiers:
-          username: !Env AK_BLUEPRINT_USER
+          username: !Env AK_BLUEPRINT_USERNAME
         attrs:
-          name: !Env AK_BLUEPRINT_USER
-          email: "${ACME_EMAIL}"
+          name: !Env AK_BLUEPRINT_NAME
+          email: !Env AK_BLUEPRINT_EMAIL
           is_active: true
           is_superuser: true  # This ensures the Admin Console is visible
           password: !Env AK_BLUEPRINT_USER_PASSWORD
@@ -29,7 +29,7 @@ data:
           name: "authentik Admins"
         attrs:
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # 3. Define the Proxy Provider
       - model: authentik_providers_proxy.proxyprovider
@@ -102,7 +102,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # Create Grafana Editors (currently empty)
       - model: authentik_core.group
@@ -188,7 +188,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       - model: authentik_providers_oauth2.oauth2provider
         id: audiobookshelf-provider
@@ -309,7 +309,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # Create custom scope mapping for Gitea role claims
       - model: authentik_providers_oauth2.scopemapping
@@ -390,7 +390,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       - model: authentik_core.group
         state: present
@@ -471,7 +471,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # OAuth2 Provider for Paperless
       - model: authentik_providers_oauth2.oauth2provider
@@ -527,7 +527,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # Nextcloud Users group (regular users, 15 GB quota)
       - model: authentik_core.group
@@ -649,7 +649,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # Frigate Viewers group
       - model: authentik_core.group
@@ -747,7 +747,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # Custom scope mapping that injects Authorization header
       - model: authentik_providers_oauth2.scopemapping
@@ -854,7 +854,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # Custom scope mapping that injects Basic auth header
       - model: authentik_providers_oauth2.scopemapping
@@ -927,7 +927,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       - model: authentik_core.group
         state: present
@@ -1012,7 +1012,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       - model: authentik_core.group
         state: present
@@ -1102,7 +1102,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # Custom scope mapping that injects Authorization header
       - model: authentik_providers_oauth2.scopemapping
@@ -1175,7 +1175,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       - model: authentik_providers_oauth2.scopemapping
         state: present
@@ -1245,7 +1245,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # Immich Users group (regular users)
       - model: authentik_core.group
@@ -1339,7 +1339,7 @@ data:
           is_superuser: false
           parent: null
           users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USER]]
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
 
       # Jellyfin Users group
       - model: authentik_core.group

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -173,11 +173,21 @@ spec:
               key: OPENCLAW_GATEWAY_PASSWORD
 
         # Blueprint variables
-        - name: AK_BLUEPRINT_USER
+        - name: AK_BLUEPRINT_USERNAME
           valueFrom:
             secretKeyRef:
               name: authentik-env
-              key: AK_BLUEPRINT_USER
+              key: AK_BLUEPRINT_USERNAME
+        - name: AK_BLUEPRINT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: authentik-env
+              key: AK_BLUEPRINT_NAME
+        - name: AK_BLUEPRINT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: authentik-env
+              key: AK_BLUEPRINT_EMAIL
         - name: AK_BLUEPRINT_USER_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Summary
- update Authentik bootstrap user fields to use the renamed username plus display name and email secret values
- preserve LibreChat's LiteLLM API key placeholder through Flux substitution and enable the agents endpoint
- add the LibreChat admin panel as a second controller/service/ingress in the existing LibreChat HelmRelease with SSO-only login and homepage metadata

## Validation
- git diff --check
- kubectl apply --dry-run=client -k kubernetes/infrastructure/security/authentik/install
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/librechat
- sops --decrypt kubernetes/apps/apps/ai/librechat/librechat-secrets.sops.yaml >/dev/null
- sops --decrypt kubernetes/infrastructure/security/authentik/install/authentik-env.sops.yaml >/dev/null

## Post-merge note
- after Flux reconciles, delete the existing LibreChat Mongo user if you want LibreChat to recreate it from the corrected Authentik claims