### PR TITLE
fix(kubernetes): fix LibreChat admin SSO and LiteLLM URL

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/configmap.yaml
+++ b/kubernetes/apps/apps/ai/librechat/configmap.yaml
@@ -17,7 +17,7 @@ data:
       custom:
         - name: LiteLLM
           apiKey: "$${LITELLM_API_KEY}"
-          baseURL: "http://litellm.ai.svc.cluster.local:4000/v1"
+          baseURL: "http://litellm-main:4000/v1"
           models:
             default:
               - openai/gpt-5.5

--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -38,6 +38,7 @@ spec:
               LOG_TO_FILE: "false"
               DOMAIN_CLIENT: https://chat.lan.${CLUSTER_DOMAIN}
               DOMAIN_SERVER: https://chat.lan.${CLUSTER_DOMAIN}
+              ADMIN_PANEL_URL: https://chat-admin.lan.${CLUSTER_DOMAIN}
               TRUST_PROXY: "1"
               NO_INDEX: "true"
               ENDPOINTS: custom,agents
@@ -348,7 +349,7 @@ spec:
                     key: POSTGRES_PASSWORD
               EMBEDDINGS_PROVIDER: openai
               EMBEDDINGS_MODEL: local/embedding
-              RAG_OPENAI_BASEURL: http://litellm.ai.svc.cluster.local:4000/v1
+              RAG_OPENAI_BASEURL: http://litellm-main:4000/v1
               RAG_OPENAI_API_KEY:
                 valueFrom:
                   secretKeyRef:
@@ -406,6 +407,7 @@ spec:
       main:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: chat.lan.${CLUSTER_DOMAIN}
+          traefik.ingress.kubernetes.io/router.middlewares: ai-librechat-admin-oauth-sanitize@kubernetescrd
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: LibreChat
           gethomepage.dev/description: AI chat interface

--- a/kubernetes/apps/apps/ai/librechat/kustomization.yaml
+++ b/kubernetes/apps/apps/ai/librechat/kustomization.yaml
@@ -6,6 +6,7 @@ components:
 
 resources:
   - configmap.yaml
+  - middleware-admin-oauth-sanitize.yaml
   - librechat-secrets.sops.yaml
   - librechat-vectordb-secrets.sops.yaml
   - helmrelease.yaml

--- a/kubernetes/apps/apps/ai/librechat/middleware-admin-oauth-sanitize.yaml
+++ b/kubernetes/apps/apps/ai/librechat/middleware-admin-oauth-sanitize.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: ai
 spec:
   redirectRegex:
-    regex: '^https://chat\.lan\.[^/]+/api/admin/oauth/openid\?code_challenge=([a-f0-9]{64})(?:&.*)?$'
+    regex: '^https://chat\.lan\.[^/]+/api/admin/oauth/openid\?code_challenge=([a-f0-9]{64})&.+$'
     replacement: 'https://chat.lan.${CLUSTER_DOMAIN}/api/admin/oauth/openid?code_challenge=$${1}'
     permanent: false

--- a/kubernetes/apps/apps/ai/librechat/middleware-admin-oauth-sanitize.yaml
+++ b/kubernetes/apps/apps/ai/librechat/middleware-admin-oauth-sanitize.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: librechat-admin-oauth-sanitize
+  namespace: ai
+spec:
+  redirectRegex:
+    regex: '^https://chat\.lan\.[^/]+/api/admin/oauth/openid\?code_challenge=([a-f0-9]{64})(?:&.*)?$'
+    replacement: 'https://chat.lan.${CLUSTER_DOMAIN}/api/admin/oauth/openid?code_challenge=$${1}'
+    permanent: false


### PR DESCRIPTION
## Summary
- point LibreChat custom and RAG LiteLLM URLs at the live litellm-main service
- set LibreChat ADMIN_PANEL_URL for admin OAuth callbacks
- add a Traefik redirect middleware to strip unsupported admin OAuth query params while preserving code_challenge

## Validation
- git diff --check
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/librechat
- CLUSTER_DOMAIN=<cluster-domain> flux envsubst < kubernetes/apps/apps/ai/librechat/middleware-admin-oauth-sanitize.yaml
- validated redirectRegex replacement with Go regexp