### PR TITLE
fix(kubernetes): fix LibreChat OIDC redirects

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -57,7 +57,7 @@ spec:
               OPENID_SCOPE: openid profile email librechat
               OPENID_BUTTON_LABEL: Authentik
               OPENID_NAME_CLAIM: name
-              OPENID_USERNAME_CLAIM: name
+              OPENID_USERNAME_CLAIM: preferred_username
               OPENID_REQUIRED_ROLE: librechat-user,librechat-admin
               OPENID_REQUIRED_ROLE_TOKEN_KIND: id
               OPENID_REQUIRED_ROLE_PARAMETER_PATH: roles

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1057,6 +1057,11 @@ data:
           redirect_uris:
             - url: "https://chat.lan.${CLUSTER_DOMAIN}/oauth/openid/callback"
               matching_mode: strict
+            - url: "https://chat.lan.${CLUSTER_DOMAIN}/api/admin/oauth/openid/callback"
+              matching_mode: strict
+            - url: "https://chat.lan.${CLUSTER_DOMAIN}/login"
+              matching_mode: strict
+              redirect_uri_type: logout
           property_mappings:
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]


### PR DESCRIPTION
## Summary
- add LibreChat admin OAuth callback to the Authentik provider redirect URIs
- add LibreChat post-logout redirect URI as a logout redirect URI
- keep LibreChat username stable by mapping OIDC username from preferred_username while using name for display name

## Validation
- git diff --check
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/librechat
- kubectl apply --dry-run=client -k kubernetes/infrastructure/security/authentik/install
- CLUSTER_DOMAIN=<cluster-domain> flux envsubst < kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml