### PR TITLE
feat(ai): bump LibreChat config to v1.3.11, enable LiteLLM debug logging

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/configmap.yaml
+++ b/kubernetes/apps/apps/ai/librechat/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ai
 data:
   librechat.yaml: |
-    version: 1.3.5
+    version: 1.3.11
     cache: true
 
     interface:

--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -59,6 +59,7 @@ spec:
               PROXY_BASE_URL: https://litellm.lan.${CLUSTER_DOMAIN}
               AUTO_REDIRECT_UI_LOGIN_TO_SSO: "true"
               REDIS_URL: redis://litellm-valkey:6379
+              SET_DEBUG: "True"
             envFrom:
               - secretRef:
                   name: litellm-credentials


### PR DESCRIPTION
## Changes

### LibreChat config version bump (1.3.5 → 1.3.11)
The running LibreChat (v0.8.6-rc1) flagged itself as outdated at config version 1.3.5 (latest: 1.3.11). Newer config versions add improved support for `reasoning_effort` passthrough on custom/OpenAI-compatible endpoints, which is needed for reasoning to work correctly with `chatgpt/gpt-5.5` via the ChatGPT subscription provider.

### LiteLLM debug logging enabled
Adds `SET_DEBUG=True` to the LiteLLM container env. This enables full request/response body logging so we can verify whether `reasoning_effort` is being passed from LibreChat → LiteLLM → ChatGPT API.

**Note:** Debug logging is verbose — this should be reverted after confirming reasoning passthrough works.

### Context
LiteLLM spend logs showed that most recent `chatgpt/gpt-5.5` requests had `reasoning_tokens: 0`, suggesting the reasoning parameter wasn't being forwarded. The request body wasn't captured in spend logs (`proxy_server_request: null`), so debug mode is needed to inspect the actual payloads.