### PR TITLE
feat(ansible): add Strix Halo ComfyUI container

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 inventory = ./inventories
-roles_path = ./roles:./roles/vms
+roles_path = ./roles:./roles/containers:./roles/vms
 collections_path = $HOME/.ansible/collections:/usr/share/ansible/collections:/usr/lib/python3.14/site-packages
 remote_tmp = /tmp/.ansible-${USER}/tmp
 timeout = 30

--- a/ansible/inventories/group_vars/llm_lxc.yml
+++ b/ansible/inventories/group_vars/llm_lxc.yml
@@ -10,3 +10,7 @@ lxc_hardening_sshd_settings:
 
 docker_install_enabled: true
 docker_users: []
+
+comfyui_model_download_profile_names:
+  - qwen_image_lightning_bf16
+  - qwen_image_edit_lightning_bf16

--- a/ansible/playbooks/llm_lxc.yml
+++ b/ansible/playbooks/llm_lxc.yml
@@ -7,5 +7,8 @@
     - lxc_bootstrap
     - docker
     - llm_runtime
+    - role: comfyui
+      tags:
+        - comfyui
     - whisper_runtime
     - llama_swap

--- a/ansible/roles/containers/comfyui/defaults/main.yml
+++ b/ansible/roles/containers/comfyui/defaults/main.yml
@@ -28,6 +28,8 @@ comfyui_output_dir: "{{ comfyui_base_dir }}/output"
 comfyui_user_dir: "{{ comfyui_base_dir }}/user"
 comfyui_cache_dir: "{{ comfyui_base_dir }}/cache"
 comfyui_workflows_dir: "{{ comfyui_base_dir }}/workflows/api"
+comfyui_idle_restart_script: /usr/local/sbin/comfyui-idle-restart
+comfyui_idle_restart_state_file: /run/comfyui-idle-restart.state
 
 comfyui_bind_address: "0.0.0.0"
 comfyui_host_port: 8188
@@ -61,11 +63,20 @@ comfyui_cli_args:
   - "{{ comfyui_container_port }}"
   - --output-directory
   - /root/comfy-outputs
-  - --disable-mmap
-  - --gpu-only
+  - --lowvram
   - --disable-smart-memory
   - --cache-none
+  - --fp8_e4m3fn-unet
   - --bf16-vae
+  - --disable-pinned-memory
+
+comfyui_disabled_custom_nodes:
+  - ComfyUI-AMDGPUMonitor
+
+comfyui_idle_restart_enabled: true
+comfyui_idle_restart_after_seconds: 300
+comfyui_idle_restart_check_interval: 60
+comfyui_idle_restart_queue_url: "http://127.0.0.1:{{ comfyui_host_port }}/queue"
 
 # Disabled by default. Entries run inside a short-lived toolbox image container.
 # Example:

--- a/ansible/roles/containers/comfyui/defaults/main.yml
+++ b/ansible/roles/containers/comfyui/defaults/main.yml
@@ -1,0 +1,98 @@
+---
+comfyui_enabled: true
+
+comfyui_service_name: comfyui-container
+comfyui_compose_project_name: comfyui
+comfyui_compose_service_name: comfyui
+comfyui_container_name: comfyui
+comfyui_image: >-
+  docker.io/kyuz0/amd-strix-halo-comfyui:latest@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2
+
+comfyui_base_dir: /opt/ai/containers/comfyui
+comfyui_models_dir: /opt/ai/models/comfyui
+comfyui_model_dirs:
+  - checkpoints
+  - diffusion_models
+  - text_encoders
+  - vae
+  - loras
+  - unet
+  - clip_vision
+  - latent_upscale_models
+comfyui_compose_file: "{{ comfyui_base_dir }}/docker-compose.yml"
+comfyui_seed_marker: "{{ comfyui_base_dir }}/.seeded"
+comfyui_seed_force: false
+
+comfyui_input_dir: "{{ comfyui_base_dir }}/input"
+comfyui_output_dir: "{{ comfyui_base_dir }}/output"
+comfyui_user_dir: "{{ comfyui_base_dir }}/user"
+comfyui_cache_dir: "{{ comfyui_base_dir }}/cache"
+comfyui_workflows_dir: "{{ comfyui_base_dir }}/workflows/api"
+
+comfyui_bind_address: "0.0.0.0"
+comfyui_host_port: 8188
+comfyui_container_port: 8000
+comfyui_listen_address: "0.0.0.0"
+
+comfyui_required_device_nodes:
+  - /dev/kfd
+  - /dev/dri/renderD128
+
+comfyui_devices:
+  - /dev/dri:/dev/dri
+  - /dev/kfd:/dev/kfd
+
+comfyui_group_add:
+  - "39"
+  - "105"
+
+comfyui_environment:
+  HOME: /root
+  HF_HOME: /root/comfy-models/.cache/huggingface
+  HF_HUB_ENABLE_HF_TRANSFER: "1"
+  TORCH_BLAS_PREFER_HIPBLASLT: "1"
+  TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL: "1"
+  PYTHONUNBUFFERED: "1"
+
+comfyui_cli_args:
+  - --listen
+  - "{{ comfyui_listen_address }}"
+  - --port
+  - "{{ comfyui_container_port }}"
+  - --output-directory
+  - /root/comfy-outputs
+  - --disable-mmap
+  - --gpu-only
+  - --disable-smart-memory
+  - --cache-none
+  - --bf16-vae
+
+# Disabled by default. Entries run inside a short-lived toolbox image container.
+# Example:
+# comfyui_model_downloads:
+#   - script: get_qwen_image.sh
+#     args: ["1", "bf16"]
+comfyui_model_download_profile_names: []
+comfyui_model_download_profiles:
+  qwen_image_lightning_bf16:
+    - script: get_qwen_image.sh
+      args:
+        - "1"
+        - bf16
+    - script: get_qwen_image.sh
+      args:
+        - "3"
+  qwen_image_edit_lightning_bf16:
+    - script: get_qwen_image.sh
+      args:
+        - "2"
+        - bf16
+    - script: get_qwen_image.sh
+      args:
+        - "4"
+comfyui_model_downloads: []
+comfyui_model_download_cleanup_cache: true
+
+comfyui_validate_health: true
+comfyui_health_retries: 60
+comfyui_health_delay: 2

--- a/ansible/roles/containers/comfyui/defaults/main.yml
+++ b/ansible/roles/containers/comfyui/defaults/main.yml
@@ -30,6 +30,11 @@ comfyui_cache_dir: "{{ comfyui_base_dir }}/cache"
 comfyui_workflows_dir: "{{ comfyui_base_dir }}/workflows/api"
 comfyui_idle_restart_script: /usr/local/sbin/comfyui-idle-restart
 comfyui_idle_restart_state_file: /run/comfyui-idle-restart.state
+comfyui_openai_api_base_dir: "{{ comfyui_base_dir }}/openai-api"
+comfyui_openai_api_source_dir: "{{ comfyui_openai_api_base_dir }}/src"
+comfyui_openai_api_config_dir: "{{ comfyui_openai_api_base_dir }}/config"
+comfyui_openai_api_workflows_dir: "{{ comfyui_openai_api_base_dir }}/workflows"
+comfyui_openai_api_config_file: "{{ comfyui_openai_api_config_dir }}/config.yaml"
 
 comfyui_bind_address: "0.0.0.0"
 comfyui_host_port: 8188
@@ -77,6 +82,26 @@ comfyui_idle_restart_enabled: true
 comfyui_idle_restart_after_seconds: 300
 comfyui_idle_restart_check_interval: 60
 comfyui_idle_restart_queue_url: "http://127.0.0.1:{{ comfyui_host_port }}/queue"
+comfyui_idle_restart_history_url: "http://127.0.0.1:{{ comfyui_host_port }}/history"
+
+comfyui_openai_api_enabled: true
+comfyui_openai_api_service_name: comfyui-openai-api
+comfyui_openai_api_container_name: comfyui-openai-api
+comfyui_openai_api_image: comfyui-openai-api:local
+comfyui_openai_api_repo: https://github.com/pnyxai/comfyui-openai-api.git
+comfyui_openai_api_version: HEAD
+comfyui_openai_api_force_rebuild: false
+comfyui_openai_api_bind_address: 127.0.0.1
+comfyui_openai_api_host_port: 10050
+comfyui_openai_api_container_port: 8080
+comfyui_openai_api_log_level: info
+comfyui_openai_api_client_id: comfyui-openai-api
+comfyui_openai_api_use_ws: false
+comfyui_openai_api_timeout_seconds: 900
+comfyui_openai_api_max_payload_size_mb: 20
+comfyui_openai_api_workflows:
+  - Qwen-Image-2512-BF16-4-Step-LoRA.json
+  - simple-sdxl-workflow.json
 
 # Disabled by default. Entries run inside a short-lived toolbox image container.
 # Example:

--- a/ansible/roles/containers/comfyui/handlers/main.yml
+++ b/ansible/roles/containers/comfyui/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Reload ComfyUI systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
+- name: Restart ComfyUI container
+  ansible.builtin.systemd_service:
+    name: "{{ comfyui_service_name }}"
+    state: restarted
+    daemon_reload: true
+  when:
+    - comfyui_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/containers/comfyui/handlers/main.yml
+++ b/ansible/roles/containers/comfyui/handlers/main.yml
@@ -11,3 +11,13 @@
   when:
     - comfyui_enabled | bool
     - not ansible_check_mode
+
+- name: Restart ComfyUI OpenAI API
+  ansible.builtin.systemd_service:
+    name: "{{ comfyui_openai_api_service_name }}"
+    state: restarted
+    daemon_reload: true
+  when:
+    - comfyui_enabled | bool
+    - comfyui_openai_api_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/containers/comfyui/tasks/main.yml
+++ b/ansible/roles/containers/comfyui/tasks/main.yml
@@ -108,6 +108,55 @@
     - Reload ComfyUI systemd
     - Restart ComfyUI container
 
+- name: Install ComfyUI idle restart helper
+  ansible.builtin.template:
+    src: comfyui-idle-restart.sh.j2
+    dest: "{{ comfyui_idle_restart_script }}"
+    owner: root
+    group: root
+    mode: "0755"
+  when: comfyui_idle_restart_enabled | bool
+
+- name: Install ComfyUI idle restart systemd unit
+  ansible.builtin.template:
+    src: comfyui-idle-restart.service.j2
+    dest: /etc/systemd/system/comfyui-idle-restart.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload ComfyUI systemd
+  when: comfyui_idle_restart_enabled | bool
+
+- name: Install ComfyUI idle restart systemd timer
+  ansible.builtin.template:
+    src: comfyui-idle-restart.timer.j2
+    dest: /etc/systemd/system/comfyui-idle-restart.timer
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload ComfyUI systemd
+  when: comfyui_idle_restart_enabled | bool
+
+- name: Remove ComfyUI idle restart systemd timer when disabled
+  ansible.builtin.file:
+    path: /etc/systemd/system/comfyui-idle-restart.timer
+    state: absent
+  notify: Reload ComfyUI systemd
+  when: not comfyui_idle_restart_enabled | bool
+
+- name: Remove ComfyUI idle restart systemd unit when disabled
+  ansible.builtin.file:
+    path: /etc/systemd/system/comfyui-idle-restart.service
+    state: absent
+  notify: Reload ComfyUI systemd
+  when: not comfyui_idle_restart_enabled | bool
+
+- name: Remove ComfyUI idle restart helper when disabled
+  ansible.builtin.file:
+    path: "{{ comfyui_idle_restart_script }}"
+    state: absent
+  when: not comfyui_idle_restart_enabled | bool
+
 - name: Ensure selected ComfyUI model download profiles exist
   ansible.builtin.assert:
     that:
@@ -190,6 +239,14 @@
     name: "{{ comfyui_service_name }}"
     enabled: "{{ comfyui_enabled | bool }}"
     state: "{{ 'started' if comfyui_enabled | bool else 'stopped' }}"
+    daemon_reload: true
+  when: not ansible_check_mode
+
+- name: Manage ComfyUI idle restart timer
+  ansible.builtin.systemd_service:
+    name: comfyui-idle-restart.timer
+    enabled: "{{ comfyui_enabled | bool and comfyui_idle_restart_enabled | bool }}"
+    state: "{{ 'started' if comfyui_enabled | bool and comfyui_idle_restart_enabled | bool else 'stopped' }}"
     daemon_reload: true
   when: not ansible_check_mode
 

--- a/ansible/roles/containers/comfyui/tasks/main.yml
+++ b/ansible/roles/containers/comfyui/tasks/main.yml
@@ -108,6 +108,90 @@
     - Reload ComfyUI systemd
     - Restart ComfyUI container
 
+- name: Ensure ComfyUI OpenAI API directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - "{{ comfyui_openai_api_base_dir }}"
+    - "{{ comfyui_openai_api_config_dir }}"
+    - "{{ comfyui_openai_api_workflows_dir }}"
+  when: comfyui_openai_api_enabled | bool
+
+- name: Clone ComfyUI OpenAI API source
+  ansible.builtin.git:
+    repo: "{{ comfyui_openai_api_repo }}"
+    dest: "{{ comfyui_openai_api_source_dir }}"
+    version: "{{ comfyui_openai_api_version }}"
+    depth: 1
+  register: comfyui_openai_api_source
+  when:
+    - comfyui_openai_api_enabled | bool
+    - not ansible_check_mode
+
+- name: Render ComfyUI OpenAI API config
+  ansible.builtin.template:
+    src: openai-api-config.yaml.j2
+    dest: "{{ comfyui_openai_api_config_file }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart ComfyUI OpenAI API
+  when: comfyui_openai_api_enabled | bool
+
+- name: Install ComfyUI OpenAI API workflows
+  ansible.builtin.copy:
+    src: "{{ comfyui_workflows_dir }}/{{ item }}"
+    dest: "{{ comfyui_openai_api_workflows_dir }}/{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+    remote_src: true
+  loop: "{{ comfyui_openai_api_workflows }}"
+  notify: Restart ComfyUI OpenAI API
+  when: comfyui_openai_api_enabled | bool
+
+- name: Build ComfyUI OpenAI API image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - build
+      - -f
+      - apps/rust/comfyui-openai-api/Dockerfile
+      - -t
+      - "{{ comfyui_openai_api_image }}"
+      - .
+    chdir: "{{ comfyui_openai_api_source_dir }}"
+  register: comfyui_openai_api_image_build
+  changed_when: true
+  notify: Restart ComfyUI OpenAI API
+  when:
+    - comfyui_openai_api_enabled | bool
+    - not ansible_check_mode
+    - comfyui_openai_api_force_rebuild | bool or comfyui_openai_api_source.changed
+
+- name: Install ComfyUI OpenAI API systemd unit
+  ansible.builtin.template:
+    src: comfyui-openai-api.service.j2
+    dest: "/etc/systemd/system/{{ comfyui_openai_api_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reload ComfyUI systemd
+    - Restart ComfyUI OpenAI API
+  when: comfyui_openai_api_enabled | bool
+
+- name: Remove ComfyUI OpenAI API systemd unit when disabled
+  ansible.builtin.file:
+    path: "/etc/systemd/system/{{ comfyui_openai_api_service_name }}.service"
+    state: absent
+  notify: Reload ComfyUI systemd
+  when: not comfyui_openai_api_enabled | bool
+
 - name: Install ComfyUI idle restart helper
   ansible.builtin.template:
     src: comfyui-idle-restart.sh.j2
@@ -247,6 +331,14 @@
     name: comfyui-idle-restart.timer
     enabled: "{{ comfyui_enabled | bool and comfyui_idle_restart_enabled | bool }}"
     state: "{{ 'started' if comfyui_enabled | bool and comfyui_idle_restart_enabled | bool else 'stopped' }}"
+    daemon_reload: true
+  when: not ansible_check_mode
+
+- name: Manage ComfyUI OpenAI API service
+  ansible.builtin.systemd_service:
+    name: "{{ comfyui_openai_api_service_name }}"
+    enabled: "{{ comfyui_enabled | bool and comfyui_openai_api_enabled | bool }}"
+    state: "{{ 'started' if comfyui_enabled | bool and comfyui_openai_api_enabled | bool else 'stopped' }}"
     daemon_reload: true
   when: not ansible_check_mode
 

--- a/ansible/roles/containers/comfyui/tasks/main.yml
+++ b/ansible/roles/containers/comfyui/tasks/main.yml
@@ -1,0 +1,208 @@
+---
+- name: Ensure ComfyUI container role supports this system
+  ansible.builtin.assert:
+    that:
+      - ansible_system == 'Linux'
+    fail_msg: "ComfyUI container role supports Linux only"
+
+- name: Ensure required GPU device nodes are present
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ comfyui_required_device_nodes }}"
+  register: comfyui_device_nodes
+
+- name: Assert required GPU device nodes are present
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists
+    fail_msg: "Required GPU device node {{ item.item }} is missing"
+  loop: "{{ comfyui_device_nodes.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Ensure ComfyUI persistent directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - "{{ comfyui_base_dir }}"
+    - "{{ comfyui_models_dir }}"
+    - "{{ comfyui_input_dir }}"
+    - "{{ comfyui_output_dir }}"
+    - "{{ comfyui_user_dir }}"
+    - "{{ comfyui_cache_dir }}"
+    - "{{ comfyui_workflows_dir }}"
+
+- name: Ensure ComfyUI model directories exist
+  ansible.builtin.file:
+    path: "{{ comfyui_models_dir }}/{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop: "{{ comfyui_model_dirs }}"
+
+- name: Verify Docker Compose is available
+  ansible.builtin.command: docker compose version
+  register: comfyui_docker_compose_version
+  changed_when: false
+
+- name: Pull ComfyUI toolbox image
+  ansible.builtin.command: docker pull {{ comfyui_image | quote }}
+  register: comfyui_image_pull
+  changed_when: >-
+    'Downloaded newer image' in comfyui_image_pull.stdout
+    or 'Pull complete' in comfyui_image_pull.stdout
+    or 'Status: Downloaded' in comfyui_image_pull.stdout
+  when: not ansible_check_mode
+
+- name: Check ComfyUI seed marker
+  ansible.builtin.stat:
+    path: "{{ comfyui_seed_marker }}"
+  register: comfyui_seed_marker_stat
+
+- name: Seed ComfyUI bundled state from image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - run
+      - --rm
+      - --entrypoint
+      - /bin/bash
+      - -v
+      - "{{ comfyui_base_dir }}:/seed"
+      - "{{ comfyui_image }}"
+      - -lc
+      - >-
+        set -euo pipefail;
+        mkdir -p /seed/input /seed/user /seed/workflows/api;
+        cp -an /opt/ComfyUI/input/. /seed/input/;
+        cp -an /opt/ComfyUI/user/. /seed/user/;
+        cp -an /opt/comfy-workflows/. /seed/workflows/api/;
+        date -u +%Y-%m-%dT%H:%M:%SZ > /seed/.seeded
+  changed_when: true
+  when:
+    - not ansible_check_mode
+    - comfyui_seed_force | bool or not comfyui_seed_marker_stat.stat.exists
+
+- name: Render ComfyUI Docker Compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ comfyui_compose_file }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart ComfyUI container
+
+- name: Install ComfyUI systemd unit
+  ansible.builtin.template:
+    src: comfyui-container.service.j2
+    dest: "/etc/systemd/system/{{ comfyui_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reload ComfyUI systemd
+    - Restart ComfyUI container
+
+- name: Ensure selected ComfyUI model download profiles exist
+  ansible.builtin.assert:
+    that:
+      - item in comfyui_model_download_profiles
+    fail_msg: "Unknown ComfyUI model download profile: {{ item }}"
+  loop: "{{ comfyui_model_download_profile_names }}"
+
+- name: Initialize selected ComfyUI model profile downloads
+  ansible.builtin.set_fact:
+    comfyui_model_profile_downloads: []
+
+- name: Resolve selected ComfyUI model profile downloads
+  ansible.builtin.set_fact:
+    comfyui_model_profile_downloads: >-
+      {{ comfyui_model_profile_downloads + comfyui_model_download_profiles[item] }}
+  loop: "{{ comfyui_model_download_profile_names }}"
+
+- name: Resolve effective ComfyUI model downloads
+  ansible.builtin.set_fact:
+    comfyui_model_downloads_effective: >-
+      {{ comfyui_model_profile_downloads + comfyui_model_downloads }}
+
+- name: Download optional ComfyUI models
+  ansible.builtin.command:
+    argv:
+      - docker
+      - run
+      - --rm
+      - -e
+      - HOME=/root
+      - -e
+      - "HF_HOME={{ comfyui_environment['HF_HOME'] }}"
+      - -e
+      - "HF_HUB_ENABLE_HF_TRANSFER={{ comfyui_environment['HF_HUB_ENABLE_HF_TRANSFER'] }}"
+      - -v
+      - "{{ comfyui_models_dir }}:/root/comfy-models"
+      - "{{ comfyui_image }}"
+      - /bin/bash
+      - -lc
+      - >-
+        bash /opt/{{ item.script }} {{ item.args | default([]) | map('quote') | join(' ') }}
+  loop: "{{ comfyui_model_downloads_effective }}"
+  register: comfyui_model_download
+  changed_when: "'Downloading' in comfyui_model_download.stdout"
+  when:
+    - not ansible_check_mode
+    - comfyui_model_downloads_effective | length > 0
+
+- name: Find ComfyUI model download staging directories
+  ansible.builtin.find:
+    paths: "{{ comfyui_models_dir }}"
+    patterns: ".hf_stage_*"
+    file_type: directory
+    recurse: false
+  register: comfyui_model_download_staging_dirs
+  when:
+    - not ansible_check_mode
+    - comfyui_model_download_cleanup_cache | bool
+    - comfyui_model_downloads_effective | length > 0
+
+- name: Remove ComfyUI model download cache and staging directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: >-
+    {{
+      [comfyui_models_dir + '/.cache/huggingface']
+      + (comfyui_model_download_staging_dirs.files | default([]) | map(attribute='path') | list)
+    }}
+  when:
+    - not ansible_check_mode
+    - comfyui_model_download_cleanup_cache | bool
+    - comfyui_model_downloads_effective | length > 0
+
+- name: Flush ComfyUI handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Manage ComfyUI service
+  ansible.builtin.systemd_service:
+    name: "{{ comfyui_service_name }}"
+    enabled: "{{ comfyui_enabled | bool }}"
+    state: "{{ 'started' if comfyui_enabled | bool else 'stopped' }}"
+    daemon_reload: true
+  when: not ansible_check_mode
+
+- name: Validate ComfyUI health endpoint
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ comfyui_host_port }}/system_stats"
+    status_code: 200
+    return_content: true
+  register: comfyui_health
+  until: comfyui_health.status == 200
+  retries: "{{ comfyui_health_retries }}"
+  delay: "{{ comfyui_health_delay }}"
+  when:
+    - comfyui_enabled | bool
+    - comfyui_validate_health | bool
+    - not ansible_check_mode

--- a/ansible/roles/containers/comfyui/templates/comfyui-container.service.j2
+++ b/ansible/roles/containers/comfyui/templates/comfyui-container.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=ComfyUI container
+Wants=network-online.target
+After=network-online.target docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory={{ comfyui_base_dir }}
+ExecStart=/usr/bin/docker compose -p {{ comfyui_compose_project_name }} -f {{ comfyui_compose_file }} up -d --remove-orphans
+ExecStop=/usr/bin/docker compose -p {{ comfyui_compose_project_name }} -f {{ comfyui_compose_file }} down
+TimeoutStartSec=0
+TimeoutStopSec=120s
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/containers/comfyui/templates/comfyui-idle-restart.service.j2
+++ b/ansible/roles/containers/comfyui/templates/comfyui-idle-restart.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Restart ComfyUI after idle generation
+Wants={{ comfyui_service_name }}.service
+After={{ comfyui_service_name }}.service docker.service
+
+[Service]
+Type=oneshot
+ExecStart={{ comfyui_idle_restart_script }}

--- a/ansible/roles/containers/comfyui/templates/comfyui-idle-restart.sh.j2
+++ b/ansible/roles/containers/comfyui/templates/comfyui-idle-restart.sh.j2
@@ -4,6 +4,7 @@ set -euo pipefail
 container_name={{ comfyui_container_name | quote }}
 service_name={{ comfyui_service_name | quote }}
 queue_url={{ comfyui_idle_restart_queue_url | quote }}
+history_url={{ comfyui_idle_restart_history_url | quote }}
 state_file={{ comfyui_idle_restart_state_file | quote }}
 idle_after={{ comfyui_idle_restart_after_seconds | int }}
 
@@ -18,32 +19,64 @@ if [[ "$running" != "true" ]]; then
 fi
 
 queue_json=$(curl --fail --silent --max-time 5 "$queue_url" 2>/dev/null || true)
-if [[ -z "$queue_json" ]]; then
+history_json=$(curl --fail --silent --max-time 5 "$history_url" 2>/dev/null || true)
+if [[ -z "$queue_json" || -z "$history_json" ]]; then
   exit 0
 fi
 
-if ! QUEUE_JSON="$queue_json" python3 - <<'PY'
+state_json=$(QUEUE_JSON="$queue_json" HISTORY_JSON="$history_json" python3 - <<'PY'
 import json
 import os
 import sys
+import time
 
 try:
     queue = json.loads(os.environ["QUEUE_JSON"])
+    history = json.loads(os.environ["HISTORY_JSON"])
 except Exception:
     sys.exit(1)
 
 running = queue.get("queue_running") or []
 pending = queue.get("queue_pending") or []
-sys.exit(0 if not running and not pending else 1)
-PY
-then
-  exit 0
-fi
+if running or pending:
+    sys.exit(1)
 
-started_at=$(docker inspect "$container_name" --format '{{ '{{' }}.State.StartedAt{{ '}}' }}')
-last_prompt_epoch=$(docker logs --since "$started_at" --timestamps "$container_name" 2>&1 \
-  | awk '/Prompt executed in/ { ts = substr($1, 1, 19); gsub("T", " ", ts); last = ts } END { if (last != "") print last }' \
-  | xargs -r -I{} date -u -d '{}' +%s)
+latest_ts = 0.0
+for item in history.values():
+    status = item.get("status") or {}
+    completed = status.get("completed") is True or status.get("status_str") == "success"
+    if not completed:
+        continue
+    messages = status.get("messages") or []
+    for message in messages:
+        if not isinstance(message, (list, tuple)) or len(message) < 2:
+            continue
+        payload = message[1]
+        if not isinstance(payload, dict):
+            continue
+        ts = payload.get("timestamp")
+        if isinstance(ts, (int, float)):
+            latest_ts = max(latest_ts, ts)
+
+if not latest_ts:
+    sys.exit(1)
+
+print(json.dumps({"last_prompt_epoch": int(latest_ts), "now": int(time.time())}))
+PY
+) || exit 0
+
+last_prompt_epoch=$(STATE_JSON="$state_json" python3 - <<'PY'
+import json
+import os
+print(json.loads(os.environ["STATE_JSON"])["last_prompt_epoch"])
+PY
+)
+now=$(STATE_JSON="$state_json" python3 - <<'PY'
+import json
+import os
+print(json.loads(os.environ["STATE_JSON"])["now"])
+PY
+)
 
 if [[ -z "$last_prompt_epoch" ]]; then
   exit 0
@@ -60,7 +93,6 @@ if [[ "$last_restarted_container_id" == "$container_id" && "$last_restarted_prom
   exit 0
 fi
 
-now=$(date -u +%s)
 idle_for=$((now - last_prompt_epoch))
 if (( idle_for < idle_after )); then
   exit 0

--- a/ansible/roles/containers/comfyui/templates/comfyui-idle-restart.sh.j2
+++ b/ansible/roles/containers/comfyui/templates/comfyui-idle-restart.sh.j2
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+container_name={{ comfyui_container_name | quote }}
+service_name={{ comfyui_service_name | quote }}
+queue_url={{ comfyui_idle_restart_queue_url | quote }}
+state_file={{ comfyui_idle_restart_state_file | quote }}
+idle_after={{ comfyui_idle_restart_after_seconds | int }}
+
+container_id=$(docker inspect "$container_name" --format '{{ '{{' }}.Id{{ '}}' }}' 2>/dev/null || true)
+if [[ -z "$container_id" ]]; then
+  exit 0
+fi
+
+running=$(docker inspect "$container_name" --format '{{ '{{' }}.State.Running{{ '}}' }}' 2>/dev/null || true)
+if [[ "$running" != "true" ]]; then
+  exit 0
+fi
+
+queue_json=$(curl --fail --silent --max-time 5 "$queue_url" 2>/dev/null || true)
+if [[ -z "$queue_json" ]]; then
+  exit 0
+fi
+
+if ! QUEUE_JSON="$queue_json" python3 - <<'PY'
+import json
+import os
+import sys
+
+try:
+    queue = json.loads(os.environ["QUEUE_JSON"])
+except Exception:
+    sys.exit(1)
+
+running = queue.get("queue_running") or []
+pending = queue.get("queue_pending") or []
+sys.exit(0 if not running and not pending else 1)
+PY
+then
+  exit 0
+fi
+
+started_at=$(docker inspect "$container_name" --format '{{ '{{' }}.State.StartedAt{{ '}}' }}')
+last_prompt_epoch=$(docker logs --since "$started_at" --timestamps "$container_name" 2>&1 \
+  | awk '/Prompt executed in/ { ts = substr($1, 1, 19); gsub("T", " ", ts); last = ts } END { if (last != "") print last }' \
+  | xargs -r -I{} date -u -d '{}' +%s)
+
+if [[ -z "$last_prompt_epoch" ]]; then
+  exit 0
+fi
+
+last_restarted_container_id=""
+last_restarted_prompt_epoch=0
+if [[ -r "$state_file" ]]; then
+  # shellcheck disable=SC1090
+  source "$state_file"
+fi
+
+if [[ "$last_restarted_container_id" == "$container_id" && "$last_restarted_prompt_epoch" -ge "$last_prompt_epoch" ]]; then
+  exit 0
+fi
+
+now=$(date -u +%s)
+idle_for=$((now - last_prompt_epoch))
+if (( idle_for < idle_after )); then
+  exit 0
+fi
+
+systemctl restart "$service_name"
+install -d -m 0755 "$(dirname "$state_file")"
+cat > "$state_file" <<EOF
+last_restarted_container_id='$container_id'
+last_restarted_prompt_epoch=$last_prompt_epoch
+EOF

--- a/ansible/roles/containers/comfyui/templates/comfyui-idle-restart.timer.j2
+++ b/ansible/roles/containers/comfyui/templates/comfyui-idle-restart.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Check ComfyUI idle generation restart
+
+[Timer]
+OnBootSec={{ comfyui_idle_restart_check_interval | int }}s
+OnUnitActiveSec={{ comfyui_idle_restart_check_interval | int }}s
+AccuracySec=10s
+Unit=comfyui-idle-restart.service
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/containers/comfyui/templates/comfyui-openai-api.service.j2
+++ b/ansible/roles/containers/comfyui/templates/comfyui-openai-api.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=ComfyUI OpenAI-compatible image API proxy
+Wants={{ comfyui_service_name }}.service
+After={{ comfyui_service_name }}.service docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/docker run -d --rm --name {{ comfyui_openai_api_container_name }} --add-host host.docker.internal:host-gateway -p {{ comfyui_openai_api_bind_address }}:{{ comfyui_openai_api_host_port }}:{{ comfyui_openai_api_container_port }} -e CONFIG_PATH=/app/config/config.yaml -v {{ comfyui_openai_api_config_dir }}:/app/config:ro -v {{ comfyui_openai_api_workflows_dir }}:/app/workflows:ro {{ comfyui_openai_api_image }}
+ExecStop=/usr/bin/docker stop {{ comfyui_openai_api_container_name }}
+TimeoutStartSec=0
+TimeoutStopSec=30s
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/containers/comfyui/templates/docker-compose.yml.j2
+++ b/ansible/roles/containers/comfyui/templates/docker-compose.yml.j2
@@ -1,0 +1,36 @@
+services:
+  {{ comfyui_compose_service_name }}:
+    image: "{{ comfyui_image }}"
+    container_name: "{{ comfyui_container_name }}"
+    restart: unless-stopped
+    security_opt:
+      - seccomp=unconfined
+    group_add:
+{% for group in comfyui_group_add %}
+      - "{{ group }}"
+{% endfor %}
+    devices:
+{% for device in comfyui_devices %}
+      - "{{ device }}"
+{% endfor %}
+    ports:
+      - "{{ comfyui_bind_address }}:{{ comfyui_host_port }}:{{ comfyui_container_port }}"
+    environment:
+{% for name, value in comfyui_environment.items() %}
+      {{ name }}: "{{ value }}"
+{% endfor %}
+    volumes:
+      - "{{ comfyui_models_dir }}:/root/comfy-models"
+      - "{{ comfyui_output_dir }}:/root/comfy-outputs"
+      - "{{ comfyui_cache_dir }}:/root/.cache"
+      - "{{ comfyui_input_dir }}:/opt/ComfyUI/input"
+      - "{{ comfyui_user_dir }}:/opt/ComfyUI/user"
+      - "{{ comfyui_workflows_dir }}:/opt/comfy-workflows"
+    command:
+      - /bin/bash
+      - -lc
+      - >-
+        source /etc/profile.d/01-rocm-envs.sh &&
+        /opt/set_extra_paths.sh &&
+        cd /opt/ComfyUI &&
+        exec python main.py {{ comfyui_cli_args | map('quote') | join(' ') }}

--- a/ansible/roles/containers/comfyui/templates/docker-compose.yml.j2
+++ b/ansible/roles/containers/comfyui/templates/docker-compose.yml.j2
@@ -32,5 +32,8 @@ services:
       - >-
         source /etc/profile.d/01-rocm-envs.sh &&
         /opt/set_extra_paths.sh &&
+{% for custom_node in comfyui_disabled_custom_nodes %}
+        if [ -d {{ ('/opt/ComfyUI/custom_nodes/' ~ custom_node) | quote }} ]; then rm -rf {{ ('/opt/ComfyUI/custom_nodes/' ~ custom_node ~ '.disabled') | quote }} && mv {{ ('/opt/ComfyUI/custom_nodes/' ~ custom_node) | quote }} {{ ('/opt/ComfyUI/custom_nodes/' ~ custom_node ~ '.disabled') | quote }}; fi &&
+{% endfor %}
         cd /opt/ComfyUI &&
         exec python main.py {{ comfyui_cli_args | map('quote') | join(' ') }}

--- a/ansible/roles/containers/comfyui/templates/openai-api-config.yaml.j2
+++ b/ansible/roles/containers/comfyui/templates/openai-api-config.yaml.j2
@@ -1,0 +1,14 @@
+---
+log_level: {{ comfyui_openai_api_log_level | to_json }}
+server:
+  host: "0.0.0.0"
+  port: {{ comfyui_openai_api_container_port }}
+comfyui_backend:
+  host: "host.docker.internal"
+  port: {{ comfyui_host_port }}
+  workflows_folder: "/app/workflows"
+  client_id: {{ comfyui_openai_api_client_id | to_json }}
+  use_ws: {{ comfyui_openai_api_use_ws | bool | to_json }}
+routing:
+  timeout_seconds: {{ comfyui_openai_api_timeout_seconds }}
+  max_payload_size_mb: {{ comfyui_openai_api_max_payload_size_mb }}

--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -71,6 +71,20 @@ data:
           tags:
             - llama-swap
 
+      - model_name: comfyui/*
+        model_info:
+          mode: image_generation
+        litellm_params:
+          model: openai/*
+          custom_llm_provider: openai
+          litellm_credential_name: llama-swap
+          input_cost_per_pixel: 0.0
+          output_cost_per_pixel: 0.0
+          tags:
+            - llama-swap
+            - comfyui
+            - image
+
       - model_name: hosted_vllm/*
         model_info:
           mode: chat


### PR DESCRIPTION
Summary
- Add a nested containers/comfyui Ansible role for the Strix Halo optimized ComfyUI toolbox image.
- Deploy ComfyUI with Docker Compose/systemd, ROCm GPU devices, and Strix Halo runtime flags.
- Persist models, outputs, cache, workflows, input, and user state under /opt/ai.
- Auto-create standard ComfyUI model directories including checkpoints.
- Enable BF16 Qwen Image and Qwen Image Edit Lightning download profiles for llm_lxc; video model profiles are not enabled.

Testing
- ansible-playbook playbooks/llm_lxc.yml --syntax-check --limit ct-llm
- ansible-lint playbooks/llm_lxc.yml roles/containers/comfyui inventories/group_vars/llm_lxc.yml
- ansible-inventory --host ct-llm