### PR TITLE
feat(litellm): add Z.AI Coding Plan models

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -122,6 +122,95 @@ data:
           input_cost_per_token: 0.0
           output_cost_per_token: 0.0
 
+      - model_name: zai-coding/glm-5.1
+        model_info:
+          mode: chat
+          max_input_tokens: 200000
+          max_output_tokens: 128000
+          supports_function_calling: true
+          supports_reasoning: true
+          supports_tool_choice: true
+        litellm_params:
+          model: zai/glm-5.1
+          custom_llm_provider: zai
+          litellm_credential_name: zai-coding
+          input_cost_per_token: 0.0000014
+          output_cost_per_token: 0.0000044
+          tags:
+            - zai
+            - coding-plan
+
+      - model_name: zai-coding/glm-5
+        model_info:
+          mode: chat
+          max_input_tokens: 200000
+          max_output_tokens: 128000
+          supports_function_calling: true
+          supports_reasoning: true
+          supports_tool_choice: true
+        litellm_params:
+          model: zai/glm-5
+          custom_llm_provider: zai
+          litellm_credential_name: zai-coding
+          input_cost_per_token: 0.000001
+          output_cost_per_token: 0.0000032
+          tags:
+            - zai
+            - coding-plan
+
+      - model_name: zai-coding/glm-5-turbo
+        model_info:
+          mode: chat
+          max_input_tokens: 200000
+          max_output_tokens: 128000
+          supports_function_calling: true
+          supports_reasoning: true
+          supports_tool_choice: true
+        litellm_params:
+          model: zai/glm-5-turbo
+          custom_llm_provider: zai
+          litellm_credential_name: zai-coding
+          input_cost_per_token: 0.0000012
+          output_cost_per_token: 0.000004
+          tags:
+            - zai
+            - coding-plan
+
+      - model_name: zai-coding/glm-4.7
+        model_info:
+          mode: chat
+          max_input_tokens: 200000
+          max_output_tokens: 128000
+          supports_function_calling: true
+          supports_reasoning: true
+          supports_tool_choice: true
+        litellm_params:
+          model: zai/glm-4.7
+          custom_llm_provider: zai
+          litellm_credential_name: zai-coding
+          input_cost_per_token: 0.0000006
+          output_cost_per_token: 0.0000022
+          tags:
+            - zai
+            - coding-plan
+
+      - model_name: zai-coding/glm-4.5-air
+        model_info:
+          mode: chat
+          max_input_tokens: 128000
+          max_output_tokens: 96000
+          supports_function_calling: true
+          supports_tool_choice: true
+        litellm_params:
+          model: zai/glm-4.5-air
+          custom_llm_provider: zai
+          litellm_credential_name: zai-coding
+          input_cost_per_token: 0.0000002
+          output_cost_per_token: 0.0000011
+          tags:
+            - zai
+            - coding-plan
+
     credential_list:
       - credential_name: llama-swap
         credential_values:
@@ -135,6 +224,13 @@ data:
           api_key: os.environ/LITELLM_CREDENTIAL_OPENROUTER_API_KEY
         credential_info:
           custom_llm_provider: openrouter
+
+      - credential_name: zai-coding
+        credential_values:
+          api_base: os.environ/LITELLM_CREDENTIAL_ZAI_CODING_API_BASE
+          api_key: os.environ/LITELLM_CREDENTIAL_ZAI_CODING_API_KEY
+        credential_info:
+          custom_llm_provider: zai
 
     litellm_settings:
       callbacks:
@@ -710,6 +806,102 @@ data:
             yield f"{BACKEND_MODEL_PREFIX}{slug}", deepcopy(info)
             yield f"{PUBLIC_MODEL_PREFIX}{slug}", deepcopy(info)
 
+  zai_coding_catalog.py: |
+    from copy import deepcopy
+
+    import litellm
+
+
+    ZAI_CODING_MODELS = {
+        "glm-5.1": {
+            "context_window": 200000,
+            "max_output_tokens": 128000,
+            "input_cost_per_token": 0.0000014,
+            "output_cost_per_token": 0.0000044,
+            "supports_reasoning": True,
+        },
+        "glm-5": {
+            "context_window": 200000,
+            "max_output_tokens": 128000,
+            "input_cost_per_token": 0.000001,
+            "output_cost_per_token": 0.0000032,
+            "supports_reasoning": True,
+        },
+        "glm-5-turbo": {
+            "context_window": 200000,
+            "max_output_tokens": 128000,
+            "input_cost_per_token": 0.0000012,
+            "output_cost_per_token": 0.000004,
+            "supports_reasoning": True,
+        },
+        "glm-4.7": {
+            "context_window": 200000,
+            "max_output_tokens": 128000,
+            "input_cost_per_token": 0.0000006,
+            "output_cost_per_token": 0.0000022,
+            "supports_reasoning": True,
+        },
+        "glm-4.5-air": {
+            "context_window": 128000,
+            "max_output_tokens": 96000,
+            "input_cost_per_token": 0.0000002,
+            "output_cost_per_token": 0.0000011,
+            "supports_reasoning": False,
+        },
+    }
+
+
+    def _metadata_for(slug):
+        info = ZAI_CODING_MODELS[slug]
+        return {
+            "litellm_provider": "zai",
+            "mode": "chat",
+            "context_window": info["context_window"],
+            "max_input_tokens": info["context_window"],
+            "max_output_tokens": info["max_output_tokens"],
+            "max_tokens": info["max_output_tokens"],
+            "supports_function_calling": True,
+            "supports_tool_choice": True,
+            "supports_reasoning": info["supports_reasoning"],
+            "input_cost_per_token": info["input_cost_per_token"],
+            "output_cost_per_token": info["output_cost_per_token"],
+            "source": "https://docs.z.ai/guides/overview/pricing",
+        }
+
+
+    def iter_model_cost_entries():
+        for slug in ZAI_CODING_MODELS:
+            metadata = _metadata_for(slug)
+            yield f"zai/{slug}", deepcopy(metadata)
+            yield f"zai-coding/{slug}", deepcopy(metadata)
+
+
+    def patch_zai_coding_model_catalog():
+        updated_model_cost = False
+        for model_name, catalog_info in iter_model_cost_entries():
+            existing_info = dict(litellm.model_cost.get(model_name, {}) or {})
+            existing_info.update(catalog_info)
+            if litellm.model_cost.get(model_name) != existing_info:
+                updated_model_cost = True
+            litellm.model_cost[model_name] = existing_info
+
+        provider_models = litellm.models_by_provider.setdefault("zai", [])
+        for slug in ZAI_CODING_MODELS:
+            if slug not in provider_models:
+                if hasattr(provider_models, "add"):
+                    provider_models.add(slug)
+                else:
+                    provider_models.append(slug)
+
+        if updated_model_cost:
+            from litellm.utils import _invalidate_model_cost_lowercase_map
+
+            _invalidate_model_cost_lowercase_map()
+
+
+    def worker_startup_hook():
+        patch_zai_coding_model_catalog()
+
   litellm_startup.py: |
     import os
     import sys
@@ -723,6 +915,7 @@ data:
     import chatgpt_codex_catalog
     import chatgpt_responses_streaming_patch
     import vllm_model_discovery
+    import zai_coding_catalog
 
 
     _SYSTEM_INSTRUCTION_ROLES = {"system", "developer"}
@@ -1102,11 +1295,13 @@ data:
         @proxy_server.app.get(public_path, include_in_schema=False)
         async def public_litellm_model_cost_map():
             patch_chatgpt_codex_model_catalog()
+            zai_coding_catalog.worker_startup_hook()
             return litellm.model_cost
 
 
     def worker_startup_hook():
         patch_chatgpt_codex_model_catalog()
+        zai_coding_catalog.worker_startup_hook()
         patch_chatgpt_codex_reasoning_validator()
         patch_chatgpt_responses_request_transform()
         patch_virtual_key_model_discovery_routes()

--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -224,6 +224,9 @@ spec:
               - path: /etc/litellm/chatgpt_codex_catalog.py
                 subPath: chatgpt_codex_catalog.py
                 readOnly: true
+              - path: /etc/litellm/zai_coding_catalog.py
+                subPath: zai_coding_catalog.py
+                readOnly: true
               - path: /etc/litellm/litellm_startup.py
                 subPath: litellm_startup.py
                 readOnly: true

--- a/kubernetes/apps/apps/ai/litellm/litellm-credentials.sops.yaml
+++ b/kubernetes/apps/apps/ai/litellm/litellm-credentials.sops.yaml
@@ -5,21 +5,23 @@ metadata:
     namespace: ai
 type: Opaque
 stringData:
-    LITELLM_CREDENTIAL_LLAMA_SWAP_API_BASE: ENC[AES256_GCM,data:AWtd0LPlq5rfrLGcIMzvMMjyPZ20nxfXaOpkRw==,iv:iKaYuZ698WqbQ/TTtjxVy8ni5RqRA3Q1h+6saUcpwTc=,tag:fv5wqdUHkBa0t4+iagNp9A==,type:str]
-    LITELLM_CREDENTIAL_LLAMA_SWAP_API_KEY: ENC[AES256_GCM,data:jjtyk3fcxXE5PovkCLh+ShGjw3XTOyAWI6VjCTWHnVbfzKdN5N4Lsg7sU0YmBzXonuwzf6xg30LETjgUmlLN7g==,iv:fQwpny3beNolx0gBa/FP20HszSGgacuPPdKwU7ov19g=,tag:D3k8GVnxYjINC4ZHYHcQiA==,type:str]
-    LITELLM_CREDENTIAL_OPENROUTER_API_KEY: ENC[AES256_GCM,data:7sHOFt3T6ZotFDyTVvcpfWFGz0ISlXHOMUxWPqTq8qeRzi7yUdygqwlM/ZQ6cyyIL3xzzDI8O8Pcl3irbSvv8HACDcTSIyevZQ==,iv:W0YVgMz0ExiM3o4+zH8IhB5N2gX+ZM2B9/4EfbsgZtA=,tag:oMxKA+i1m0jqRFxkz101Tw==,type:str]
+    LITELLM_CREDENTIAL_LLAMA_SWAP_API_BASE: ENC[AES256_GCM,data:tfy5Hs6Yvf71r5JkNxRF46YeL8txVrlOc/IMUw==,iv:TTo8BkH0XNGWCWfbyjC1R9vX44Ot5jWjnpqO9VSvgUA=,tag:6T8xuwVAwqaQ36aeBoubcQ==,type:str]
+    LITELLM_CREDENTIAL_LLAMA_SWAP_API_KEY: ENC[AES256_GCM,data:XLkZ0eA2ajnUhGNOE822FalxGSOfF0nKC2NG32nS1naEp60GjBiD6CuMa1Xc/5B1fkGPYe9WGXhV7hJ2XM4aNA==,iv:wSeQPMJafYE2OjTnve6qkGWDxKfoXuFij9jAbRPPDfw=,tag:JH/jQlUX1UsWMQh3iRXweA==,type:str]
+    LITELLM_CREDENTIAL_OPENROUTER_API_KEY: ENC[AES256_GCM,data:kbDsQjWmtLRxwAevQ9py9HbqFFTW75zkHgD78HBi+QTiS1V3H3YwFGrfRC1O8yfX2wyZtbyE7FR1EzYsXbDRf0pveFnnAWw4jg==,iv:bj30Ci/4ImafVMXCNsmxIgbw+npOglBrR5CnUQMvz/c=,tag:aKotPHVufaml+HG7oeSMGA==,type:str]
+    LITELLM_CREDENTIAL_ZAI_CODING_API_BASE: ENC[AES256_GCM,data:2cc5I04DRm230NWh2utUE8kT8rf0+VFRQNeTigw4bsc1Tm4=,iv:uJjIUbqXAk67hPeIoA4LD2ojsK+85T3ZugXpGCn2gKs=,tag:72E6uNkenWLfJwPKz5gHIw==,type:str]
+    LITELLM_CREDENTIAL_ZAI_CODING_API_KEY: ENC[AES256_GCM,data:SObipN6WuY9Lulh0d85eFit48hsf57hjsb2p0uvX3PHAKXuIEqAj15EZmnoDWZe9lQ==,iv:XDYx0Ulepo7BoXsjSOBfcRnmW7Zjdr9UnMbU/NI8RbU=,tag:B3W7+0vVZ5txx6EkYkIuOQ==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmNTBPbW51WGF0dURZNUF2
-            SGwwM1A2UzJjTU95eUZtSUZFUlFvSC9jZEVVCkNQUW1xUTBvZk9KZ2Fxc0kzdnpo
-            RGhwMldTbXg1eXJtSFErNCsxVkxJTDgKLS0tIDdUeDZINE9sTVd4UUtuSUVLcUdD
-            WkZWb0JqVHk5ZGFMciszTHN2N2dvclUKrQ6qCE2NTER4y33wGQWLOv1pzNkAzP4R
-            +nGaaJSZwUMdw728mPrba/rPO4ZAhMvryILJkAJz6InOUjWOD0CTAQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0eExBOCtBNWR1ZlIyenpM
+            ZmY4blFYblFna2NqSmtmL0RlMjlSNVpFKzFBCnJVV0F6OGh2dU5paVcyRDJhK1NI
+            Z0dZOE40UnVWVklQSTJiRnpXTHNORjgKLS0tIGI4SXdpUDhuRWR3RFpxMGJHZHVI
+            bnB3UlByanRsUlBxVkQ1aUxJMnBSSmMK7nKrlYfxaTmjyRmPhLXtQLe91YYbM6+O
+            sTrR0bojoH1UrCuWTBbzqoO4fcjjg88PxG9nBl1B8P5BVeAi4BXu5A==
             -----END AGE ENCRYPTED FILE-----
           recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-24T00:01:49Z"
-    mac: ENC[AES256_GCM,data:DaTJ77K+KQaPnao3XvvJQ7eUuzpAhIHlnTbtHifVVMTnhDCXmXtdSOD6QMUNjSOXqhW6p3rcI1Rfbgf2bGqnQN98Slfzuo8SKWBucoT9gxu3pDX0ohowlEU0dceozQTnYLIdL4GJsk9piYlPtIlqydsR99peH6xtcSj20ergsng=,iv:BjsTzp2kIA3D0yeKo3GDoC1QsuVd6IC0RhM1YJ2fjds=,tag:b937NrCvcP33hVnhv4mscQ==,type:str]
+    lastmodified: "2026-06-01T20:03:46Z"
+    mac: ENC[AES256_GCM,data:qGipGPYbbbLAlIh+9or4a37BCch17RBHPtygmWIBkRkkyRlfKcCd6Gxv1FY/n9LX5VBmxrZXta9wy5pBNNoLwtJc/BUQpktO72r6ZrzrDRjORnfFnBW3B0IONZWB3le3uo0NbokbouYN9c2T7IVoDFs4iWqgkjwlzRwr4n1CqAQ=,iv:EoVdARlxJrz4sg+eJCjWhwR45IgBgMhBWZ9PA+2NfqE=,tag:sN33OSk4OOhicIrNfbDs8g==,type:str]
     version: 3.13.1


### PR DESCRIPTION
## Summary
- add Z.AI Coding Plan model entries to LiteLLM with public API price estimates for tracking
- wire Z.AI Coding Plan credentials from the encrypted litellm credentials secret
- add a LiteLLM startup catalog patch for Z.AI Coding model metadata

## Validation
- pre-commit run --files kubernetes/apps/apps/ai/litellm/configmap.yaml kubernetes/apps/apps/ai/litellm/helmrelease.yaml kubernetes/apps/apps/ai/litellm/litellm-credentials.sops.yaml
- kubectl kustomize kubernetes/apps/apps/ai/litellm
- sops decrypt/key check for Z.AI Coding API base/key