### PR TITLE
fix(litellm): allow Z.AI max completion tokens

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -939,8 +939,12 @@ data:
             # Z.AI GLM models support native `thinking`, but not OpenAI-style
             # `reasoning_effort`. Keep `thinking` accepted even while the public
             # LiteLLM metadata hides generic reasoning support from clients.
-            if _zai_coding_slug(model) is not None and "thinking" not in supported_params:
-                supported_params.append("thinking")
+            # OpenAI-compatible clients may also send max_completion_tokens;
+            # Z.AI accepts it, but LiteLLM's ZAI provider does not list it by default.
+            if _zai_coding_slug(model) is not None:
+                for param in ("thinking", "max_completion_tokens"):
+                    if param not in supported_params:
+                        supported_params.append(param)
             return supported_params
 
         get_supported_openai_params._zai_coding_supported_params_patch = True


### PR DESCRIPTION
## Summary
- allow max_completion_tokens for Z.AI Coding Plan models in the LiteLLM ZAI provider patch
- keep native Z.AI thinking allowed while still hiding generic OpenAI reasoning metadata

## Validation
- python YAML parse and embedded startup module compile check
- kubectl kustomize kubernetes/apps/apps/ai/litellm
- pre-commit run --files kubernetes/apps/apps/ai/litellm/configmap.yaml
- live reproduction showed LiteLLM accepts max_completion_tokens when allowed_openai_params includes it