### PR TITLE
chore(backups): temporarily disable s3 backups

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/ai/litellm/cnpg-cluster.yaml
@@ -23,7 +23,7 @@ spec:
     parameters:
       wal_level: "replica"
       archive_timeout: "43200" # Wait 12 hours before shipping WALs when no activity
-      archive_mode: "on"
+      archive_mode: "off"
 
   bootstrap:
     initdb:
@@ -31,28 +31,6 @@ spec:
       owner: litellm
       secret:
         name: litellm-db-secrets
-
-  backup:
-    barmanObjectStore:
-      wal:
-        compression: gzip
-      data:
-        compression: gzip
-
-      s3Credentials:
-        accessKeyId:
-          name: cnpg-backup-s3
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: cnpg-backup-s3
-          key: ACCESS_SECRET_KEY
-        region:
-          name: cnpg-backup-s3
-          key: AWS_DEFAULT_REGION
-      destinationPath: "s3://cloudnative-pg/litellm"
-      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
-      serverName: "litellm-pg-v1"
-    retentionPolicy: "14d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -61,6 +39,7 @@ metadata:
   namespace: ai
 spec:
   schedule: "0 0 0 * * *"  # Daily at midnight
+  suspend: true
   backupOwnerReference: self
   cluster:
     name: litellm-pg

--- a/kubernetes/apps/apps/automation/n8n/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/automation/n8n/cnpg-cluster.yaml
@@ -21,7 +21,7 @@ spec:
     parameters:
       wal_level: "replica"
       archive_timeout: "43200" # Wait 12 hours before shipping WALs when no activity
-      archive_mode: "on"
+      archive_mode: "off"
 
   bootstrap:
     initdb:
@@ -29,28 +29,6 @@ spec:
       owner: n8n
       secret:
         name: n8n-db-secrets
-
-  backup:
-    barmanObjectStore:
-      wal:
-        compression: gzip
-      data:
-        compression: gzip
-
-      s3Credentials:
-        accessKeyId:
-          name: cnpg-backup-s3
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: cnpg-backup-s3
-          key: ACCESS_SECRET_KEY
-        region:
-          name: cnpg-backup-s3
-          key: AWS_DEFAULT_REGION
-      destinationPath: "s3://cloudnative-pg/n8n"
-      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
-      serverName: "n8n-pg-v1"
-    retentionPolicy: "14d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -59,6 +37,7 @@ metadata:
   namespace: automation
 spec:
   schedule: "0 0 0 * * *"  # Daily at midnight
+  suspend: true
   backupOwnerReference: self
   cluster:
     name: n8n-pg

--- a/kubernetes/apps/apps/immich/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/immich/cnpg-cluster.yaml
@@ -23,7 +23,7 @@ spec:
     parameters:
       wal_level: "replica"
       archive_timeout: "43200" # Wait 12 hours before shipping WALs when no activity
-      archive_mode: "on"
+      archive_mode: "off"
     shared_preload_libraries:
       - "vchord.so"
 
@@ -36,28 +36,6 @@ spec:
       postInitApplicationSQL:
         - CREATE EXTENSION vchord CASCADE;
         - CREATE EXTENSION earthdistance CASCADE;
-
-  backup:
-    barmanObjectStore:
-      wal:
-        compression: gzip
-      data:
-        compression: gzip
-
-      s3Credentials:
-        accessKeyId:
-          name: cnpg-backup-s3
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: cnpg-backup-s3
-          key: ACCESS_SECRET_KEY
-        region:
-          name: cnpg-backup-s3
-          key: AWS_DEFAULT_REGION
-      destinationPath: "s3://cloudnative-pg/immich"
-      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
-      serverName: "immich-pg-v1"
-    retentionPolicy: "14d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -66,6 +44,7 @@ metadata:
   namespace: immich
 spec:
   schedule: "0 0 0 * * *"  # Daily at midnight
+  suspend: true
   backupOwnerReference: self
   cluster:
     name: immich-pg

--- a/kubernetes/apps/apps/nextcloud/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/nextcloud/cnpg-cluster.yaml
@@ -24,7 +24,7 @@ spec:
     parameters:
       wal_level: "replica"
       archive_timeout: "43200"
-      archive_mode: "on"
+      archive_mode: "off"
 
   bootstrap:
     initdb:
@@ -32,28 +32,6 @@ spec:
       owner: nextcloud
       secret:
         name: nextcloud-db-secrets
-
-  backup:
-    barmanObjectStore:
-      wal:
-        compression: gzip
-      data:
-        compression: gzip
-
-      s3Credentials:
-        accessKeyId:
-          name: cnpg-backup-s3
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: cnpg-backup-s3
-          key: ACCESS_SECRET_KEY
-        region:
-          name: cnpg-backup-s3
-          key: AWS_DEFAULT_REGION
-      destinationPath: "s3://cloudnative-pg/nextcloud"
-      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
-      serverName: "nextcloud-pg-v1"
-    retentionPolicy: "14d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -62,6 +40,7 @@ metadata:
   namespace: nextcloud
 spec:
   schedule: "0 0 0 * * *"
+  suspend: true
   backupOwnerReference: self
   cluster:
     name: nextcloud-pg

--- a/kubernetes/apps/apps/paperless/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/paperless/cnpg-cluster.yaml
@@ -23,7 +23,7 @@ spec:
     parameters:
       wal_level: "replica"
       archive_timeout: "43200" # Wait 12 hours before shipping WALs when no activity
-      archive_mode: "on"
+      archive_mode: "off"
 
   bootstrap:
     initdb:
@@ -31,28 +31,6 @@ spec:
       owner: paperless
       secret:
         name: paperless-db-secrets
-
-  backup:
-    barmanObjectStore:
-      wal:
-        compression: gzip
-      data:
-        compression: gzip
-
-      s3Credentials:
-        accessKeyId:
-          name: cnpg-backup-s3
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: cnpg-backup-s3
-          key: ACCESS_SECRET_KEY
-        region:
-          name: cnpg-backup-s3
-          key: AWS_DEFAULT_REGION
-      destinationPath: "s3://cloudnative-pg/paperless"
-      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
-      serverName: "paperless-pg-v1"
-    retentionPolicy: "14d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -61,6 +39,7 @@ metadata:
   namespace: paperless
 spec:
   schedule: "0 0 0 * * *"  # Daily at midnight
+  suspend: true
   backupOwnerReference: self
   cluster:
     name: paperless-pg

--- a/kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/authentik-db.yaml
@@ -26,30 +26,8 @@ spec:
     parameters:
       wal_level: "logical"
       archive_timeout: "5min"
-      archive_mode: "on"
+      archive_mode: "off"
 
-  backup:
-    barmanObjectStore:
-      wal:
-        compression: gzip
-        encryption: AES256
-      data:
-        compression: gzip
-        encryption: AES256
-      s3Credentials:
-        accessKeyId:
-          name: cnpg-backup-s3
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: cnpg-backup-s3
-          key: ACCESS_SECRET_KEY
-        region:
-          name: cnpg-backup-s3
-          key: AWS_DEFAULT_REGION
-      destinationPath: "s3://cloudnative-pg/authentik"
-      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
-      serverName: "authentik-pg-v1"
-    retentionPolicy: "14d"
 
   bootstrap:
     initdb:
@@ -65,6 +43,7 @@ metadata:
   namespace: authentik
 spec:
   schedule: "0 0 0 * * *"
+  suspend: true
   backupOwnerReference: self
   cluster:
     name: authentik-pg

--- a/kubernetes/infrastructure/storage/longhorn/config/kustomization.yaml
+++ b/kubernetes/infrastructure/storage/longhorn/config/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
   - settings-failover.yaml
   - ingress-longhorn-ui.yaml
   - longhorn-backup-secret.sops.yaml
-  - recurring-backup-jobs.yaml


### PR DESCRIPTION
## Summary

Temporarily disables S3-backed backups while the backup backend is unstable:

- removes the Longhorn recurring backup jobs from the Longhorn config kustomization
- removes CloudNativePG `ScheduledBackup` resources
- removes CloudNativePG `spec.backup.barmanObjectStore` blocks
- sets CloudNativePG `archive_mode` to `off` for the affected PostgreSQL clusters

Affected CNPG clusters:

- `authentik-pg`
- `immich-pg`
- `nextcloud-pg`
- `paperless-pg`
- `n8n-pg`
- `litellm-pg`

## Why

Garage/S3-backed backup operations have been involved in Longhorn/CNPG backup failures. This gives us a GitOps-controlled way to pause backup generation temporarily without touching live data or deleting existing backup objects.

## Validation

- `kubectl apply --dry-run=client -f ...` for each modified CNPG cluster manifest
- `kubectl kustomize kubernetes/infrastructure/storage/longhorn/config`
- `git diff --check`

Note: `kubectl apply --dry-run=client` emitted existing-resource warnings about missing last-applied annotations, but the manifests parsed successfully.

## Rollback

Revert this PR to re-enable the Longhorn recurring backup jobs and CNPG S3 backup configuration.
