### PR TITLE
fix(kubernetes): extend traefik read timeout

### DIFF
--- a/kubernetes/infrastructure/networking/traefik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/networking/traefik/install/helmrelease.yaml
@@ -55,7 +55,8 @@ spec:
             - 10.42.0.0/16
         transport:
           respondingTimeouts:
-            readTimeout: 10m
+            # Registry pull-through cache fills can exceed 10m for large layers; keep reads open.
+            readTimeout: 1h
             writeTimeout: 0s
             idleTimeout: 1h
         http:


### PR DESCRIPTION
## Summary
- extend Traefik `websecure` read timeout from 10 minutes to 1 hour
- document why large registry pull-through cache fills need a longer read window

## Validation
- `pre-commit run check-yaml --files kubernetes/infrastructure/networking/traefik/install/helmrelease.yaml`
- `kubectl apply --dry-run=client -f kubernetes/infrastructure/networking/traefik/install/helmrelease.yaml`

## Context
Harbor pull-through cache fills for large registry blobs can exceed the previous 10 minute read timeout, causing the request to be closed before Harbor commits the blob.
