### PR TITLE
fix(kubernetes): roll back nextcloud image

### DIFF
--- a/kubernetes/apps/apps/nextcloud/helmrelease.yaml
+++ b/kubernetes/apps/apps/nextcloud/helmrelease.yaml
@@ -44,7 +44,7 @@ spec:
             image:
               # renovate: datasource=docker depName=linuxserver/nextcloud registryUrl=https://lscr.io
               repository: lscr.io/linuxserver/nextcloud
-              tag: 34.0.0
+              tag: 33.0.5
             env:
               TZ: Europe/Berlin
               PUID: "1000"


### PR DESCRIPTION
## Summary
- roll back linuxserver/nextcloud from 34.0.0 to 33.0.5
- use the last known configured version while Harbor cannot complete the 34.0.0 blob cache

## Validation
- pre-commit run check-yaml --files kubernetes/apps/apps/nextcloud/helmrelease.yaml
- kubectl apply --dry-run=client -f kubernetes/apps/apps/nextcloud/helmrelease.yaml