### PR TITLE
fix(kubernetes): route Harbor egress through VPN proxy

### DIFF
--- a/ansible/roles/k3s/defaults/main.yml
+++ b/ansible/roles/k3s/defaults/main.yml
@@ -35,7 +35,7 @@ k3s_registry_mirrors:
     endpoint:
       - "{{ k3s_harbor_registry_endpoint }}"
     rewrite:
-      "^(.*)$": "n8n/$1"
+      "^(.*)$": "dockerhub/$1"
   docker.gitea.com:
     endpoint:
       - "{{ k3s_harbor_registry_endpoint }}"

--- a/kubernetes/infrastructure/registry/harbor/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/registry/harbor/install/helmrelease.yaml
@@ -85,6 +85,16 @@ spec:
     cache:
       enabled: true
 
+    proxy:
+      httpProxy: http://sabnzbd.media.svc.cluster.local:8118
+      httpsProxy: http://sabnzbd.media.svc.cluster.local:8118
+      noProxy: >-
+        127.0.0.1,localhost,.local,.internal,.svc,.cluster.local,10.42.0.0/16,10.43.0.0/16,harbor.lan.${CLUSTER_DOMAIN}
+      components:
+        - core
+        - jobservice
+        - trivy
+
     portal:
       resources:
         requests:


### PR DESCRIPTION
## Summary
- configure Harbor's chart-level proxy settings to use sabnzbd Privoxy on port 8118
- include core, jobservice, and trivy so Harbor registry egress and vulnerability DB updates use the VPN-backed proxy
- update the stale K3s `docker.n8n.io` mirror rewrite to use the existing `dockerhub` Harbor proxy-cache project

## Validation
- From `harbor-harbor-core`, verified HTTP proxy access through `sabnzbd.media.svc.cluster.local:8118` to `http://example.com/` returned `HTTP/1.1 200 OK`
- From `harbor-harbor-core`, verified HTTPS CONNECT through Privoxy to `registry-1.docker.io:443` returned `HTTP/1.1 200 Connection established`
- From `harbor-harbor-jobservice`, verified HTTP proxy access through `sabnzbd.media.svc.cluster.local:8118` to `http://example.com/` returned `HTTP/1.1 200 OK`
- From `harbor-harbor-jobservice`, verified HTTPS CONNECT through Privoxy to `registry-1.docker.io:443` returned `HTTP/1.1 200 Connection established`
- `python3` YAML parse for changed files
- `kubectl apply --dry-run=client -f kubernetes/infrastructure/registry/harbor/install/helmrelease.yaml`
- `pre-commit run check-yaml --files kubernetes/infrastructure/registry/harbor/install/helmrelease.yaml ansible/roles/k3s/defaults/main.yml`
- `pre-commit run yamllint --files kubernetes/infrastructure/registry/harbor/install/helmrelease.yaml ansible/roles/k3s/defaults/main.yml`

## Notes
This PR does not reconcile Flux or mutate live Harbor. Applying it will roll Harbor components managed by the HelmRelease because the generated ConfigMaps/env change.
