### PR TITLE
fix(kubernetes): mount Meilisearch data in auto-wipe

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -510,6 +510,8 @@ spec:
             claimName: librechat-meilisearch
         advancedMounts:
           meilisearch:
+            auto-wipe:
+              - path: /meili_data
             init-permissions:
               - path: /meili_data
             meilisearch:


### PR DESCRIPTION
## Summary
- mount the LibreChat Meilisearch PVC into the `auto-wipe` initContainer
- allow the existing incompatible-version cleanup logic to actually remove stale `data.ms` on future Meilisearch bumps

## Live remediation already performed
- scaled `ai/librechat-meilisearch` to 0
- removed only `/meili_data/data.ms` from the `librechat-meilisearch` PVC with a one-shot BusyBox pod
- scaled `ai/librechat-meilisearch` back to 1
- verified Meilisearch is running on `v1.47.0` and `/health` returns available from LibreChat main

## Validation
- `kubectl -n ai rollout status deploy/librechat-meilisearch --timeout=5m`
- `kubectl -n ai exec deploy/librechat-main -- wget -qO- http://librechat-meilisearch:7700/health`
- YAML parse for `kubernetes/apps/apps/ai/librechat/helmrelease.yaml`
- `kubectl apply --dry-run=client -f kubernetes/apps/apps/ai/librechat/helmrelease.yaml`
- `pre-commit run check-yaml --files kubernetes/apps/apps/ai/librechat/helmrelease.yaml`
- `pre-commit run yamllint --files kubernetes/apps/apps/ai/librechat/helmrelease.yaml`
