### PR TITLE
fix(kubernetes): allow ZAI reasoning params

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -950,18 +950,48 @@ data:
 
         def get_supported_openai_params(self, model):
             supported_params = list(original_get_supported_openai_params(self, model))
-            # Z.AI GLM models support native `thinking`, but the public API
-            # schema does not expose OpenAI-style `reasoning_effort`.
+            # Z.AI GLM models support native `thinking`, and GLM-5.2 also
+            # accepts OpenAI-style `reasoning_effort` values `high` and `max`.
             # OpenAI-compatible clients may also send max_completion_tokens;
             # Z.AI accepts it, but LiteLLM's ZAI provider does not list it by default.
-            if _zai_coding_slug(model) is not None:
-                for param in ("thinking", "max_completion_tokens"):
+            slug = _zai_coding_slug(model)
+            if slug is not None:
+                params = ["thinking", "max_completion_tokens", "extra_body"]
+                if slug == "glm-5.2":
+                    params.append("reasoning_effort")
+                for param in params:
                     if param not in supported_params:
                         supported_params.append(param)
             return supported_params
 
         get_supported_openai_params._zai_coding_supported_params_patch = True
         ZAIChatConfig.get_supported_openai_params = get_supported_openai_params
+
+        if getattr(
+            ZAIChatConfig.map_openai_params,
+            "_zai_coding_map_params_patch",
+            False,
+        ):
+            return
+
+        original_map_openai_params = ZAIChatConfig.map_openai_params
+
+        def map_openai_params(self, non_default_params, optional_params, model, drop_params):
+            optional_params = original_map_openai_params(
+                self,
+                non_default_params=non_default_params,
+                optional_params=optional_params,
+                model=model,
+                drop_params=drop_params,
+            )
+            if _zai_coding_slug(model) is not None and "thinking" in optional_params:
+                extra_body = dict(optional_params.get("extra_body") or {})
+                extra_body["thinking"] = optional_params.pop("thinking")
+                optional_params["extra_body"] = extra_body
+            return optional_params
+
+        map_openai_params._zai_coding_map_params_patch = True
+        ZAIChatConfig.map_openai_params = map_openai_params
 
 
     def patch_zai_coding_model_catalog():


### PR DESCRIPTION
## Summary
- allow GLM-5.2 to accept reasoning_effort high/max through LiteLLM
- allow extra_body for Z.AI Coding Plan requests
- map top-level thinking into extra_body.thinking so LiteLLM's Z.AI SDK path does not fail before HTTP

## Live validation before fix
- LiteLLM plain zai-coding/glm-5.2 request succeeded and returned reasoning tokens
- LiteLLM reasoning_effort high/max failed unless allowed_openai_params included reasoning_effort
- direct upstream Z.AI Coding Plan accepted thinking enabled/disabled and reasoning_effort high/max
- LiteLLM extra_body.thinking worked when extra_body was explicitly allowed

## Validation
- python AST parse of embedded zai_coding_catalog.py
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/litellm
