### PR TITLE
fix(flux): add 10m timeout to bjw-s app-template HelmReleases

### DIFF
--- a/kubernetes/components/bjw-s-defaults/kustomization.yaml
+++ b/kubernetes/components/bjw-s-defaults/kustomization.yaml
@@ -9,6 +9,9 @@ patches:
         path: /spec/interval
         value: 15m
       - op: add
+        path: /spec/timeout
+        value: 10m
+      - op: add
         path: /spec/chart/spec/version
         # renovate: datasource=helm depName=app-template registryUrl=https://bjw-s-labs.github.io/helm-charts/
         value: "5.0.1"


### PR DESCRIPTION
## Context

Jellyfin and Seerr consistently exceed Flux's default 5m Helm upgrade timeout during Recreate rollouts due to slow startup probes. This causes Helm release failures () and Flux stalls with .

## Change

Add  to the shared  kustomize component so all app-template HelmReleases get enough headroom for pod rollouts.

## Affected

All HelmReleases using the  component (~30 releases). The timeout only applies during install/upgrade — no effect on steady-state reconciliation.

### Already stuck (will be fixed by this)

-  — failed since June 6
-  — failed since June 6

### Already healthy (no behavior change)

-  — upgraded successfully after rollback
-  — upgraded successfully after rollback