### PR TITLE
feat(kubernetes): expose garage web endpoint

### DIFF
--- a/kubernetes/apps/apps/external-proxy/garage-s3.yaml
+++ b/kubernetes/apps/apps/external-proxy/garage-s3.yaml
@@ -9,6 +9,9 @@ spec:
     - name: s3
       port: 9000
       targetPort: 9000
+    - name: web
+      port: 3902
+      targetPort: 3902
 ---
 apiVersion: v1
 kind: Endpoints
@@ -21,6 +24,9 @@ subsets:
     ports:
       - name: s3
         port: 9000
+        protocol: TCP
+      - name: web
+        port: 3902
         protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1
@@ -45,3 +51,25 @@ spec:
                 name: garage-s3
                 port:
                   name: s3
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: garage-s3-web
+  namespace: external-proxy
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    external-dns.alpha.kubernetes.io/hostname: "*.web.${CLUSTER_DOMAIN}"
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: "*.web.${CLUSTER_DOMAIN}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: garage-s3
+                port:
+                  name: web

--- a/kubernetes/apps/apps/external-proxy/garage-s3.yaml
+++ b/kubernetes/apps/apps/external-proxy/garage-s3.yaml
@@ -59,7 +59,7 @@ metadata:
   namespace: external-proxy
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    external-dns.alpha.kubernetes.io/hostname: "*.web.${CLUSTER_DOMAIN}"
+    external-dns.alpha.kubernetes.io/controller: ignore
 spec:
   ingressClassName: traefik
   rules:

--- a/kubernetes/infrastructure/security/cert-manager/config/wildcard-cert.yaml
+++ b/kubernetes/infrastructure/security/cert-manager/config/wildcard-cert.yaml
@@ -14,3 +14,4 @@ spec:
   dnsNames:
     - "*.${CLUSTER_DOMAIN}"
     - "*.lan.${CLUSTER_DOMAIN}"
+    - "*.web.${CLUSTER_DOMAIN}"


### PR DESCRIPTION
## Summary
- add Garage web port 3902 to the existing external Garage proxy Service and Endpoints
- add a wildcard Ingress for *.web.${CLUSTER_DOMAIN} on Traefik websecure
- include *.web.${CLUSTER_DOMAIN} in the managed wildcard certificate

## Validation
- kubectl apply --dry-run=client -k kubernetes/apps/apps/external-proxy
- kubectl apply --dry-run=client -f kubernetes/infrastructure/security/cert-manager/config/wildcard-cert.yaml
- pre-commit run --files kubernetes/apps/apps/external-proxy/garage-s3.yaml kubernetes/infrastructure/security/cert-manager/config/wildcard-cert.yaml