### PR TITLE
chore(kubernetes): pin moving image tags

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -355,7 +355,7 @@ spec:
             image:
               # renovate: datasource=docker depName=danny-avila/librechat-rag-api-dev-lite registryUrl=https://registry.librechat.ai
               repository: registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite
-              tag: latest
+              tag: v0.8.0
             env:
               TZ: Europe/Berlin
               RAG_HOST: 0.0.0.0

--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -127,9 +127,8 @@ spec:
         containers:
           admin-panel:
             image:
-              # renovate: datasource=docker depName=clickhouse/librechat-admin-panel registryUrl=https://ghcr.io
               repository: ghcr.io/clickhouse/librechat-admin-panel
-              tag: latest
+              tag: 6768bdeb40873ffeac63f84f48365b4ff33d69c8
             env:
               TZ: Europe/Berlin
               PORT: "3000"

--- a/kubernetes/apps/apps/automation/n8n/helmrelease.yaml
+++ b/kubernetes/apps/apps/automation/n8n/helmrelease.yaml
@@ -28,8 +28,9 @@ spec:
         initContainers:
           init-permissions:
             image:
-              repository: alpine
-              tag: latest
+              # renovate: datasource=docker depName=library/alpine registryUrl=https://docker.io
+              repository: docker.io/library/alpine
+              tag: 3.24.1
             command: ["/bin/sh", "-c", "chown -R 1000:1000 /home/node/.n8n && chmod 700 /home/node/.n8n"]
             securityContext:
               runAsUser: 0

--- a/kubernetes/apps/apps/immich/auto-stack-cronjob.yaml
+++ b/kubernetes/apps/apps/immich/auto-stack-cronjob.yaml
@@ -4,10 +4,9 @@ metadata:
   name: immich-auto-stack
   namespace: immich
   annotations:
-    checkov.io/skip1: CKV_K8S_14=Upstream image does not publish stable versioned tags.
-    checkov.io/skip2: CKV_K8S_35=Immich auto-stack expects its API key as an environment variable.
-    checkov.io/skip3: CKV_K8S_43=Upstream image is pinned to an immutable commit tag; digest pinning will be handled separately.
-    checkov.io/skip4: CKV_K8S_40=Upstream image runs as UID 1000 by design.
+    checkov.io/skip1: CKV_K8S_35=Immich auto-stack expects its API key as an environment variable.
+    checkov.io/skip2: CKV_K8S_43=Upstream image is pinned to an immutable commit tag; digest pinning will be handled separately.
+    checkov.io/skip3: CKV_K8S_40=Upstream image runs as UID 1000 by design.
 spec:
   schedule: "0 * * * *"
   concurrencyPolicy: Forbid

--- a/kubernetes/apps/apps/immich/auto-stack-cronjob.yaml
+++ b/kubernetes/apps/apps/immich/auto-stack-cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     checkov.io/skip1: CKV_K8S_14=Upstream image does not publish stable versioned tags.
     checkov.io/skip2: CKV_K8S_35=Immich auto-stack expects its API key as an environment variable.
-    checkov.io/skip3: CKV_K8S_43=Image tags are Renovate-managed; digest pinning will be handled separately.
+    checkov.io/skip3: CKV_K8S_43=Upstream image is pinned to an immutable commit tag; digest pinning will be handled separately.
     checkov.io/skip4: CKV_K8S_40=Upstream image runs as UID 1000 by design.
 spec:
   schedule: "0 * * * *"
@@ -29,7 +29,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: auto-stack
-              image: majorfi/immich-stack:latest
+              image: majorfi/immich-stack:sha-48a5450
               imagePullPolicy: Always
               securityContext:
                 allowPrivilegeEscalation: false

--- a/kubernetes/apps/apps/media/plex-exporter/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/plex-exporter/helmrelease.yaml
@@ -14,7 +14,6 @@ spec:
           main:
             image:
               repository: ghcr.io/jsclayton/prometheus-plex-exporter
-              tag: main
               digest: sha256:18ef1b2197efbcb75bd7276380955760995f10a9fbe55106809a6fcff91c2940
               pullPolicy: Always
             envFrom:

--- a/kubernetes/apps/apps/media/plex-exporter/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/plex-exporter/helmrelease.yaml
@@ -13,9 +13,9 @@ spec:
         containers:
           main:
             image:
-              # renovate: datasource=docker depName=jsclayton/prometheus-plex-exporter registryUrl=https://ghcr.io
               repository: ghcr.io/jsclayton/prometheus-plex-exporter
               tag: main
+              digest: sha256:18ef1b2197efbcb75bd7276380955760995f10a9fbe55106809a6fcff91c2940
               pullPolicy: Always
             envFrom:
               - secretRef:

--- a/kubernetes/apps/apps/media/plextraktsync/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/plextraktsync/helmrelease.yaml
@@ -14,8 +14,9 @@ spec:
         initContainers:
           copy-trakt-config:
             image:
-              repository: busybox
-              tag: latest
+              # renovate: datasource=docker depName=library/busybox registryUrl=https://docker.io
+              repository: docker.io/library/busybox
+              tag: 1.38.0
             command:
               - /bin/sh
               - -c

--- a/kubernetes/apps/apps/media/plextraktsync/sync-job.yaml
+++ b/kubernetes/apps/apps/media/plextraktsync/sync-job.yaml
@@ -37,10 +37,9 @@ metadata:
   name: plextraktsync-sync
   namespace: media
   annotations:
-    checkov.io/skip1: CKV_K8S_14=Kubectl client image tracks the cluster until digest pinning is adopted.
-    checkov.io/skip2: CKV_K8S_38=This job intentionally needs a token to run kubectl exec.
-    checkov.io/skip3: CKV_K8S_43=Image tags are Renovate-managed; digest pinning will be handled separately.
-    checkov.io/skip4: CKV_K8S_40=Bitnami kubectl image runs as non-root UID 1001 by design.
+    checkov.io/skip1: CKV_K8S_38=This job intentionally needs a token to run kubectl exec.
+    checkov.io/skip2: CKV_K8S_43=Kubectl tag intentionally matches the cluster Kubernetes version; digest pinning will be handled separately.
+    checkov.io/skip3: CKV_K8S_40=Kubectl job runs under explicit non-root UID 1001.
 spec:
   schedule: "0 */12 * * *"
   concurrencyPolicy: Forbid
@@ -62,7 +61,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: runner
-              image: bitnami/kubectl:latest
+              image: alpine/kubectl:1.35.1
               imagePullPolicy: Always
               securityContext:
                 allowPrivilegeEscalation: false

--- a/kubernetes/apps/apps/nextcloud/helmrelease.yaml
+++ b/kubernetes/apps/apps/nextcloud/helmrelease.yaml
@@ -54,8 +54,9 @@ spec:
                 containerPort: 443
           log-tailer:
             image:
-              repository: docker.io/busybox
-              tag: latest
+              # renovate: datasource=docker depName=library/busybox registryUrl=https://docker.io
+              repository: docker.io/library/busybox
+              tag: 1.38.0
             command:
               - /bin/sh
               - -c

--- a/kubernetes/apps/apps/paperless/backup-job.yaml
+++ b/kubernetes/apps/apps/paperless/backup-job.yaml
@@ -37,10 +37,9 @@ metadata:
   name: paperless-backup
   namespace: paperless
   annotations:
-    checkov.io/skip1: CKV_K8S_14=Kubectl client image tracks the cluster until digest pinning is adopted.
-    checkov.io/skip2: CKV_K8S_38=This job intentionally needs a token to run kubectl exec.
-    checkov.io/skip3: CKV_K8S_43=Image tags are Renovate-managed; digest pinning will be handled separately.
-    checkov.io/skip4: CKV_K8S_40=Bitnami kubectl image runs as non-root UID 1001 by design.
+    checkov.io/skip1: CKV_K8S_38=This job intentionally needs a token to run kubectl exec.
+    checkov.io/skip2: CKV_K8S_43=Kubectl tag intentionally matches the cluster Kubernetes version; digest pinning will be handled separately.
+    checkov.io/skip3: CKV_K8S_40=Kubectl job runs under explicit non-root UID 1001.
 spec:
   schedule: "0 3 */3 * *"
   concurrencyPolicy: Forbid
@@ -62,7 +61,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: runner
-              image: bitnami/kubectl:latest
+              image: alpine/kubectl:1.35.1
               imagePullPolicy: Always
               securityContext:
                 allowPrivilegeEscalation: false

--- a/kubernetes/apps/apps/paperless/helmrelease.yaml
+++ b/kubernetes/apps/apps/paperless/helmrelease.yaml
@@ -140,7 +140,7 @@ spec:
             image:
               # renovate: datasource=docker depName=apache/tika registryUrl=https://docker.io
               repository: docker.io/apache/tika
-              tag: latest
+              tag: 3.3.1.0
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/apps/apps/security/frigate/helmrelease.yaml
+++ b/kubernetes/apps/apps/security/frigate/helmrelease.yaml
@@ -53,7 +53,7 @@ spec:
             image:
               # renovate: datasource=docker depName=blakeblackshear/frigate registryUrl=https://ghcr.io
               repository: ghcr.io/blakeblackshear/frigate
-              tag: stable
+              tag: 0.17.1
               pullPolicy: Always
             env:
               TZ: Europe/Berlin

--- a/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/alternate/helmrelease.yaml
@@ -133,7 +133,7 @@ spec:
           steam-presence:
             image:
               repository: ghcr.io/nreymundo/steam-presence
-              tag: latest
+              tag: sha-176881e
               pullPolicy: Always
             env:
               XDG_RUNTIME_DIR: /run/user/1000

--- a/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/discord-presence/main/helmrelease.yaml
@@ -133,7 +133,7 @@ spec:
           steam-presence:
             image:
               repository: ghcr.io/nreymundo/steam-presence
-              tag: latest
+              tag: sha-176881e
               pullPolicy: Always
             env:
               XDG_RUNTIME_DIR: /run/user/1000

--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,34 @@
       "allowedVersions": "/^3\\.\\d+\\.\\d+$/"
     },
     {
+      "description": "Keep Alpine on stable semver tags",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["library/alpine"],
+      "matchPackageNames": ["library/alpine", "docker.io/library/alpine"],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+$/"
+    },
+    {
+      "description": "Keep BusyBox on stable semver tags",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["library/busybox"],
+      "matchPackageNames": ["library/busybox", "docker.io/library/busybox"],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+$/"
+    },
+    {
+      "description": "Keep Apache Tika on stable semver tags",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["apache/tika"],
+      "matchPackageNames": ["apache/tika", "docker.io/apache/tika"],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+\\.\\d+$/"
+    },
+    {
+      "description": "Keep Frigate on stable semver tags",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["blakeblackshear/frigate"],
+      "matchPackageNames": ["blakeblackshear/frigate", "ghcr.io/blakeblackshear/frigate"],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+$/"
+    },
+    {
       "description": "Global stability and automerge schedule",
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "minimumReleaseAge": "5 days",

--- a/renovate.json
+++ b/renovate.json
@@ -70,6 +70,17 @@
       "allowedVersions": "/^\\d+\\.\\d+\\.\\d+$/"
     },
     {
+      "description": "Keep LibreChat RAG API on release semver tags",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["danny-avila/librechat-rag-api-dev-lite"],
+      "matchPackageNames": [
+        "danny-avila/librechat-rag-api-dev-lite",
+        "registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite"
+      ],
+      "versioning": "semver",
+      "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+$/"
+    },
+    {
       "description": "Global stability and automerge schedule",
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "minimumReleaseAge": "5 days",


### PR DESCRIPTION
## Summary
- Pin Kubernetes app images that used moving tags to semver, commit, digest, or cluster-version tags
- Add Renovate allowed-version rules for newly semver-managed images
- Clean stale Checkov image-tag skip metadata where the pinned image no longer needs it

## Validation
- pre-commit run --files for all branch-modified files
- kubectl apply --dry-run=client for all changed Kubernetes manifests
- checkov --framework kubernetes --compact for all changed Kubernetes manifests
- npx --yes --package renovate renovate-config-validator renovate.json
- git diff --check master...HEAD
- registry manifest verification for every new image reference