### PR TITLE
fix(kubernetes): use ghcr for librechat rag api

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -353,8 +353,8 @@ spec:
         containers:
           rag-api:
             image:
-              # renovate: datasource=docker depName=danny-avila/librechat-rag-api-dev-lite registryUrl=https://registry.librechat.ai
-              repository: registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite
+              # renovate: datasource=docker depName=danny-avila/librechat-rag-api-dev-lite registryUrl=https://ghcr.io
+              repository: ghcr.io/danny-avila/librechat-rag-api-dev-lite
               tag: v0.8.0
             env:
               TZ: Europe/Berlin

--- a/renovate.json
+++ b/renovate.json
@@ -75,7 +75,7 @@
       "matchDepNames": ["danny-avila/librechat-rag-api-dev-lite"],
       "matchPackageNames": [
         "danny-avila/librechat-rag-api-dev-lite",
-        "registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite"
+        "ghcr.io/danny-avila/librechat-rag-api-dev-lite"
       ],
       "versioning": "semver",
       "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+$/"


### PR DESCRIPTION
## Summary
- Switch LibreChat RAG API image from registry.librechat.ai to ghcr.io for v0.8.0
- Update Renovate metadata and package rule to track the GHCR image reference

## Reason
- The cluster cannot pull registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite:v0.8.0 and librechat-rag-api is in ImagePullBackOff
- The same tag is available from GHCR and began downloading successfully with docker pull --platform linux/amd64

## Validation
- docker pull --platform linux/amd64 ghcr.io/danny-avila/librechat-rag-api-dev-lite:v0.8.0 reached layer downloads
- docker manifest inspect ghcr.io/danny-avila/librechat-rag-api-dev-lite:v0.8.0
- kubectl apply --dry-run=client -f kubernetes/apps/apps/ai/librechat/helmrelease.yaml
- checkov --framework kubernetes --compact -f kubernetes/apps/apps/ai/librechat/helmrelease.yaml
- npx --yes --package renovate renovate-config-validator renovate.json
- pre-commit run --files kubernetes/apps/apps/ai/librechat/helmrelease.yaml renovate.json