### PR TITLE
feat(litellm): add Headroom request compression

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -283,6 +283,7 @@ data:
     litellm_settings:
       callbacks:
         - cache_bypass.proxy_handler_instance
+        - headroom_adapter.headroom_callback_instance
       check_provider_endpoint: true
       cache: true
       cache_params:
@@ -1466,6 +1467,153 @@ data:
 
 
     litellm_startup.worker_startup_hook()
+
+  headroom_adapter.py: |
+    import logging
+    from typing import Any
+
+    from litellm.integrations.custom_logger import CustomLogger
+
+    logger = logging.getLogger(__name__)
+
+    try:
+        from headroom.integrations.litellm_callback import HeadroomCallback
+    except ImportError:
+        HeadroomCallback = None
+
+
+    _SUPPORTED_CALL_TYPES = {
+        "completion",
+        "acompletion",
+        "responses",
+        "aresponses",
+    }
+
+
+    def _normalize_responses_input(input_items: Any) -> list[dict[str, Any]]:
+        if isinstance(input_items, str):
+            return [{"role": "user", "content": input_items}]
+
+        if not isinstance(input_items, list):
+            return []
+
+        messages = []
+        for item in input_items:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type", "message") != "message":
+                continue
+
+            role = item.get("role") or "user"
+            content = item.get("content")
+            if isinstance(content, str):
+                normalized_content = content
+            elif isinstance(content, list):
+                normalized_content = []
+                for part in content:
+                    if isinstance(part, str):
+                        normalized_content.append({"type": "text", "text": part})
+                    elif isinstance(part, dict):
+                        normalized_content.append(part)
+                if not normalized_content:
+                    continue
+            elif isinstance(content, dict):
+                normalized_content = [content]
+            else:
+                continue
+
+            messages.append({"role": role, "content": normalized_content})
+        return messages
+
+
+    def _responses_messages_changed(original_input: Any, compressed_messages: list[dict[str, Any]]) -> bool:
+        normalized_original = _normalize_responses_input(original_input)
+        return normalized_original != compressed_messages
+
+
+    def _merge_compressed_responses_input(original_input: Any, compressed_messages: list[dict[str, Any]]):
+        if not isinstance(original_input, list):
+            return original_input
+
+        compressed_iter = iter(compressed_messages)
+        merged_items = []
+        for item in original_input:
+            if not isinstance(item, dict) or item.get("type", "message") != "message":
+                merged_items.append(item)
+                continue
+
+            try:
+                compressed_message = next(compressed_iter)
+            except StopIteration:
+                merged_items.append(item)
+                continue
+
+            updated_item = dict(item)
+            updated_item["role"] = compressed_message.get("role", item.get("role"))
+            updated_item["content"] = compressed_message.get("content", item.get("content"))
+            merged_items.append(updated_item)
+
+        return merged_items
+
+
+    class HeadroomAdapterCallback(CustomLogger):
+        def __init__(self):
+            self._headroom_callback = None
+            if HeadroomCallback is None:
+                logger.warning("Headroom package not available; callback disabled")
+                return
+            try:
+                self._headroom_callback = HeadroomCallback()
+                logger.info("Headroom callback adapter initialized")
+            except Exception as exc:
+                logger.warning("Headroom callback failed to initialize: %s", exc)
+
+        async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+            if not self._headroom_callback or call_type not in _SUPPORTED_CALL_TYPES:
+                return data
+
+            request_data = data
+            request_call_type = call_type
+            restore_responses = False
+            original_input = None
+
+            if call_type in {"responses", "aresponses"}:
+                original_input = data.get("input")
+                request_data = dict(data)
+                request_data["messages"] = _normalize_responses_input(original_input)
+                if not request_data["messages"]:
+                    return data
+                request_call_type = "completion"
+                restore_responses = True
+            elif not data.get("messages"):
+                return data
+
+            try:
+                updated = await self._headroom_callback.async_pre_call_hook(
+                    user_api_key_dict,
+                    request_data,
+                    request_call_type,
+                )
+            except Exception as exc:
+                logger.warning("Headroom pre-call hook failed: %s", exc)
+                return data
+
+            if not isinstance(updated, dict):
+                return data
+
+            if restore_responses:
+                compressed_messages = updated.get("messages") or []
+                if _responses_messages_changed(original_input, compressed_messages):
+                    data["input"] = _merge_compressed_responses_input(
+                        original_input,
+                        compressed_messages,
+                    )
+                return data
+
+            return updated
+
+
+    headroom_callback_instance = HeadroomAdapterCallback()
 
   vllm_model_discovery.py: |
     import os

--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -4,6 +4,11 @@ metadata:
   name: litellm-config
   namespace: ai
 data:
+  headroom-requirements.txt: |
+    headroom-ai==0.27.0 \
+        --hash=sha256:640e67a41743265376582a92691a192a8c2448ef0b2167a0e14a2a458adbe2dd \
+        --hash=sha256:f8fa150061db2513e8584d2e4b50af930131bcfe301080f297464b351a03f577
+
   config.yaml: |
     model_list:
       - model_name: openai/gpt-5.5

--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -22,8 +22,63 @@ spec:
               - -lc
               - |
                 set -euo pipefail
+                python3 - <<'PY'
+                import time
+                import urllib.request
+
+                urls = [
+                    "https://pypi.org/simple/headroom-ai/",
+                    "https://files.pythonhosted.org/",
+                ]
+
+                for url in urls:
+                    last_error = None
+                    for attempt in range(1, 6):
+                        try:
+                            with urllib.request.urlopen(url, timeout=10) as response:
+                                if 200 <= response.status < 400:
+                                    break
+                                last_error = RuntimeError(f"unexpected status {response.status}")
+                        except Exception as exc:
+                            last_error = exc
+                        if attempt == 5:
+                            raise SystemExit(f"PyPI endpoint unavailable: {url}: {last_error}")
+                        time.sleep(attempt * 2)
+                PY
                 python3 -m ensurepip --default-pip >/dev/null
-                python3 -m pip install --no-cache-dir --no-deps --target /opt/headroom headroom-ai==0.27.0
+                python3 -m pip install \
+                  --no-cache-dir \
+                  --no-deps \
+                  --only-binary=:all: \
+                  --require-hashes \
+                  --retries 5 \
+                  --timeout 30 \
+                  --target /opt/headroom \
+                  -r /etc/litellm/headroom-requirements.txt
+                PYTHONPATH=/opt/headroom:/etc/litellm python3 - <<'PY'
+                import asyncio
+
+                from headroom.integrations.litellm_callback import HeadroomCallback
+                import headroom_adapter
+
+                callback = HeadroomCallback()
+                assert callback is not None
+
+                async def main():
+                    data = {
+                        "model": "test-model",
+                        "messages": [{"role": "user", "content": "hello"}],
+                    }
+                    result = await headroom_adapter.headroom_callback_instance.async_pre_call_hook(
+                        None,
+                        None,
+                        data,
+                        "completion",
+                    )
+                    assert isinstance(result, dict)
+
+                asyncio.run(main())
+                PY
         containers:
           main:
             image:
@@ -229,6 +284,13 @@ spec:
         name: litellm-config
         advancedMounts:
           main:
+            install-headroom:
+              - path: /etc/litellm/headroom-requirements.txt
+                subPath: headroom-requirements.txt
+                readOnly: true
+              - path: /etc/litellm/headroom_adapter.py
+                subPath: headroom_adapter.py
+                readOnly: true
             main:
               - path: /etc/litellm/config.yaml
                 subPath: config.yaml
@@ -256,4 +318,7 @@ spec:
                 readOnly: true
               - path: /etc/litellm/headroom_adapter.py
                 subPath: headroom_adapter.py
+                readOnly: true
+              - path: /etc/litellm/headroom-requirements.txt
+                subPath: headroom-requirements.txt
                 readOnly: true

--- a/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/litellm/helmrelease.yaml
@@ -12,6 +12,18 @@ spec:
       main:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          install-headroom:
+            image:
+              repository: ghcr.io/berriai/litellm
+              tag: v1.89.0-rc.2
+            command:
+              - /bin/sh
+              - -lc
+              - |
+                set -euo pipefail
+                python3 -m ensurepip --default-pip >/dev/null
+                python3 -m pip install --no-cache-dir --no-deps --target /opt/headroom headroom-ai==0.27.0
         containers:
           main:
             image:
@@ -20,7 +32,7 @@ spec:
               tag: v1.89.0-rc.2
             env:
               TZ: Europe/Berlin
-              PYTHONPATH: /etc/litellm
+              PYTHONPATH: /opt/headroom:/etc/litellm
               LITELLM_WORKER_STARTUP_HOOKS: litellm_startup:worker_startup_hook
               STORE_MODEL_IN_DB: "True"
               CONFIG_FILE_PATH: /etc/litellm/config.yaml
@@ -202,6 +214,15 @@ spec:
           valkey:
             valkey:
               - path: /data
+      headroom-site:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          main:
+            install-headroom:
+              - path: /opt/headroom
+            main:
+              - path: /opt/headroom
       config:
         enabled: true
         type: configMap
@@ -232,4 +253,7 @@ spec:
                 readOnly: true
               - path: /etc/litellm/sitecustomize.py
                 subPath: sitecustomize.py
+                readOnly: true
+              - path: /etc/litellm/headroom_adapter.py
+                subPath: headroom_adapter.py
                 readOnly: true


### PR DESCRIPTION
## What this does
- installs `headroom-ai==0.27.0` into the existing LiteLLM pod at startup via a reversible init-container step
- wires LiteLLM's existing callback chain to a local `headroom_adapter.py`
- compresses only chat-like traffic (`completion`/`acompletion` and `responses`/`aresponses`)
- leaves image generation, speech, transcription, embeddings, moderation, and the rest of the proxy behavior alone

## Why this shape
- keeps the change scoped to the existing LiteLLM app manifests only
- avoids switching the deployment over to Headroom's standalone proxy/middleware path
- preserves the current custom LiteLLM patches and startup hooks
- keeps rollback simple: revert one commit / one PR

## Install model
Headroom is **not** provided by the LiteLLM chart itself.
This PR installs it inside the existing LiteLLM pod by:
- adding an init container based on the same `ghcr.io/berriai/litellm:v1.89.0-rc.2` image
- running `python3 -m ensurepip --default-pip`
- installing the prebuilt `headroom-ai==0.27.0` wheel into `/opt/headroom` with `pip install --no-deps --target /opt/headroom`
- prepending `/opt/headroom` to `PYTHONPATH`

I verified against the upstream LiteLLM image that:
- Python is present
- `pip` is not preinstalled, but `ensurepip` works
- `headroom-ai==0.27.0` installs successfully as a wheel with `--no-deps`
- `headroom.integrations.litellm_callback.HeadroomCallback` imports correctly afterward

## What it does *not* include
- no standalone Headroom proxy deployment
- no Headroom dashboard/UI deployment
- no extra service, ingress, PVC, or CRD
- no changes to non-LiteLLM apps

So this is **backend compression/integration only**, inside the current LiteLLM deployment.

## Responses API handling
OpenClaw uses LiteLLM in `responses` mode for the GPT-5.x ChatGPT-backed models. Headroom's upstream LiteLLM callback operates on `messages`, while LiteLLM proxy hands `/v1/responses` traffic to hooks as `input` with call type `aresponses`.

This PR adds a small adapter that:
- normalizes Responses API `input` items into temporary chat-style `messages`
- runs Headroom only for supported chat-like call types
- merges compressed content back into the original `input` shape
- ignores non-message response items instead of mutating them

## Validation
- parsed `kubernetes/apps/apps/ai/litellm/configmap.yaml`
- parsed `kubernetes/apps/apps/ai/litellm/helmrelease.yaml`
- compiled the embedded `headroom_adapter.py`
- confirmed LiteLLM proxy pre-call hooks receive `route_type="aresponses"` for `/v1/responses`
- confirmed the current LiteLLM image can install and import `headroom-ai==0.27.0`
- smoke-tested the adapter inside the LiteLLM image with `headroom-ai` installed

## Rollback
- `git revert <merge-or-commit>`
- or revert this PR in GitHub

No live reconcile/apply is included in this PR.
