### PR TITLE
chore(scripts): bootstrap helm tooling

### DIFF
--- a/scripts/bootstrap-host-tools.sh
+++ b/scripts/bootstrap-host-tools.sh
@@ -12,6 +12,9 @@ readonly REQUIRED_TOOLS=(
   packer
   ansible-lint
   kubectl
+  helm
+  helm-diff
+  helm-secrets
   flux
   ansible-playbook
   bws
@@ -31,6 +34,17 @@ readonly UBUNTU_DISTRO_TOKENS=(
   ubuntu
 )
 
+readonly HELM_DIFF_PLUGIN_URL="https://github.com/databus23/helm-diff"
+readonly HELM_SECRETS_PLUGIN_VERSION="4.7.7"
+readonly HELM_SECRETS_RELEASE_BASE_URL="https://github.com/jkroepke/helm-secrets/releases/download/v$HELM_SECRETS_PLUGIN_VERSION"
+readonly HELM_SECRETS_CLI_PLUGIN_URL="$HELM_SECRETS_RELEASE_BASE_URL/secrets-$HELM_SECRETS_PLUGIN_VERSION.tgz"
+readonly HELM_SECRETS_GETTER_PLUGIN_URL="$HELM_SECRETS_RELEASE_BASE_URL/secrets-getter-$HELM_SECRETS_PLUGIN_VERSION.tgz"
+readonly HELM_SECRETS_POST_RENDERER_PLUGIN_URL="$HELM_SECRETS_RELEASE_BASE_URL/secrets-post-renderer-$HELM_SECRETS_PLUGIN_VERSION.tgz"
+readonly ARCH_HELM_DIFF_PLUGIN_PATH="/usr/lib/helm/plugins/diff"
+readonly ARCH_HELM_SECRETS_CLI_PLUGIN_PATH="/usr/lib/helm/plugins/secrets-cli"
+readonly ARCH_HELM_SECRETS_GETTER_PLUGIN_PATH="/usr/lib/helm/plugins/secrets-getter"
+readonly ARCH_HELM_SECRETS_POST_RENDERER_PLUGIN_PATH="/usr/lib/helm/plugins/secrets-post-renderer"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
 
@@ -49,6 +63,7 @@ AUR_PACKAGES_TO_INSTALL=()
 APT_PACKAGES_TO_INSTALL=()
 BREW_PACKAGES_TO_INSTALL=()
 SNAP_CLASSIC_PACKAGES_TO_INSTALL=()
+HELM_PLUGINS_TO_INSTALL=()
 MANUAL_TOOLS_TO_INSTALL=()
 
 usage() {
@@ -84,6 +99,95 @@ die() {
 
 command_exists() {
   command -v "$1" >/dev/null 2>&1
+}
+
+pacman_package_installed() {
+  local package="$1"
+
+  command_exists pacman || return 1
+  pacman -Q "$package" >/dev/null 2>&1
+}
+
+helm_plugin_command_exists() {
+  local plugin_command="$1"
+
+  command_exists helm || return 1
+  helm "$plugin_command" --help >/dev/null 2>&1
+}
+
+helm_plugin_metadata_exists() {
+  local plugin_name="$1"
+  local plugin_yaml
+  local plugins_dir
+  local line
+  local name_pattern
+
+  command_exists helm || return 1
+
+  plugins_dir="$(helm env HELM_PLUGINS 2>/dev/null)" || return 1
+  name_pattern="^[[:space:]]*name:[[:space:]]*\"?$plugin_name\"?[[:space:]]*$"
+
+  for plugin_yaml in "$plugins_dir"/*/plugin.yaml; do
+    [[ -f "$plugin_yaml" ]] || continue
+
+    while IFS= read -r line; do
+      if [[ "$line" =~ $name_pattern ]]; then
+        return 0
+      fi
+    done < "$plugin_yaml"
+  done
+
+  return 1
+}
+
+tool_exists() {
+  local tool="$1"
+
+  case "$tool" in
+    helm-diff)
+      helm_plugin_command_exists diff
+      ;;
+    helm-secrets)
+      helm_plugin_command_exists secrets && \
+        helm_plugin_metadata_exists secrets-getter && \
+        helm_plugin_metadata_exists secrets-post-renderer
+      ;;
+    *)
+      command_exists "$tool"
+      ;;
+  esac
+}
+
+helm_plugin_spec_installed() {
+  local plugin_name="$1"
+
+  case "$plugin_name" in
+    diff|secrets)
+      helm_plugin_command_exists "$plugin_name"
+      ;;
+    *)
+      helm_plugin_metadata_exists "$plugin_name"
+      ;;
+  esac
+}
+
+helm_plugin_source_is_local_path() {
+  local plugin_source="$1"
+
+  [[ "$plugin_source" == /* ]]
+}
+
+print_helm_plugin_install_command() {
+  local plugin_source="$1"
+
+  if helm_plugin_source_is_local_path "$plugin_source"; then
+    # shellcheck disable=SC2016
+    printf '  mkdir -p "$(helm env HELM_PLUGINS)" && ln -s %q "$(helm env HELM_PLUGINS)/%s"\n' \
+      "$plugin_source" "${plugin_source##*/}" >&2
+    return
+  fi
+
+  printf '  helm plugin install %q\n' "$plugin_source" >&2
 }
 
 parse_args() {
@@ -174,7 +278,7 @@ check_required_tools() {
   MISSING_TOOLS=()
 
   for tool in "${REQUIRED_TOOLS[@]}"; do
-    if command_exists "$tool"; then
+    if tool_exists "$tool"; then
       PRESENT_TOOLS+=("$tool")
     else
       MISSING_TOOLS+=("$tool")
@@ -228,6 +332,23 @@ prepare_arch_package_plan() {
       ;;
     kubectl)
       append_unique PACMAN_PACKAGES_TO_INSTALL kubectl
+      ;;
+    helm)
+      append_unique PACMAN_PACKAGES_TO_INSTALL helm
+      ;;
+    helm-diff)
+      if ! pacman_package_installed helm-diff; then
+        append_unique AUR_PACKAGES_TO_INSTALL helm-diff
+      fi
+      append_unique HELM_PLUGINS_TO_INSTALL "diff=$ARCH_HELM_DIFF_PLUGIN_PATH"
+      ;;
+    helm-secrets)
+      if ! pacman_package_installed helm-secrets; then
+        append_unique AUR_PACKAGES_TO_INSTALL helm-secrets
+      fi
+      append_unique HELM_PLUGINS_TO_INSTALL "secrets=$ARCH_HELM_SECRETS_CLI_PLUGIN_PATH"
+      append_unique HELM_PLUGINS_TO_INSTALL "secrets-getter=$ARCH_HELM_SECRETS_GETTER_PLUGIN_PATH"
+      append_unique HELM_PLUGINS_TO_INSTALL "secrets-post-renderer=$ARCH_HELM_SECRETS_POST_RENDERER_PLUGIN_PATH"
       ;;
     flux)
       append_unique PACMAN_PACKAGES_TO_INSTALL fluxcd
@@ -296,6 +417,17 @@ prepare_ubuntu_package_plan() {
     kubectl)
       append_unique BREW_PACKAGES_TO_INSTALL kubernetes-cli
       ;;
+    helm)
+      append_unique BREW_PACKAGES_TO_INSTALL helm
+      ;;
+    helm-diff)
+      append_unique HELM_PLUGINS_TO_INSTALL "diff=$HELM_DIFF_PLUGIN_URL"
+      ;;
+    helm-secrets)
+      append_unique HELM_PLUGINS_TO_INSTALL "secrets=$HELM_SECRETS_CLI_PLUGIN_URL"
+      append_unique HELM_PLUGINS_TO_INSTALL "secrets-getter=$HELM_SECRETS_GETTER_PLUGIN_URL"
+      append_unique HELM_PLUGINS_TO_INSTALL "secrets-post-renderer=$HELM_SECRETS_POST_RENDERER_PLUGIN_URL"
+      ;;
     flux)
       append_unique BREW_PACKAGES_TO_INSTALL fluxcd/tap/flux
       ;;
@@ -335,6 +467,7 @@ build_install_plan() {
   APT_PACKAGES_TO_INSTALL=()
   BREW_PACKAGES_TO_INSTALL=()
   SNAP_CLASSIC_PACKAGES_TO_INSTALL=()
+  HELM_PLUGINS_TO_INSTALL=()
   MANUAL_TOOLS_TO_INSTALL=()
 
   for tool in "${MISSING_TOOLS[@]}"; do
@@ -373,13 +506,15 @@ print_tool_report() {
     return
   fi
 
-  log_warn "Missing required tools (${#MISSING_TOOLS[@]}):"
+  log_warn "Missing or unavailable required tools (${#MISSING_TOOLS[@]}):"
   for tool in "${MISSING_TOOLS[@]}"; do
     printf '  - %s\n' "$tool" >&2
   done
 }
 
 print_install_plan() {
+  local plugin_spec
+  local plugin_url
   local tool
 
   cat >&2 <<EOF
@@ -407,6 +542,15 @@ EOF
         printf '\n' >&2
       else
         printf '  No AUR packages need installation.\n' >&2
+      fi
+
+      if [[ ${#HELM_PLUGINS_TO_INSTALL[@]} -gt 0 ]]; then
+        for plugin_spec in "${HELM_PLUGINS_TO_INSTALL[@]}"; do
+          plugin_url="${plugin_spec#*=}"
+          print_helm_plugin_install_command "$plugin_url"
+        done
+      else
+        printf '  No Helm plugins need registration.\n' >&2
       fi
 
       if [[ ${#MANUAL_TOOLS_TO_INSTALL[@]} -gt 0 ]]; then
@@ -443,6 +587,15 @@ EOF
         printf '  No snap packages need installation.\n' >&2
       fi
 
+      if [[ ${#HELM_PLUGINS_TO_INSTALL[@]} -gt 0 ]]; then
+        for plugin_spec in "${HELM_PLUGINS_TO_INSTALL[@]}"; do
+          plugin_url="${plugin_spec#*=}"
+          print_helm_plugin_install_command "$plugin_url"
+        done
+      else
+        printf '  No Helm plugins need installation.\n' >&2
+      fi
+
       if [[ ${#MANUAL_TOOLS_TO_INSTALL[@]} -gt 0 ]]; then
         printf '  Manual installation still required for:\n' >&2
         for tool in "${MANUAL_TOOLS_TO_INSTALL[@]}"; do
@@ -456,6 +609,49 @@ EOF
       die "Unsupported distro family '$DISTRO_FAMILY'"
       ;;
   esac
+}
+
+install_helm_plugins() {
+  local plugin_destination
+  local plugin_name
+  local plugin_spec
+  local plugin_url
+  local plugins_dir
+
+  if [[ ${#HELM_PLUGINS_TO_INSTALL[@]} -eq 0 ]]; then
+    return
+  fi
+
+  command_exists helm || die "helm is required to install Helm plugins. Install helm and rerun the script."
+
+  for plugin_spec in "${HELM_PLUGINS_TO_INSTALL[@]}"; do
+    plugin_name="${plugin_spec%%=*}"
+    plugin_url="${plugin_spec#*=}"
+
+    if helm_plugin_spec_installed "$plugin_name"; then
+      continue
+    fi
+
+    if helm_plugin_source_is_local_path "$plugin_url"; then
+      [[ -d "$plugin_url" ]] || die "Helm plugin source does not exist: $plugin_url"
+
+      plugins_dir="$(helm env HELM_PLUGINS 2>/dev/null)" || die "Could not determine Helm plugin directory."
+      plugin_destination="$plugins_dir/${plugin_url##*/}"
+
+      mkdir -p "$plugins_dir"
+
+      if [[ -e "$plugin_destination" || -L "$plugin_destination" ]]; then
+        die "Helm plugin destination exists but $plugin_name is unavailable: $plugin_destination. Remove or fix it and rerun the script."
+      fi
+
+      log_info "Registering Helm plugin $plugin_name from $plugin_url"
+      ln -s "$plugin_url" "$plugin_destination"
+      continue
+    fi
+
+    log_info "Installing Helm plugin $plugin_name"
+    helm plugin install "$plugin_url"
+  done
 }
 
 install_missing_tools() {
@@ -474,6 +670,8 @@ install_missing_tools() {
         log_info "Installing missing AUR packages with $AUR_HELPER"
         "$AUR_HELPER" -S --needed "${AUR_PACKAGES_TO_INSTALL[@]}"
       fi
+
+      install_helm_plugins
 
       if [[ ${#MANUAL_TOOLS_TO_INSTALL[@]} -gt 0 ]]; then
         print_install_plan
@@ -498,6 +696,8 @@ install_missing_tools() {
         log_info "Installing missing snap packages"
         sudo snap install --classic "${SNAP_CLASSIC_PACKAGES_TO_INSTALL[@]}"
       fi
+
+      install_helm_plugins
 
       if [[ ${#MANUAL_TOOLS_TO_INSTALL[@]} -gt 0 ]]; then
         print_install_plan

--- a/scripts/bootstrap-host-tools.sh
+++ b/scripts/bootstrap-host-tools.sh
@@ -177,6 +177,12 @@ helm_plugin_source_is_local_path() {
   [[ "$plugin_source" == /* ]]
 }
 
+helm_plugin_source_is_tarball() {
+  local plugin_source="$1"
+
+  [[ "$plugin_source" == *.tgz || "$plugin_source" == *.tar.gz ]]
+}
+
 print_helm_plugin_install_command() {
   local plugin_source="$1"
 
@@ -184,6 +190,11 @@ print_helm_plugin_install_command() {
     # shellcheck disable=SC2016
     printf '  mkdir -p "$(helm env HELM_PLUGINS)" && ln -s %q "$(helm env HELM_PLUGINS)/%s"\n' \
       "$plugin_source" "${plugin_source##*/}" >&2
+    return
+  fi
+
+  if helm_plugin_source_is_tarball "$plugin_source"; then
+    printf '  helm plugin install --verify=false %q\n' "$plugin_source" >&2
     return
   fi
 
@@ -650,7 +661,11 @@ install_helm_plugins() {
     fi
 
     log_info "Installing Helm plugin $plugin_name"
-    helm plugin install "$plugin_url"
+    if helm_plugin_source_is_tarball "$plugin_url"; then
+      helm plugin install --verify=false "$plugin_url"
+    else
+      helm plugin install "$plugin_url"
+    fi
   done
 }
 


### PR DESCRIPTION
## Summary
- add helm, helm-diff, and helm-secrets to bootstrap host tool checks
- map Arch installs to pacman/AUR packages and register packaged Helm plugins locally
- map Ubuntu helm to Homebrew and install Helm plugins from upstream sources

## Validation
- bash -n scripts/bootstrap-host-tools.sh
- scripts/bootstrap-host-tools.sh --check
- git diff --check master...HEAD