### PR TITLE
fix(deps): revert immich-app/immich from v3.0.0 to v2.7.5

### DIFF
--- a/kubernetes/apps/apps/immich/helmrelease.yaml
+++ b/kubernetes/apps/apps/immich/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
             image:
               # renovate: datasource=github-tags depName=immich-app/immich
               repository: ghcr.io/immich-app/immich-server
-              tag: v3.0.0
+              tag: v2.7.5
             env:
               TZ: Europe/Berlin
               IMMICH_HELMET_FILE: true
@@ -88,7 +88,7 @@ spec:
             image:
               # renovate: datasource=github-tags depName=immich-app/immich
               repository: ghcr.io/immich-app/immich-machine-learning
-              tag: v3.0.0
+              tag: v2.7.5
             env:
               TZ: Europe/Berlin
               TRANSFORMERS_CACHE: /cache


### PR DESCRIPTION
Reverts #720.

Immich v3 doesn't have a stable release yet — only RCs. Renovate picked up `v3.0.0` which is a pre-release tag. This reverts the image tags back to `v2.7.5` for both `immich-server` and `immich-machine-learning`.
