### PR TITLE
fix(renovate): gate majors and track immich image tags

### DIFF
--- a/kubernetes/apps/apps/immich/helmrelease.yaml
+++ b/kubernetes/apps/apps/immich/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
         containers:
           server:
             image:
-              # renovate: datasource=github-tags depName=immich-app/immich
+              # renovate: datasource=docker depName=immich-app/immich-server registryUrl=https://ghcr.io
               repository: ghcr.io/immich-app/immich-server
               tag: v2.7.5
             env:
@@ -86,7 +86,7 @@ spec:
         containers:
           machine-learning:
             image:
-              # renovate: datasource=github-tags depName=immich-app/immich
+              # renovate: datasource=docker depName=immich-app/immich-machine-learning registryUrl=https://ghcr.io
               repository: ghcr.io/immich-app/immich-machine-learning
               tag: v2.7.5
             env:

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,8 @@
   "timezone": "UTC",
   "labels": ["dependencies", "renovate"],
   "commitMessagePrefix": "chore(deps):",
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
   "ignorePaths": ["kubernetes/clusters/production/flux-system/**"],
 
   "separateMajorMinor": true,
@@ -96,6 +98,11 @@
       "automergeType": "pr",
       "rebaseWhen": "conflicted",
       "automergeSchedule": ["at any time"]
+    },
+    {
+      "description": "Major updates wait before manual review",
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "5 days"
     },
     {
       "description": "Kubernetes major updates require manual review",


### PR DESCRIPTION
Summary:
- Track Immich server and machine-learning tags from GHCR Docker packages instead of the Immich GitHub repo tags.
- Add a 5-day minimum release age for all major updates.
- Delay Renovate PR creation until pending checks, including release-age checks, resolve.

Validation:
- jq empty renovate.json
- npx --yes --package renovate@39.4.0 renovate-config-validator renovate.json
- git diff --check
- commit hooks