### PR TITLE
feat(kubernetes): add AirTrail deployment

### DIFF
--- a/kubernetes/apps/apps/utils/airtrail/airtrail-db-secrets.sops.yaml
+++ b/kubernetes/apps/apps/utils/airtrail/airtrail-db-secrets.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: airtrail-db-secrets
+    namespace: utils
+type: Opaque
+stringData:
+    username: ENC[AES256_GCM,data:Up16a18qk/c=,iv:lbd0im56i23151YtrRqXxOyXiswBoLIPeCECK3HRgZY=,tag:8LiJ6CIQqcjuqmCdT89MLg==,type:str]
+    password: ENC[AES256_GCM,data:l8AC8Oi0E9R3xUZLKFvauTsrMXp3zY2ChJNXpJo0/+StcI45VzzAYQuOZTF6F1NNVjuaQErmdG7nOu7exO1q6w==,iv:X7RZ7KJ583VEMPYl2xOH/dhj3aDzjOwh+D1iM1uUDcs=,tag:gUFSiFMEWz3enk1JKueLxw==,type:str]
+    DB_URL: ENC[AES256_GCM,data:pzf6rydOj23KjzMdUMXsODAApgLgW4DyFDA0rfAi82AcA7ghPPm6W7S5q3R/DaAHjsUyC9B0oGq7O9S3ZvGSSdKZbjEzoU2UTh+wa6UGqmHTOOe5QFMuOq7kPKy9hIHOGyDEey6NVhQPHzjahGPACd0=,iv:QpKXl7/mbFpS8ILzgiDILW5VPQnGZfQsUbg+KLf9c9o=,tag:11i7MLwMhMSsalZJrMgb7g==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKWG1DOGJxZW5SdGpQTGcy
+            a0lsa0dsazVKa3lCMlZ3SXpCMk5GS1pCdjIwCkplUUxobmJZRWxNdUVoQjBGVEhy
+            Q3hpZXhUS2tXdWgzeWxxcXpvaWNqblEKLS0tIGVTbXZXMkZXWCs2NWRGVGxldWZo
+            M3NGMGVVanZrVTdUVkVad3dYYmgwUW8K71SwrxrJsFCH/BnXiIL2+eoc0lLEQ+jq
+            ObENnlARCyQ75U+I01IE7O6mBUpJwyd4jnp5WH2o03b3u/Ur0qK6Mw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-04T00:46:53Z"
+    mac: ENC[AES256_GCM,data:iAgzjqhy+NWcpxuSjs+CGBVfeSjWJJJFVDXDfaEFca5XnaO78eRYkJoPw+rIm0/gLrb5s546OdkkmQclR37RXeq3VpRKmEZsXo5SOGDwaFcdMjqmdBX4moTkDaeywnc/x+kGuvz5VGI4dbvoibnCBEsun1XQX5NFNf219gEOLt4=,iv:psW3qWtA24M4LVy6PTCiJ2uvp0XQ7jjkLuJJO6HaTeg=,tag:PJ596sM3uQyjpIk3KdqsOA==,type:str]
+    version: 3.13.2

--- a/kubernetes/apps/apps/utils/airtrail/airtrail-oidc-secrets.sops.yaml
+++ b/kubernetes/apps/apps/utils/airtrail/airtrail-oidc-secrets.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: airtrail-oidc-secrets
+    namespace: utils
+type: Opaque
+stringData:
+    OAUTH_CLIENT_ID: ENC[AES256_GCM,data:95AP2jX/wpePa4Gd3IPcWOSmGkO1a4RG8q2Ex7EyoWZKrMIG/BcKKio9Yz9Libd1vFkgS/nXhBVJYRmYT2dyrA==,iv:gCvRXVUN1A4vTxVYwsNFBXKkEKkeg3MvhyqY5cNdQfM=,tag:trzB4VSta8W+r2ssfwMV+A==,type:str]
+    OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:ap7S646raoeWNT2MTf/ON8xxV9yQXJa0t5duiO610ZPGPyjW/p/H1Tnu4mIRC0V64Y6aNK1T/V2/UZqjCnepKDejEFHJoBRSRkE29bzhYX+IFmPM1uP9/51Nk+ojXn4pW5vnYfSTiru2vkxhMuOGGD+PLnO1ONTq62HIYHinuAk=,iv:fYnU2SRdsPkVQVaAzoTflJzra5DhEVrOx+YgkpizQ/M=,tag:s2LO4te8KUmhWqUroh3AuA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKQTJESy8wSHVVMVpHcDkv
+            dHZQUXBmdkwrU0kwVDVnaHptUldzVlJWSUZVCjRnNjd3Y0w2Ty82MlJIdklsRHFW
+            NWc2a3RpWXVhek5mbGFWNDZRVGFiMHcKLS0tIGJ2QVhPVVRBUHJ2Nll3NFQyWGdw
+            RGdyTm5wSlk2dEhWYyt0Q1dnd0pITXMKztrOYQugYIfgwGzQX2HxyeqPDaya8nwp
+            pVEvlmZH2ReS+eNV0yov/E8lwrArKX2C3WTVWTyHbvbabMZm0Slupg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-04T00:46:53Z"
+    mac: ENC[AES256_GCM,data:alBm47CAPznM/Pg0be3j+mXD5xYs7QCNCcTyxxC0CQ5kCID2o2j/Pfc/MhA6zhI2UhV6jYo8WutCJzPqWTNBhSEreuzfQPx8mx9mhoDjc6q2z5XktGpRU/DX85LMf9J3j4cgDbwq/3svQ15CwXK+hDdBvbnAGMXB1ZzqNw/e33k=,iv:0c/780DuoYT7AJo13SqgrolErPAsOM1IQQqgwfSHQhY=,tag:uNUCWzbOLzRLbCgM/XEDvw==,type:str]
+    version: 3.13.2

--- a/kubernetes/apps/apps/utils/airtrail/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/utils/airtrail/cnpg-cluster.yaml
@@ -1,0 +1,69 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: airtrail-pg
+  namespace: utils
+  labels:
+    release: observability-kube-prometheus-stack
+spec:
+  inheritedMetadata:
+    labels:
+      recurring-job.longhorn.io/backup-daily: enabled
+      recurring-job.longhorn.io/backup-weekly: enabled
+  instances: 1
+  monitoring:
+    enablePodMonitor: true
+  storage:
+    size: 5Gi
+    storageClass: longhorn-r2
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+
+  postgresql:
+    parameters:
+      wal_level: "replica"
+      archive_timeout: "21600" # Wait 6 hours before shipping WALs when no activity
+      archive_mode: "on"
+
+  bootstrap:
+    initdb:
+      database: airtrail
+      owner: airtrail
+      secret:
+        name: airtrail-db-secrets
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS unaccent;
+
+  backup:
+    barmanObjectStore:
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-backup-s3
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-backup-s3
+          key: ACCESS_SECRET_KEY
+        region:
+          name: cnpg-backup-s3
+          key: AWS_DEFAULT_REGION
+      destinationPath: "s3://cloudnative-pg/airtrail"
+      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
+      serverName: "airtrail-pg-v1"
+    retentionPolicy: "14d"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: airtrail-pg-backup
+  namespace: utils
+spec:
+  schedule: "0 0 0 * * *"  # Daily at midnight
+  backupOwnerReference: self
+  cluster:
+    name: airtrail-pg
+  method: barmanObjectStore

--- a/kubernetes/apps/apps/utils/airtrail/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/airtrail/helmrelease.yaml
@@ -1,0 +1,133 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: airtrail
+  namespace: utils
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsUser: 1000
+        runAsGroup: 1000
+
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              # renovate: datasource=docker depName=johly/airtrail registryUrl=https://docker.io
+              repository: docker.io/johly/airtrail
+              tag: v3.11.1
+            env:
+              TZ: Europe/Berlin
+              NODE_ENV: production
+              HOST: 0.0.0.0
+              PORT: "3000"
+              ORIGIN: https://airtrail.lan.${CLUSTER_DOMAIN}
+              UPLOAD_LOCATION: /app/uploads
+              DB_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: airtrail-db-secrets
+                    key: DB_URL
+              OAUTH_ENABLED: "true"
+              OAUTH_ISSUER_URL: https://sso.${CLUSTER_DOMAIN}/application/o/airtrail/
+              OAUTH_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: airtrail-oidc-secrets
+                    key: OAUTH_CLIENT_ID
+              OAUTH_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: airtrail-oidc-secrets
+                    key: OAUTH_CLIENT_SECRET
+              OAUTH_TOKEN_ENDPOINT_AUTH_METHOD: client_secret_post
+              OAUTH_SCOPE: openid profile email
+              OAUTH_AUTO_REGISTER: "true"
+              OAUTH_AUTO_LOGIN: "false"
+              OAUTH_HIDE_PASSWORD_FORM: "false"
+              OAUTH_BUTTON_TEXT: Log in with Authentik
+            ports:
+              - name: http
+                containerPort: 3000
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/ping
+                    port: 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/ping
+                    port: 3000
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/ping
+                    port: 3000
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 2000m
+                memory: 2Gi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 3000
+
+    ingress:
+      main:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: airtrail.lan.${CLUSTER_DOMAIN}
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: AirTrail
+          gethomepage.dev/description: Flight history tracker
+          gethomepage.dev/group: "Kubernetes"
+          gethomepage.dev/icon: air-trail.png
+        hosts:
+          - host: airtrail.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+
+    persistence:
+      uploads:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: airtrail
+        globalMounts:
+          - path: /app/uploads

--- a/kubernetes/apps/apps/utils/airtrail/kustomization.yaml
+++ b/kubernetes/apps/apps/utils/airtrail/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+  - ../../../../components/ingress/traefik-base
+
+resources:
+  - airtrail-db-secrets.sops.yaml
+  - airtrail-oidc-secrets.sops.yaml
+  - cnpg-cluster.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../apps/utils/it-tools
   - ../apps/utils/searxng
   - ../apps/utils/dawarich
+  - ../apps/utils/airtrail
   - ../apps/nextcloud
   - ../apps/media/audiobookshelf
   - ../apps/media/jellyfin

--- a/kubernetes/apps/storage/pvcs/utils/airtrail-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/utils/airtrail-pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: airtrail
+  namespace: utils
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/apps/storage/pvcs/utils/kustomization.yaml
+++ b/kubernetes/apps/storage/pvcs/utils/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - airtrail-pvc.yaml
   - bambuddy-data-pvc.yaml
   - bambuddy-logs-pvc.yaml
   - dawarich-pvc.yaml

--- a/kubernetes/infrastructure/security/authentik/install/airtrail-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/airtrail-sso-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: airtrail-sso-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:kzscz1+lC/1f05eDB9/l24FVZHr0IoRlXLSPBH1oHTrMqd+DFU/5n4Y9S3KwKXGE3gCm9fDkRRHALZdk/fpjqw==,iv:GIjwA6SlvY0ATe81y2Sq37Syf9lMLmGsiI9Q6YDEneY=,tag:HoK0mOMmttLElD+X0GI0xQ==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:uy4+ZnCQ5yFVFNagDYvy+xNXS71rk5aZwW2zeZ10TeozU+VAnJLDOZbf40k/j84KhUQWyQNe4RAikZ6QjJCVEwEkJ1KRSg30hRYeV65I4KeBz3gFXAaFdp765YfJ38qK7zapUQ/pSZHSZi8W0hFDPMkNbmcx0P1vHcJwU8n4U7s=,iv:PmxtnW3bVBreaGND6/Rq1+JtV09MLkgXURLPUQktEUY=,tag:loiZBA7rM6tt3At+GDSFYQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3cGhGeEZEaHBGdHY2WFFh
+            cHYxRnJjNDlacHdLVlFMb3NJR0ttalZUa3owCmFFbWRQa3dwVTVrS0tEQXVocU81
+            Mm91dEJpT3MwRitib2JuY2RjNW4wNjgKLS0tIFc1eDF4OE9BN013L2d2OHRQbTJJ
+            eTFNbzFXeWNtbURFcFZGWU1lR2NQenMK+xeoFPySPS5ZbVA5je0M98XIgVMbPX+u
+            i1dDfebUOFK0Nfl3WzmnCgKYhA7GzhcotFtBl5wbn55z94d9zj2TVw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-04T00:46:53Z"
+    mac: ENC[AES256_GCM,data:znalJUJHaByjiTbH5y0fDSYqitviMedjx/ayEvH38uT/sePeyrmK6N5AQ8mRDJop8SnB8m0AkuzIqzNxfZMJjHOeuJPo9vshP+VL8MWJWsHEgfOdxBFmG0wCUIj70Ox2JulFLWEYi8rKZMUAHBm52UTzlUcNKE7CfJm9O/qALyc=,iv:HPsh1DlXTRKRZJsCYEl08izs7+qeL6SCiGJe8LRrCCw=,tag:ijDvNrFXsJ2r7bmOOatEBQ==,type:str]
+    version: 3.13.2

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -571,6 +571,64 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "Dawarich Users"]]
 
+  253-airtrail.yaml: |
+    version: 1
+    metadata:
+      name: airtrail-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # AirTrail Users group
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "AirTrail Users"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # OAuth2 Provider for AirTrail
+      - model: authentik_providers_oauth2.oauth2provider
+        id: airtrail-provider
+        identifiers:
+          name: "AirTrail"
+        attrs:
+          client_id: !Env AIRTRAIL_CLIENT_ID
+          client_secret: !Env AIRTRAIL_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          encryption_key: null
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_post
+          redirect_uris:
+            - url: "https://airtrail.lan.${CLUSTER_DOMAIN}/login"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+
+      # AirTrail Application
+      - model: authentik_core.application
+        identifiers:
+          slug: "airtrail"
+        attrs:
+          name: "AirTrail"
+          provider: !KeyOf airtrail-provider
+          group: "Utils"
+
+      # Restrict access to AirTrail Users
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "airtrail"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "AirTrail Users"]]
+
   255-nextcloud.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -122,6 +122,16 @@ spec:
             secretKeyRef:
               name: dawarich-sso-secret
               key: CLIENT_SECRET
+        - name: AIRTRAIL_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: airtrail-sso-secret
+              key: CLIENT_ID
+        - name: AIRTRAIL_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: airtrail-sso-secret
+              key: CLIENT_SECRET
         - name: NEXTCLOUD_CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - immich-sso-secret.sops.yaml
   - paperless-sso-secret.sops.yaml
   - dawarich-sso-secret.sops.yaml
+  - airtrail-sso-secret.sops.yaml
   - nextcloud-sso-secret.sops.yaml
   - litellm-sso-secret.sops.yaml
   - librechat-sso-secret.sops.yaml


### PR DESCRIPTION
## Summary
- add AirTrail app-template deployment under utils with LAN ingress and Homepage annotations
- add CNPG Postgres, uploads PVC, and SOPS-encrypted app/OIDC secrets
- add Authentik OIDC provider/application blueprint and secret wiring

## Validation
- kubectl apply --dry-run=client -k kubernetes/apps/apps/utils/airtrail
- kubectl apply --dry-run=client -k kubernetes/apps/storage/pvcs/utils
- kubectl apply --dry-run=client -k kubernetes/infrastructure/security/authentik/install
- kubectl apply --dry-run=client -k kubernetes/apps/production
- kubectl apply --dry-run=client -k kubernetes/apps/storage/production
- git diff --check
- docker manifest inspect ghcr.io/cloudnative-pg/postgresql:16
- pre-commit hooks via git commit

## Notes
- Initial AirTrail owner still needs to be created through /setup before relying on OIDC login.