### PR TITLE
feat(kubernetes): add WatchState deployment

### DIFF
--- a/kubernetes/apps/apps/media/watchstate/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/watchstate/helmrelease.yaml
@@ -1,0 +1,123 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: watchstate
+  namespace: media
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsUser: 1000
+        runAsGroup: 1000
+    controllers:
+      main:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              # renovate: datasource=docker depName=arabcoders/watchstate registryUrl=https://ghcr.io
+              repository: ghcr.io/arabcoders/watchstate
+              tag: v1.9.1
+            env:
+              TZ: Europe/Berlin
+              WS_TZ: Europe/Berlin
+              WS_SECURE_API_ENDPOINTS: "true"
+              WS_TRUST_PROXY: "true"
+              WS_TRUST_LOCAL: "true"
+              WS_GUID_PATH_ENABLED: "true"
+            envFrom:
+              - secretRef:
+                  name: watchstate-secrets
+            ports:
+              - name: http
+                containerPort: 8080
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v1/api/system/healthcheck
+                    port: 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v1/api/system/healthcheck
+                    port: 8080
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v1/api/system/healthcheck
+                    port: 8080
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 8080
+    ingress:
+      main:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: watchstate.lan.${CLUSTER_DOMAIN}
+          gethomepage.dev/name: WatchState
+          gethomepage.dev/description: Media watch state sync
+          gethomepage.dev/group: "Kubernetes"
+          gethomepage.dev/icon: watchstate.png
+          gethomepage.dev/enabled: "true"
+        hosts:
+          - host: watchstate.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+      webhook:
+        enabled: true
+        className: traefik
+        annotations:
+          traefik.ingress.kubernetes.io/router.middlewares: traefik-lan-allowlist@kubernetescrd
+          traefik.ingress.kubernetes.io/router.priority: "100"
+        hosts:
+          - host: watchstate.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /v1/api/webhook
+                service:
+                  identifier: main
+                  port: http
+    persistence:
+      config:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: watchstate
+        globalMounts:
+          - path: /config

--- a/kubernetes/apps/apps/media/watchstate/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/watchstate/helmrelease.yaml
@@ -29,8 +29,6 @@ spec:
               TZ: Europe/Berlin
               WS_TZ: Europe/Berlin
               WS_SECURE_API_ENDPOINTS: "true"
-              WS_TRUST_PROXY: "true"
-              WS_TRUST_LOCAL: "true"
               WS_GUID_PATH_ENABLED: "true"
             envFrom:
               - secretRef:

--- a/kubernetes/apps/apps/media/watchstate/kustomization.yaml
+++ b/kubernetes/apps/apps/media/watchstate/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+  - ../../../../components/ingress/traefik-base
+  - ../../../../components/ingress/auth-guard
+resources:
+  - helmrelease.yaml
+  - secret.sops.yaml

--- a/kubernetes/apps/apps/media/watchstate/secret.sops.yaml
+++ b/kubernetes/apps/apps/media/watchstate/secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: watchstate-secrets
+    namespace: media
+type: Opaque
+stringData:
+    WS_SYSTEM_USER: ENC[AES256_GCM,data:sxpAX9I=,iv:nwX60O/l3bHbKgShFsY44UvkeSK6S2v3Dt3E8rHXtt4=,tag:dRA+eNKK3U5muQ6JdZKuqA==,type:str]
+    WS_SYSTEM_PASSWORD: ENC[AES256_GCM,data:wI0ZDJfG9/52ZvZEmtB+K1nlASFqYwXaCsRAAVLojXCzVKcau5/SAA9DU5vkQzWk+McPlJajpJLxkO/pbPV2jsnPI/RY,iv:0QByq2BgX7jTz6j+8uhmNmpt1QhPjdw1KUquPFvTDl4=,tag:2knB/jWJANcm2BHNMgwRiQ==,type:str]
+    WS_SYSTEM_SECRET: ENC[AES256_GCM,data:Q4ZNN6cHb+C69xbtM9TK5qL6d725F6gy33nwH3BFoA73kpbJz5mMUoLLMkIjY2D0Z8BNDsEKcHvQ6YKijRHYF+7X20gAW582bv6KuC43Jogxxsqewg3wRLnpV0Ou+YDN,iv:y34iyR/57qCEgBg84RTNx/Vk4oASFfKOPCIUtR1L2UY=,tag:ir6s01xDuXg5nHj8nceQ5g==,type:str]
+    WS_API_KEY: ENC[AES256_GCM,data:kaUUQqWu1QcANvqhiuiqEJK3O0qeVdOnMnwyGaIqtLZPA0wjwjfe62chwmubk0b4tvUa4o+NOp7yLFcHmMHMjw==,iv:/bxYQ4SwCSKFFnR+T4dRx4VR3xme0EPmLMASAcd5gLQ=,tag:T414zdTc+cdOXgEn9rkGRw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSNUxkVmJnRTdKQXVRTlhq
+            TlNtUStwVXF6NjdEYWMzUkMzUEZiOVBOb1dRCmxvdUs4Tk8rZFVNR3FXTUo4ZFM1
+            QXhzbks0N1NtcjFxY2hqT2wxRC9pU0UKLS0tIFB1Um1nL2pTeHpZTWZpQ3RZbmVo
+            UTYyemxKUkxtTlRCT0JPNzBoVDRjQzAKHSbFtoZd707WDe7rwUoWzu6fKyO07Xtg
+            Gg2gWyOeNP7GzmuYdEkNDnT26yxGVqcf2SUcfVB56Mo6qh9uNfK3AA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-04T18:42:06Z"
+    mac: ENC[AES256_GCM,data:U6Zj3NNybZQQMu7v8Lai7qHyz4ndN5aE9LYjYUhYpavCohOLy+6toC8jrNDgEJg6GOQK0OGkYAAEUWwq3LKmY1y/G/q4WYVyM7UTL+wpwLc1zCXMW3ylp2d8bajl4tF7355qJsb80KDs6o+kuGk9iCv2uo8JnQlzb/aA/FrlMSk=,iv:6/ubsHmI0uRpae58WuevMJPu47XoWiVParipnyMRGFU=,tag:lfw6mcB/uekNocaTzayTxw==,type:str]
+    version: 3.13.2

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
   - ../apps/security/frigate
   - ../apps/immich
   - ../apps/media/jellyplex-watched
+  - ../apps/media/watchstate
   - ../apps/utils/discord-presence
   - ../apps/media/plextraktsync
   - ../apps/media/plex-media-enrichment

--- a/kubernetes/apps/storage/pvcs/media/kustomization.yaml
+++ b/kubernetes/apps/storage/pvcs/media/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - sonarr-pvc.yaml
   - tautulli-pvc.yaml
   - tidarr-pvc.yaml
+  - watchstate-pvc.yaml

--- a/kubernetes/apps/storage/pvcs/media/watchstate-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/media/watchstate-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: watchstate
+  namespace: media
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
## Summary
- add WatchState as a parallel media app without removing jellyplex-watched
- add Authentik-protected UI ingress and LAN-allowlisted webhook ingress with API-key enforcement
- add SOPS-encrypted WatchState auth/API settings and a Longhorn-backed config PVC

## Testing
- sops --decrypt kubernetes/apps/apps/media/watchstate/secret.sops.yaml >/dev/null
- kubectl apply --dry-run=client -k kubernetes/apps/apps/media/watchstate
- kubectl apply --dry-run=client -f kubernetes/apps/storage/pvcs/media/watchstate-pvc.yaml
- kubectl kustomize kubernetes/apps/production >/dev/null
- kubectl kustomize kubernetes/apps/storage/production >/dev/null
- pre-commit run --files kubernetes/apps/apps/media/watchstate/helmrelease.yaml kubernetes/apps/apps/media/watchstate/kustomization.yaml kubernetes/apps/apps/media/watchstate/secret.sops.yaml kubernetes/apps/storage/pvcs/media/watchstate-pvc.yaml kubernetes/apps/storage/pvcs/media/kustomization.yaml kubernetes/apps/production/kustomization.yaml