### PR TITLE
fix(kubernetes): enable WatchState auth bypass

### DIFF
--- a/kubernetes/apps/apps/media/watchstate/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/watchstate/helmrelease.yaml
@@ -29,6 +29,7 @@ spec:
               TZ: Europe/Berlin
               WS_TZ: Europe/Berlin
               WS_SECURE_API_ENDPOINTS: "true"
+              WS_TRUST_LOCAL: "true"
               WS_GUID_PATH_ENABLED: "true"
             envFrom:
               - secretRef:


### PR DESCRIPTION
## Summary
- reuse the existing Authentik gatekeeper/auth-guard middleware for WatchState
- enable WatchState trusted-local auto-login with WS_TRUST_LOCAL=true
- keep WS_SECURE_API_ENDPOINTS=true so webhook/API routes still require WatchState API auth

## Notes
- no dedicated Authentik application/provider or Traefik middleware is added
- this leaves the current watchstate-main ingress behind traefik-gatekeeper-auth-chain and keeps the webhook ingress LAN-allowlisted

## Testing
- kubectl apply --dry-run=client -k kubernetes/apps/apps/media/watchstate
- kubectl kustomize kubernetes/apps/production >/dev/null
- pre-commit run --files kubernetes/apps/apps/media/watchstate/helmrelease.yaml
- git diff --check