### PR TITLE
fix(librechat): run mongodb as statefulset

### DIFF
--- a/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/librechat/helmrelease.yaml
@@ -173,6 +173,9 @@ spec:
                 memory: 512Mi
 
       mongodb:
+        type: statefulset
+        replicas: 1
+        strategy: RollingUpdate
         containers:
           mongodb:
             image:


### PR DESCRIPTION
## Summary
- Run LibreChat MongoDB as a single-replica StatefulSet
- Keep the existing PVC and service wiring unchanged
- Make MongoDB updates replace the stable pod identity instead of creating a second Deployment pod against the RWO volume

## Validation
- kubectl apply --dry-run=client -k kubernetes/apps/apps/ai/librechat
- helm template librechat app-template --repo https://bjw-s-labs.github.io/helm-charts/ --version 5.0.1 --namespace ai --values <(yq '.spec.values' kubernetes/apps/apps/ai/librechat/helmrelease.yaml) | kubectl apply --dry-run=client -f -
- git diff --check
- commit hooks, including kubeconform rendered Kubernetes manifests