### PR TITLE
fix(litellm): remove unsupported ultra reasoning

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -599,7 +599,7 @@ data:
         "extra_headers",
     ]
 
-    REASONING_LEVELS = ["low", "medium", "high", "xhigh", "max", "ultra"]
+    REASONING_LEVELS = ["low", "medium", "high", "xhigh", "max"]
 
     CHATGPT_CODEX_MODELS = {
         "gpt-5.6-sol": {
@@ -623,7 +623,7 @@ data:
             ],
             "additional_speed_tiers": ["fast"],
             "truncation_policy": {"mode": "tokens", "limit": 10000},
-            "supported_reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"],
+            "supported_reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
             "input_cost_per_token": 0.000005,
             "output_cost_per_token": 0.00003,
         },
@@ -648,7 +648,7 @@ data:
             ],
             "additional_speed_tiers": ["fast"],
             "truncation_policy": {"mode": "tokens", "limit": 10000},
-            "supported_reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"],
+            "supported_reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
             "input_cost_per_token": 0.0000025,
             "output_cost_per_token": 0.000015,
         },


### PR DESCRIPTION
## Summary
- Remove the account-catalog `ultra` reasoning effort from GPT-5.6 Sol and Terra.
- Keep the live ChatGPT Responses backend-supported `max` effort.

## Runtime Evidence
- The deployed ChatGPT Responses backend rejects `reasoning.effort: "ultra"` with HTTP 400.
- The model metadata validation and rendered manifest dry-run pass.

## Validation
- Embedded catalog metadata assertion
- `kubectl kustomize kubernetes/apps/apps/ai/litellm`
- `kubectl apply --dry-run=client -f /tmp/litellm-reasoning-efforts-rendered.yaml`
- Commit hooks: YAML validation, yamllint, and kubeconform