### PR TITLE
fix(litellm): advertise GPT-5.6 none reasoning

### DIFF
--- a/kubernetes/apps/apps/ai/litellm/configmap.yaml
+++ b/kubernetes/apps/apps/ai/litellm/configmap.yaml
@@ -599,7 +599,7 @@ data:
         "extra_headers",
     ]
 
-    REASONING_LEVELS = ["low", "medium", "high", "xhigh", "max"]
+    REASONING_LEVELS = ["none", "low", "medium", "high", "xhigh", "max"]
 
     CHATGPT_CODEX_MODELS = {
         "gpt-5.6-sol": {
@@ -623,7 +623,7 @@ data:
             ],
             "additional_speed_tiers": ["fast"],
             "truncation_policy": {"mode": "tokens", "limit": 10000},
-            "supported_reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+            "supported_reasoning_efforts": ["none", "low", "medium", "high", "xhigh", "max"],
             "input_cost_per_token": 0.000005,
             "output_cost_per_token": 0.00003,
         },
@@ -648,7 +648,7 @@ data:
             ],
             "additional_speed_tiers": ["fast"],
             "truncation_policy": {"mode": "tokens", "limit": 10000},
-            "supported_reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+            "supported_reasoning_efforts": ["none", "low", "medium", "high", "xhigh", "max"],
             "input_cost_per_token": 0.0000025,
             "output_cost_per_token": 0.000015,
         },
@@ -673,7 +673,7 @@ data:
             ],
             "additional_speed_tiers": ["fast"],
             "truncation_policy": {"mode": "tokens", "limit": 10000},
-            "supported_reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+            "supported_reasoning_efforts": ["none", "low", "medium", "high", "xhigh", "max"],
             "input_cost_per_token": 0.000001,
             "output_cost_per_token": 0.000006,
         },


### PR DESCRIPTION
## Summary
- Advertise `none` reasoning for the GPT-5.6 Sol, Terra, and Luna routes.
- Preserve `max` and omit backend-rejected `ultra`.

## Runtime Evidence
- A live authenticated Terra Responses request with `reasoning.effort: "none"` completed successfully.

## Validation
- Embedded catalog metadata assertion
- `kubectl kustomize kubernetes/apps/apps/ai/litellm`
- `kubectl apply --dry-run=client -f /tmp/litellm-none-reasoning-rendered.yaml`
- Commit hooks: YAML validation, yamllint, and kubeconform