### PR TITLE
feat(jellyfin): automate media server bootstrap

### DIFF
--- a/kubernetes/apps/apps/media/jellyfin/automation-config.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/automation-config.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jellyfin-automation
+  namespace: media
+data:
+  enabled: "true"
+  plugins.json: |
+    [
+      {"name":"Intro Skipper","guid":"c83d86bba1e04c35a113e2101cf4ee6","version":"1.10.11.22","repositoryUrl":"https://intro-skipper.org/manifest.json"},
+      {"name":"LDAP Authentication","guid":"958aad6637844d2ab89aa7b6fab6e25c","version":"23.0.0.0","repositoryUrl":"https://repo.jellyfin.org/files/plugin/manifest.json"},
+      {"name":"TheTVDB","guid":"a677c0dafac54cde941a7134223f14c8","version":"22.0.0.0","repositoryUrl":"https://repo.jellyfin.org/files/plugin/manifest.json"},
+      {"name":"Webhook","guid":"71552a5a5c5c4350a2aeebe451a30173","version":"21.0.0.0","repositoryUrl":"https://repo.jellyfin.org/files/plugin/manifest.json"}
+    ]
+  libraries.json: |
+    [
+      {"name":"Anime Movies","path":"/data/libraries/anime_movies","collectionType":"movies","profile":"anime_movie"},
+      {"name":"Anime Shows","path":"/data/libraries/anime","collectionType":"tvshows","profile":"anime_show"},
+      {"name":"Movies","path":"/data/libraries/movies","collectionType":"movies","profile":"movie"},
+      {"name":"Music","path":"/data/libraries/music","collectionType":"music","profile":"music"},
+      {"name":"Music Videos","path":"/data/libraries/music_videos","collectionType":"musicvideos","profile":"music_video"},
+      {"name":"TV Shows","path":"/data/libraries/tv","collectionType":"tvshows","profile":"tv_show"}
+    ]

--- a/kubernetes/apps/apps/media/jellyfin/automation-cronjob.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/automation-cronjob.yaml
@@ -1,0 +1,206 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: jellyfin-automation
+  namespace: media
+spec:
+  suspend: false
+  schedule: "17 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: configure
+              # renovate: datasource=docker depName=library/python registryUrl=https://docker.io
+              image: docker.io/library/python:3.13-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              command:
+                - sh
+                - -ec
+                - |
+                  exec python3 - <<'PY'
+                  import json
+                  import os
+                  import urllib.error
+                  import urllib.parse
+                  import urllib.request
+
+                  if os.environ["JELLYFIN_AUTOMATION_ENABLED"] != "true":
+                      print("Jellyfin automation is disabled.")
+                      raise SystemExit(0)
+
+                  api_key = os.environ.get("JELLYFIN_API_KEY")
+                  if not api_key:
+                      raise SystemExit("JELLYFIN_API_KEY is required when automation is enabled.")
+
+                  common_options = {
+                      "Enabled": True,
+                      "EnablePhotos": True,
+                      "EnableRealtimeMonitor": True,
+                      "EnableLUFSScan": True,
+                      "SaveLocalMetadata": False,
+                      "EnableInternetProviders": False,
+                      "EnableEmbeddedTitles": False,
+                      "EnableEmbeddedExtrasTitles": False,
+                      "EnableEmbeddedEpisodeInfos": False,
+                      "SeasonZeroDisplayName": "Specials",
+                      "MetadataSavers": [],
+                      "DisabledLocalMetadataReaders": [],
+                      "LocalMetadataReaderOrder": ["Nfo"],
+                      "DisabledSubtitleFetchers": [],
+                      "SubtitleFetcherOrder": [],
+                      "DisabledMediaSegmentProviders": [],
+                      "MediaSegmentProviderOrder": [],
+                      "SkipSubtitlesIfEmbeddedSubtitlesPresent": False,
+                      "SkipSubtitlesIfAudioTrackMatches": False,
+                      "SubtitleDownloadLanguages": [],
+                      "RequirePerfectSubtitleMatch": True,
+                      "SaveSubtitlesWithMedia": True,
+                      "SaveLyricsWithMedia": False,
+                      "SaveTrickplayWithMedia": False,
+                      "DisabledLyricFetchers": [],
+                      "LyricFetcherOrder": [],
+                      "PreferNonstandardArtistsTag": False,
+                      "UseCustomTagDelimiters": False,
+                      "CustomTagDelimiters": ["/", "|", ";", "\\"],
+                      "DelimiterWhitelist": [],
+                      "AutomaticallyAddToCollection": False,
+                      "AllowEmbeddedSubtitles": "AllowAll",
+                  }
+
+                  movie_type_options = [{
+                      "Type": "Movie",
+                      "MetadataFetchers": ["TheMovieDb", "The Open Movie Database"],
+                      "MetadataFetcherOrder": ["TheMovieDb", "The Open Movie Database"],
+                      "ImageFetchers": ["TheMovieDb", "The Open Movie Database", "Embedded Image Extractor", "Screen Grabber"],
+                      "ImageFetcherOrder": ["TheMovieDb", "The Open Movie Database", "Embedded Image Extractor", "Screen Grabber"],
+                      "ImageOptions": [],
+                  }]
+                  show_type_options = [
+                      {"Type": "Series", "MetadataFetchers": ["TheMovieDb", "The Open Movie Database"], "MetadataFetcherOrder": ["TheMovieDb", "The Open Movie Database"], "ImageFetchers": ["TheMovieDb"], "ImageFetcherOrder": ["TheMovieDb"], "ImageOptions": []},
+                      {"Type": "Season", "MetadataFetchers": ["TheMovieDb"], "MetadataFetcherOrder": ["TheMovieDb"], "ImageFetchers": ["TheMovieDb"], "ImageFetcherOrder": ["TheMovieDb"], "ImageOptions": []},
+                      {"Type": "Episode", "MetadataFetchers": ["TheMovieDb", "The Open Movie Database"], "MetadataFetcherOrder": ["TheMovieDb", "The Open Movie Database"], "ImageFetchers": ["TheMovieDb", "The Open Movie Database", "Embedded Image Extractor", "Screen Grabber"], "ImageFetcherOrder": ["TheMovieDb", "The Open Movie Database", "Embedded Image Extractor", "Screen Grabber"], "ImageOptions": []},
+                  ]
+                  profiles = {
+                      "anime_movie": {"EnableChapterImageExtraction": True, "ExtractChapterImagesDuringLibraryScan": True, "EnableTrickplayImageExtraction": True, "ExtractTrickplayImagesDuringLibraryScan": True, "EnableAutomaticSeriesGrouping": False, "AutomaticRefreshIntervalDays": 0, "PreferredMetadataLanguage": "ja", "MetadataCountryCode": "JP", "TypeOptions": movie_type_options},
+                      "anime_show": {"EnableChapterImageExtraction": True, "ExtractChapterImagesDuringLibraryScan": True, "EnableTrickplayImageExtraction": True, "ExtractTrickplayImagesDuringLibraryScan": True, "EnableAutomaticSeriesGrouping": True, "AutomaticRefreshIntervalDays": 0, "PreferredMetadataLanguage": "ja", "MetadataCountryCode": "JP", "TypeOptions": show_type_options},
+                      "movie": {"EnableChapterImageExtraction": True, "ExtractChapterImagesDuringLibraryScan": True, "EnableTrickplayImageExtraction": True, "ExtractTrickplayImagesDuringLibraryScan": True, "EnableAutomaticSeriesGrouping": False, "AutomaticRefreshIntervalDays": 30, "PreferredMetadataLanguage": "", "MetadataCountryCode": "", "TypeOptions": movie_type_options},
+                      "music": {"EnableChapterImageExtraction": False, "ExtractChapterImagesDuringLibraryScan": False, "EnableTrickplayImageExtraction": False, "ExtractTrickplayImagesDuringLibraryScan": False, "EnableAutomaticSeriesGrouping": False, "AutomaticRefreshIntervalDays": 30, "PreferredMetadataLanguage": "", "MetadataCountryCode": "", "SaveLyricsWithMedia": True, "TypeOptions": [{"Type": "MusicArtist", "MetadataFetchers": ["MusicBrainz"], "MetadataFetcherOrder": ["TheAudioDB", "MusicBrainz"], "ImageFetchers": ["TheAudioDB"], "ImageFetcherOrder": ["TheAudioDB"], "ImageOptions": []}, {"Type": "MusicAlbum", "MetadataFetchers": ["MusicBrainz"], "MetadataFetcherOrder": ["MusicBrainz", "TheAudioDB"], "ImageFetchers": ["TheAudioDB"], "ImageFetcherOrder": ["TheAudioDB"], "ImageOptions": []}, {"Type": "Audio", "MetadataFetchers": [], "MetadataFetcherOrder": [], "ImageFetchers": ["Image Extractor"], "ImageFetcherOrder": ["Image Extractor"], "ImageOptions": []}, {"Type": "MusicVideo", "MetadataFetchers": [], "MetadataFetcherOrder": [], "ImageFetchers": ["Embedded Image Extractor", "Screen Grabber"], "ImageFetcherOrder": ["Embedded Image Extractor", "Screen Grabber"], "ImageOptions": []}]},
+                      "music_video": {"EnableChapterImageExtraction": True, "ExtractChapterImagesDuringLibraryScan": True, "EnableTrickplayImageExtraction": True, "ExtractTrickplayImagesDuringLibraryScan": True, "EnableAutomaticSeriesGrouping": False, "AutomaticRefreshIntervalDays": 0, "PreferredMetadataLanguage": "", "MetadataCountryCode": "", "TypeOptions": [{"Type": "MusicVideo", "MetadataFetchers": [], "MetadataFetcherOrder": [], "ImageFetchers": ["Embedded Image Extractor", "Screen Grabber"], "ImageFetcherOrder": ["Embedded Image Extractor", "Screen Grabber"], "ImageOptions": []}]},
+                      "tv_show": {"EnableChapterImageExtraction": True, "ExtractChapterImagesDuringLibraryScan": True, "EnableTrickplayImageExtraction": True, "ExtractTrickplayImagesDuringLibraryScan": True, "EnableAutomaticSeriesGrouping": True, "AutomaticRefreshIntervalDays": 0, "PreferredMetadataLanguage": "", "MetadataCountryCode": "", "TypeOptions": show_type_options},
+                  }
+
+                  def request(method, path, payload=None):
+                      data = json.dumps(payload).encode() if payload is not None else None
+                      request = urllib.request.Request(
+                          f"http://jellyfin.media.svc.cluster.local:8096{path}",
+                          data=data,
+                          method=method,
+                          headers={"X-Emby-Token": api_key, "Content-Type": "application/json"},
+                      )
+                      try:
+                          with urllib.request.urlopen(request, timeout=30) as response:
+                              return json.load(response) if response.length != 0 else None
+                      except urllib.error.HTTPError as error:
+                          raise SystemExit(f"{method} {path} failed: {error.code} {error.read().decode()}") from error
+
+                  repositories = [
+                      {"Name": "Jellyfin Stable", "Url": "https://repo.jellyfin.org/files/plugin/manifest.json", "Enabled": True},
+                      {"Name": "Intro-Skipper", "Url": "https://intro-skipper.org/manifest.json", "Enabled": True},
+                  ]
+                  request("POST", "/Repositories", repositories)
+
+                  available_packages = {
+                      package["guid"]: package for package in request("GET", "/Packages")
+                  }
+                  installed_plugins = {
+                      plugin["Id"]: plugin for plugin in request("GET", "/Plugins")
+                  }
+                  for plugin in json.load(open("/config/plugins.json")):
+                      installed = installed_plugins.get(plugin["guid"])
+                      if installed and installed["Version"] == plugin["version"]:
+                          print(f"{plugin['name']} {plugin['version']} is installed.")
+                          continue
+
+                      package = available_packages.get(plugin["guid"])
+                      if not package or not any(
+                          version["version"] == plugin["version"]
+                          and version["repositoryUrl"] == plugin["repositoryUrl"]
+                          for version in package["versions"]
+                      ):
+                          raise SystemExit(f"{plugin['name']} {plugin['version']} is unavailable.")
+
+                      query = urllib.parse.urlencode({
+                          "assemblyGuid": plugin["guid"],
+                          "version": plugin["version"],
+                          "repositoryUrl": plugin["repositoryUrl"],
+                      })
+                      request("POST", f"/Packages/Installed/{urllib.parse.quote(plugin['name'])}?{query}")
+                      print(f"Installed {plugin['name']} {plugin['version']}; restart Jellyfin to load it.")
+
+                  libraries = json.load(open("/config/libraries.json"))
+                  existing = {library["Name"]: library for library in request("GET", "/Library/VirtualFolders")}
+                  for library in libraries:
+                      current = existing.get(library["name"])
+                      if current:
+                          if current["CollectionType"] != library["collectionType"] or current["Locations"] != [library["path"]]:
+                              raise SystemExit(f"{library['name']} conflicts with the configured library type or path.")
+                          print(f"{library['name']} already exists.")
+                          continue
+
+                      query = urllib.parse.urlencode([
+                          ("name", library["name"]),
+                          ("collectionType", library["collectionType"]),
+                          ("refreshLibrary", "false"),
+                          ("paths", library["path"]),
+                      ])
+                      request("POST", f"/Library/VirtualFolders?{query}", common_options | profiles[library["profile"]])
+                      print(f"Created {library['name']}.")
+                  PY
+              env:
+                - name: JELLYFIN_AUTOMATION_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: jellyfin-automation
+                      key: enabled
+                - name: JELLYFIN_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: jellyfin-automation-secret
+                      key: api-key
+                      optional: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+              volumeMounts:
+                - name: configuration
+                  mountPath: /config
+                  readOnly: true
+          volumes:
+            - name: configuration
+              configMap:
+                name: jellyfin-automation

--- a/kubernetes/apps/apps/media/jellyfin/automation-cronjob.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/automation-cronjob.yaml
@@ -27,7 +27,8 @@ spec:
           containers:
             - name: configure
               # renovate: datasource=docker depName=library/python registryUrl=https://docker.io
-              image: docker.io/library/python:3.13-alpine
+              image: docker.io/library/python:3.13-alpine@sha256:c25cd44f45df1279a2cba589e67dfcd9db04647ea483b117a7de8b1a99bdfb23
+              imagePullPolicy: Always
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
@@ -49,9 +50,9 @@ spec:
                       print("Jellyfin automation is disabled.")
                       raise SystemExit(0)
 
-                  api_key = os.environ.get("JELLYFIN_API_KEY")
+                  api_key = open(os.environ["JELLYFIN_API_KEY_FILE"], encoding="utf-8").read().strip()
                   if not api_key:
-                      raise SystemExit("JELLYFIN_API_KEY is required when automation is enabled.")
+                      raise SystemExit("Jellyfin automation API key is required when automation is enabled.")
 
                   common_options = {
                       "Enabled": True,
@@ -183,12 +184,8 @@ spec:
                     configMapKeyRef:
                       name: jellyfin-automation
                       key: enabled
-                - name: JELLYFIN_API_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: jellyfin-automation-secret
-                      key: api-key
-                      optional: true
+                - name: JELLYFIN_API_KEY_FILE
+                  value: /credentials/api-key
               resources:
                 requests:
                   cpu: 10m
@@ -200,7 +197,13 @@ spec:
                 - name: configuration
                   mountPath: /config
                   readOnly: true
+                - name: credentials
+                  mountPath: /credentials
+                  readOnly: true
           volumes:
             - name: configuration
               configMap:
                 name: jellyfin-automation
+            - name: credentials
+              secret:
+                secretName: jellyfin-automation-secret

--- a/kubernetes/apps/apps/media/jellyfin/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/helmrelease.yaml
@@ -22,6 +22,22 @@ spec:
               # renovate: datasource=docker depName=linuxserver/jellyfin registryUrl=https://lscr.io
               repository: lscr.io/linuxserver/jellyfin
               tag: 10.11.11
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 99
+              runAsGroup: 100
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                cpu: 100m
+                memory: 64Mi
             command:
               - sh
               - -c

--- a/kubernetes/apps/apps/media/jellyfin/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/helmrelease.yaml
@@ -16,6 +16,32 @@ spec:
     controllers:
       main:
         strategy: Recreate
+        initContainers:
+          configure-transcoding:
+            image:
+              # renovate: datasource=docker depName=linuxserver/jellyfin registryUrl=https://lscr.io
+              repository: lscr.io/linuxserver/jellyfin
+              tag: 10.11.11
+            command:
+              - sh
+              - -c
+              - |
+                xmlstarlet ed -L \
+                  -u '/EncodingOptions/HardwareAccelerationType' -v vaapi \
+                  -u '/EncodingOptions/VaapiDevice' -v /dev/dri/renderD128 \
+                  -u '/EncodingOptions/EnableHardwareEncoding' -v true \
+                  -u '/EncodingOptions/AllowHevcEncoding' -v true \
+                  -d '/EncodingOptions/TranscodingTempPath' \
+                  -s '/EncodingOptions' -t elem -n TranscodingTempPath -v /transcode \
+                  -d '/EncodingOptions/HardwareDecodingCodecs/string' \
+                  -s '/EncodingOptions/HardwareDecodingCodecs' -t elem -n string -v h264 \
+                  -s '/EncodingOptions/HardwareDecodingCodecs' -t elem -n string -v hevc \
+                  -s '/EncodingOptions/HardwareDecodingCodecs' -t elem -n string -v mpeg2video \
+                  -s '/EncodingOptions/HardwareDecodingCodecs' -t elem -n string -v vc1 \
+                  -s '/EncodingOptions/HardwareDecodingCodecs' -t elem -n string -v vp8 \
+                  -s '/EncodingOptions/HardwareDecodingCodecs' -t elem -n string -v vp9 \
+                  -s '/EncodingOptions/HardwareDecodingCodecs' -t elem -n string -v av1 \
+                  /config/encoding.xml
         containers:
           main:
             image:
@@ -24,6 +50,7 @@ spec:
               tag: 10.11.11
             env:
               TZ: Europe/Berlin
+              LIBVA_DRIVER_NAME: iHD
               PUID: "99"
               PGID: "100"
             ports:
@@ -68,9 +95,11 @@ spec:
                   failureThreshold: 30
             resources:
               requests:
+                gpu.intel.com/i915: 1
                 cpu: 500m
                 memory: 1Gi
               limits:
+                gpu.intel.com/i915: 1
                 cpu: 2000m
                 memory: 4Gi
     service:
@@ -113,3 +142,9 @@ spec:
         path: /mnt/user/media
         globalMounts:
           - path: /data
+      transcode:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 1Gi
+        globalMounts:
+          - path: /transcode

--- a/kubernetes/apps/apps/media/jellyfin/jellyfin-automation-secret.sops.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/jellyfin-automation-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: jellyfin-automation-secret
+    namespace: media
+type: Opaque
+stringData:
+    api-key: ENC[AES256_GCM,data:vyTW5daaDLz+yA1rF3ybzcjyCQ4JJQQOEMUSquexFdQ=,iv:997u1cHa/6BiHWERGBybwkp61LEvhXLwaDFrkvUvsQw=,tag:zC0SYBJTeYNtF/H8Bdwi2A==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoMXg0Qzd0YVo3V0xkcUVz
+            RjFMYlo4bFc1c2g3cGhpM3hlSEhQcENxRG44CnVPdSszRy81Q3RwUmo2ellXQWxK
+            UW8wMmczRmw0S0Q5Zm1XREZhZ3V1TEEKLS0tIGN0ZmxONVZWSUhFMCtOTVd3aFNL
+            RktFZzhrdDlzcGxTRGsvOFB6dStsTGcKNjfG/JZXhrHku2MzYVmku3iSztDm/5fo
+            c9jP0dy2tK/j2rWTP3D/t0TtmyDQUoKfrBvaDLJb6e7j8QH7ZtsWYA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-12T22:52:03Z"
+    mac: ENC[AES256_GCM,data:fvfmZkftof/+lSRALHm5vOlvWtRw3lmXjNna7OXTz56+rnEV4DAvN5+DoRYn/liJlXme56br80lRRIlvwlG3fPttwKYkMl+gNoS8vOlhqDD9lnRlpccTibxGYWs+Pa1Zn4yCQuCqL0FKRqGm9zDqm2El7pED/Bx4e0skCsnglps=,iv:cGHrOtbP9EthBIb/MpgcbNqtQLn0wjp2IDM084JaRQY=,tag:dRLyosAqNyFNZS2n+iURzg==,type:str]
+    version: 3.13.2

--- a/kubernetes/apps/apps/media/jellyfin/kustomization.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/kustomization.yaml
@@ -5,3 +5,6 @@ components:
   - ../../../../components/ingress/traefik-base
 resources:
   - helmrelease.yaml
+  - automation-config.yaml
+  - automation-cronjob.yaml
+  - jellyfin-automation-secret.sops.yaml


### PR DESCRIPTION
## Summary
- enable Intel VA-API transcoding with a memory-backed transcode workspace
- add guarded Jellyfin library and plugin bootstrap automation
- configure the automation credential as a SOPS-encrypted secret

## Validation
- pre-commit hooks
- kubectl client dry-run and Kustomize rendering
- Python syntax validation
- kubeconform