### PR TITLE
feat(jellyfin): automate LDAP configuration

### DIFF
--- a/kubernetes/apps/apps/media/jellyfin/automation-config.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/automation-config.yaml
@@ -13,6 +13,35 @@ data:
       {"name":"TheTVDB","guid":"a677c0dafac54cde941a7134223f14c8","repositoryUrl":"https://repo.jellyfin.org/files/plugin/manifest.json"},
       {"name":"Webhook","guid":"71552a5a5c5c4350a2aeebe451a30173","repositoryUrl":"https://repo.jellyfin.org/files/plugin/manifest.json"}
     ]
+  ldap.json: |
+    {
+      "pluginId": "958aad6637844d2ab89aa7b6fab6e25c",
+      "LdapServer": "ak-outpost-ldap-outpost.authentik.svc.cluster.local",
+      "LdapPort": 636,
+      "UseSsl": true,
+      "UseStartTls": false,
+      "SkipSslVerify": true,
+      "LdapBindUser": "cn=ldap-search,ou=users,dc=home,dc=lan",
+      "LdapBaseDn": "ou=users,dc=home,dc=lan",
+      "LdapSearchFilter": "(&(objectClass=user)(|(memberOf=cn=Jellyfin Users,ou=groups,dc=home,dc=lan)(memberOf=cn=Jellyfin Admins,ou=groups,dc=home,dc=lan)))",
+      "LdapAdminBaseDn": "ou=users,dc=home,dc=lan",
+      "LdapAdminFilter": "(memberOf=cn=Jellyfin Admins,ou=groups,dc=home,dc=lan)",
+      "EnableLdapAdminFilterMemberUid": false,
+      "LdapSearchAttributes": "uid, cn, mail, displayName",
+      "LdapClientCertPath": "",
+      "LdapClientKeyPath": "",
+      "LdapRootCaPath": "",
+      "CreateUsersFromLdap": true,
+      "AllowPassChange": false,
+      "LdapUidAttribute": "uid",
+      "LdapUsernameAttribute": "cn",
+      "LdapPasswordAttribute": "userPassword",
+      "EnableLdapProfileImageSync": false,
+      "RemoveImagesNotInLdap": false,
+      "LdapProfileImageAttribute": "",
+      "EnableAllFolders": false,
+      "EnabledFolders": []
+    }
   libraries.json: |
     [
       {"name":"Anime Movies","path":"/data/libraries/anime_movies","collectionType":"movies","profile":"anime_movie"},

--- a/kubernetes/apps/apps/media/jellyfin/automation-cronjob.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/automation-cronjob.yaml
@@ -153,6 +153,61 @@ spec:
                       request("POST", f"/Packages/Installed/{urllib.parse.quote(plugin['name'])}?{query}")
                       print(f"Installed the latest compatible {plugin['name']}; restart Jellyfin to load it.")
 
+                  ldap_settings = json.load(open("/config/ldap.json"))
+                  ldap_plugin = installed_plugins.get(ldap_settings.pop("pluginId"))
+                  if ldap_plugin is None:
+                      print("LDAP Authentication was installed; restart Jellyfin before configuring it.")
+                  else:
+                      ldap_password_path = "/ldap-credentials/AK_LDAP_SEARCH_PASSWORD"
+                      if not os.path.exists(ldap_password_path):
+                          raise SystemExit("Replicated LDAP credentials are unavailable.")
+
+                      ldap_configuration = request(
+                          "GET", f"/Plugins/{ldap_plugin['Id']}/Configuration"
+                      )
+                      # Preserve LdapUsers because it records account links created after LDAP logins.
+                      ldap_configuration.update(ldap_settings)
+                      ldap_configuration["LdapBindPassword"] = open(
+                          ldap_password_path, encoding="utf-8"
+                      ).read().strip()
+                      request(
+                          "POST", f"/Plugins/{ldap_plugin['Id']}/Configuration", ldap_configuration
+                      )
+
+                      bind_result = request(
+                          "POST",
+                          "/Ldap/TestServerBind",
+                          {
+                              key: ldap_configuration.get(key, "")
+                              for key in (
+                                  "LdapServer", "LdapPort", "UseSsl", "UseStartTls",
+                                  "SkipSslVerify", "AllowPassChange", "LdapBindUser",
+                                  "LdapBindPassword", "LdapBaseDn", "PasswordResetUrl",
+                                  "LdapClientCertPath", "LdapClientKeyPath", "LdapRootCaPath",
+                              )
+                          },
+                      )
+                      if bind_result.get("Connect") != "Success" or bind_result.get("Bind") != "Success":
+                          raise SystemExit(f"LDAP bind validation failed: {bind_result.get('Error', bind_result)}")
+
+                      filter_result = request(
+                          "POST",
+                          "/Ldap/TestLdapFilters",
+                          {
+                              "LdapSearchFilter": ldap_configuration["LdapSearchFilter"],
+                              "LdapAdminFilter": ldap_configuration["LdapAdminFilter"],
+                              "EnableLdapAdminFilterMemberUid": ldap_configuration[
+                                  "EnableLdapAdminFilterMemberUid"
+                              ],
+                          },
+                      )
+                      if filter_result.get("Users", 0) == 0 or not filter_result.get("IsSubset"):
+                          raise SystemExit(f"LDAP filter validation failed: {filter_result}")
+                      print(
+                          f"Configured LDAP: {filter_result['Users']} users, "
+                          f"{filter_result['Admins']} administrators."
+                      )
+
                   libraries = json.load(open("/config/libraries.json"))
                   existing = {library["Name"]: library for library in request("GET", "/Library/VirtualFolders")}
                   for library in libraries:
@@ -194,6 +249,9 @@ spec:
                 - name: credentials
                   mountPath: /credentials
                   readOnly: true
+                - name: ldap-credentials
+                  mountPath: /ldap-credentials
+                  readOnly: true
           volumes:
             - name: configuration
               configMap:
@@ -201,3 +259,7 @@ spec:
             - name: credentials
               secret:
                 secretName: jellyfin-automation-secret
+            - name: ldap-credentials
+              secret:
+                secretName: ldap-search-secret
+                optional: true

--- a/kubernetes/infrastructure/security/authentik/install/ldap-search-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/ldap-search-secret.sops.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
     name: ldap-search-secret
     namespace: authentik
+    annotations:
+        replicator.v1.mittwald.de/replicate-to: media
 type: Opaque
 stringData:
     AK_LDAP_SEARCH_PASSWORD: ENC[AES256_GCM,data:XwXtv36fefJCqsxY/hdj885Qgo16T8PSWt2wtrveaPofEiQOlvkr1KJ3Kep5bDOcnQhThaKwI4PCJItZ2NKbwQ==,iv:da7HIbv+KXw0vlxo7D+RliPYSkZfOGCowPihu2xBwUE=,tag:o7uKEAcwCLIBQ8roLnJ13g==,type:str]

--- a/kubernetes/infrastructure/security/authentik/install/ldap-search-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/ldap-search-secret.sops.yaml
@@ -7,19 +7,19 @@ metadata:
         replicator.v1.mittwald.de/replicate-to: media
 type: Opaque
 stringData:
-    AK_LDAP_SEARCH_PASSWORD: ENC[AES256_GCM,data:XwXtv36fefJCqsxY/hdj885Qgo16T8PSWt2wtrveaPofEiQOlvkr1KJ3Kep5bDOcnQhThaKwI4PCJItZ2NKbwQ==,iv:da7HIbv+KXw0vlxo7D+RliPYSkZfOGCowPihu2xBwUE=,tag:o7uKEAcwCLIBQ8roLnJ13g==,type:str]
+    AK_LDAP_SEARCH_PASSWORD: ENC[AES256_GCM,data:+/UaDX4GU3RfFmCD1y64ChgW7iSf47b07HPB2urxrSIck9+oxYpC7BINddab7meey7p+5tmG59mtx5+gzXTlCw==,iv:77iw/XjY4vzna0kAlLy0ug2sf2QuSpaZ8DA66AQpGOg=,tag:sMY6Lnc2p6QK2aWHH1gCgQ==,type:str]
 sops:
     age:
-        - recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmY3JNM1I2Nkl2OEdFbnN6
-            SjI4UnlaRktNSXVkM1NFdDVCYzhWNkx1SkU0ClhSNTE3OU5XQjFhSzhVbTZwRUFZ
-            RmVJZk1zQ1lqd2JOQ1I2bDNld1V4QWsKLS0tIExLUjMvUTVHOVBSdlZ5ZzVrVDN5
-            Z2E5MkNWVDlWVWtKT2I2VnlOWXpMZlUK2LYc0uT0yoBR3qjN+ecrJzLH8gcRfaSV
-            vBd1pIC0VQcBbMQGBuT5kJP9s2xr6XtgWIXGK4FjdbT+lugGV9lSPw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBSndMeU5WMjV2QytnMm1T
+            VkdUNnc3OVdQUkRTNzJFaE9BNWZQWGdxT0JzCm1TR3R3L3V1allIR2JTRDhsR0Ez
+            YyszNll5WVYxTnJqajdPOHVCMk1ldWcKLS0tIHVlMlZCWnIvaGx1WlVmYVQ2Ui82
+            M2dHWFdQSkYwQkFlMHJlcUFGWXd0S0EKEYWZJ85m3T8oiQuHg5EqmJDTwdXTQEzQ
+            dVXe/7pLCDWRIM+CrW8EJ6lxsUfJa7qHDt4Tjz0DNXinwUFnTk8O7Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-07T00:00:55Z"
-    mac: ENC[AES256_GCM,data:d1sb3bHp31tWVFmPbwXFPb9/ZFJmHHp7KPAxvD/jU6kYeyENisQX14zV9K+Ohp06ckF2IWga3w7LD/7TDizR9ouIHHE8FXXbPCQfM1uB1sEW2BIRRTSDj99/uGQsIS2ANnaYJ2S1JbZY+as50n+ZddIGIgnDq6LQhKLwjpX9Brg=,iv:jZU7eQQf4CxLyJ+V5QDjjWG9VPIl8rkz8iHXBmmvC88=,tag:ukb3aZm4zJ/ZPcwNVe0ZJA==,type:str]
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
     encrypted_regex: ^(data|stringData)$
-    version: 3.12.1
+    lastmodified: "2026-07-13T14:56:05Z"
+    mac: ENC[AES256_GCM,data:DJRH8oaj6JbFnsdhaQHbL0y8rhg5UaAHhPCWPeBhUWP+kfIensxO7PEArca5m+89aWuUf2YwDyLsvAVUX0FiBjc47RZv68N9ghLTNiicoNEZj/+H2Eo2okFaIuVGTu6fqt0T6FbuYhqkykORTTCP5uY29aWPHjKE50RP4UdjU5w=,iv:hP1bIfHAeDuUfgRJPIJAOUNZXLaiQ28VCr6V338csEU=,tag:niakkPQ5OcDooQsq33t6SA==,type:str]
+    version: 3.13.2


### PR DESCRIPTION
## Summary
- replicate the Authentik LDAP bind credential into the media namespace
- declare Jellyfin LDAP connection, group filters, and provisioning settings
- reconcile and validate LDAP configuration through the Jellyfin automation Job

## Validation
- pre-commit hooks
- Kubernetes client dry-runs and Kustomize rendering
- embedded Python syntax validation
- kubeconform
- Checkov