### PR TITLE
feat(authentik): add NetBird SSO application

### DIFF
--- a/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
@@ -185,6 +185,10 @@ spec:
                 #   url: http://192.168.10.1
                 #   username: "{{HOMEPAGE_VAR_OPNSENSE_KEY}}"
                 #   password: "{{HOMEPAGE_VAR_OPNSENSE_SECRET}}"
+            - NetBird:
+                icon: netbird.png
+                description: "Zero-trust network access"
+                href: https://netbird.${CLUSTER_DOMAIN}
             - Pi-hole:
                 icon: pi-hole.png
                 description: "DNS resolver and ad-blocker"

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -88,6 +88,79 @@ data:
                 }
             }
 
+  120-netbird.yaml: |
+    version: 1
+    metadata:
+      name: netbird-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_core.group
+        id: netbird-admins
+        identifiers:
+          name: "NetBird Admins"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      - model: authentik_core.group
+        id: netbird-users
+        identifiers:
+          name: "NetBird Users"
+        attrs:
+          is_superuser: false
+          parent: null
+
+      - model: authentik_providers_oauth2.oauth2provider
+        id: netbird-provider
+        identifiers:
+          name: "NetBird"
+        attrs:
+          client_id: !Env NETBIRD_CLIENT_ID
+          client_secret: !Env NETBIRD_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          client_type: confidential
+          client_authentication_method: client_secret_post
+          include_claims_in_id_token: true
+          redirect_uris:
+            - url: "https://netbird.${CLUSTER_DOMAIN}/oauth2/callback"
+              matching_mode: strict
+            - url: "https://netbird.${CLUSTER_DOMAIN}/oauth2/logout/callback"
+              matching_mode: strict
+              redirect_uri_type: logout
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+
+      - model: authentik_core.application
+        id: netbird-application
+        identifiers:
+          slug: "netbird"
+        attrs:
+          name: "NetBird"
+          provider: !KeyOf netbird-provider
+          group: "Infrastructure"
+
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf netbird-application
+          order: 0
+        attrs:
+          group: !KeyOf netbird-admins
+
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf netbird-application
+          order: 1
+        attrs:
+          group: !KeyOf netbird-users
+
   200-grafana.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -172,6 +172,16 @@ spec:
             secretKeyRef:
               name: harbor-sso-secret
               key: CLIENT_SECRET
+        - name: NETBIRD_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: netbird-sso-secret
+              key: CLIENT_ID
+        - name: NETBIRD_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: netbird-sso-secret
+              key: CLIENT_SECRET
         - name: DISCORD_BASIC_AUTH
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - litellm-sso-secret.sops.yaml
   - librechat-sso-secret.sops.yaml
   - harbor-sso-secret.sops.yaml
+  - netbird-sso-secret.sops.yaml
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml
   - llama-auth-secret.sops.yaml

--- a/kubernetes/infrastructure/security/authentik/install/netbird-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/netbird-sso-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: netbird-sso-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:Gi7vRD637jmJnVvhjViJNEV3d2tptCfyypPSbtu+OCU=,iv:+eHGtLfS3+FWyG3bp6yWICArHPtTRDCzZSHdkuc3HA8=,tag:s1fnu8VBtbunZtljjsCWCA==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:oMFru+vl1x4tXXTeRd5pcBP0BUjl+QHGLA7spQ5S8sUceGtVQXfuif2DxWJfIOPCyEBWr3FcB0ZmFq6jmb7TPg==,iv:XwzjbjNJGBtqGGkefUgmumPDtjo3FWXI6xLg3YxiM0g=,tag:lTZRJfuULBWZJwNzWUWu/Q==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJeitWek5YUmlGN3BrYity
+            a1MxaFo1aHJlT2N0UTExNURVaHZRVVJadm1vCi9YbE1OOE9VaUhQVlJMLzVPRWxC
+            NUZEdEZMSGZSanU3cXNzWVc5NzZMZW8KLS0tIEdJZUQ0eGZkdDk4d2NoaHNoUitj
+            R3h5NG9ZUWs1MHphOE1BODlGZVZKTFUKg/kJbOGapiXAz45VMHFmNtP/eBJLxa8E
+            qJlYAhbVX1uoiKrtUgRBiDTEh+OeKzc2ni4oIpjDUn0foCJLG3Hc3A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-15T14:56:38Z"
+    mac: ENC[AES256_GCM,data:VMX+R06EImgiV6hxoPtE5PAwHPf+fl/iyS8XMip8Z2WAIxH7Lfy21oMlK+tOOTBTZMIS4H5hFKETZT9eGdfr5TkdjfnEmgkPXB/AIJ+6Xj54MEoAaueIIwNc6+N33w7We4wjJjdNt6357YahbLYoGOyflACBleIpfzVSML41psg=,iv:UxjgTBrRcUR8+lqbSfv3agcnktDHbudTUMi2d796Iq0=,tag:3JIlyKgLYVs/5uST1bA/AQ==,type:str]
+    version: 3.13.2


### PR DESCRIPTION
## Summary
- add a confidential Authentik OIDC application for NetBird with admin and user groups
- grant the bootstrap user NetBird administrator access and register the dashboard callback URLs
- add the NetBird dashboard to Homepage

## Validation
- `sops -d kubernetes/infrastructure/security/authentik/install/netbird-sso-secret.sops.yaml`
- `kubectl kustomize kubernetes/infrastructure/security/authentik/install`
- `kubectl apply --dry-run=client -k kubernetes/infrastructure/security/authentik/install`
- `kubectl kustomize kubernetes/apps/apps/utils/homepage`
- `pre-commit run --files ...`