### PR TITLE
feat(netbird): enforce CrowdSec HTTP decisions

### DIFF
--- a/ansible/roles/containers/netbird/defaults/main.yml
+++ b/ansible/roles/containers/netbird/defaults/main.yml
@@ -9,6 +9,8 @@ netbird_dashboard_env_file: "{{ netbird_base_dir }}/dashboard.env"
 netbird_proxy_env_file: "{{ netbird_base_dir }}/proxy.env"
 netbird_bootstrap_pat_file: "{{ netbird_base_dir }}/.bootstrap-pat"
 netbird_bootstrap_complete_file: "{{ netbird_base_dir }}/.bootstrap-complete"
+netbird_crowdsec_acquisition_file: "{{ netbird_base_dir }}/crowdsec/acquis.yaml"
+netbird_traefik_bouncer_key_file: "{{ netbird_base_dir }}/crowdsec/traefik-bouncer.key"
 netbird_service_name: netbird-compose
 netbird_update_service_name: netbird-update
 netbird_update_timer_name: netbird-update.timer
@@ -26,6 +28,13 @@ netbird_server_image: netbirdio/netbird-server:latest
 netbird_proxy_image: netbirdio/reverse-proxy:latest
 netbird_traefik_image: traefik:latest
 netbird_crowdsec_image: crowdsecurity/crowdsec:latest
+
+netbird_crowdsec_collections:
+  - crowdsecurity/traefik
+  - crowdsecurity/http-cve
+  - crowdsecurity/http-dos
+netbird_traefik_bouncer_requested: true
+netbird_traefik_bouncer_plugin_version: v1.3.5
 
 netbird_mesh_proxy_hostname: netbird-proxy
 netbird_mesh_proxy_wireguard_port: 51821

--- a/ansible/roles/containers/netbird/tasks/main.yml
+++ b/ansible/roles/containers/netbird/tasks/main.yml
@@ -355,10 +355,10 @@
       - --purge
   changed_when: true
   when:
+    - not ansible_check_mode
     - >-
       (netbird_crowdsec_installed_collections.stdout | from_json).collections
       | selectattr('name', 'equalto', 'crowdsecurity/linux') | list | length > 0
-    - not ansible_check_mode
   notify: Restart NetBird containers
 
 - name: List installed CrowdSec parsers
@@ -400,10 +400,10 @@
       - crowdsecurity/syslog-logs
   changed_when: true
   when:
+    - not ansible_check_mode
     - >-
       (netbird_crowdsec_installed_parsers.stdout | from_json).parsers
       | selectattr('name', 'equalto', 'crowdsecurity/syslog-logs') | list | length == 0
-    - not ansible_check_mode
   notify: Restart NetBird containers
 
 - name: Wait for NetBird server before proxy bootstrap

--- a/ansible/roles/containers/netbird/tasks/main.yml
+++ b/ansible/roles/containers/netbird/tasks/main.yml
@@ -88,6 +88,11 @@
     - "{{ netbird_base_dir }}"
     - "{{ netbird_base_dir }}/crowdsec"
 
+- name: Check for existing Traefik CrowdSec bouncer credentials
+  ansible.builtin.stat:
+    path: "{{ netbird_traefik_bouncer_key_file }}"
+  register: netbird_traefik_bouncer_key_stat
+
 - name: Verify Docker Compose is available
   ansible.builtin.command: docker compose version
   changed_when: false
@@ -149,6 +154,15 @@
   no_log: true
   notify: Restart NetBird containers
 
+- name: Render CrowdSec acquisition configuration
+  ansible.builtin.template:
+    src: crowdsec-acquis.yaml.j2
+    dest: "{{ netbird_crowdsec_acquisition_file }}"
+    owner: "{{ netbird_container_owner }}"
+    group: "{{ netbird_container_group }}"
+    mode: "0640"
+  notify: Restart NetBird containers
+
 - name: Render Traefik dynamic configuration
   ansible.builtin.template:
     src: traefik-dynamic.yaml.j2
@@ -156,6 +170,9 @@
     owner: "{{ netbird_container_owner }}"
     group: "{{ netbird_container_group }}"
     mode: "0644"
+  vars:
+    netbird_traefik_bouncer_enabled: >-
+      {{ netbird_traefik_bouncer_requested | bool and netbird_traefik_bouncer_key_stat.stat.exists }}
   notify: Restart NetBird containers
 
 - name: Render NetBird Docker Compose file
@@ -194,7 +211,6 @@
       - "{{ netbird_compose_file }}"
       - up
       - -d
-      - traefik
       - dashboard
       - netbird-server
       - crowdsec
@@ -202,6 +218,193 @@
   when:
     - not netbird_proxy_env_stat.stat.exists
     - not ansible_check_mode
+
+- name: Wait for CrowdSec before bouncer bootstrap
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -p
+      - netbird
+      - -f
+      - "{{ netbird_compose_file }}"
+      - exec
+      - -T
+      - crowdsec
+      - cscli
+      - lapi
+      - status
+  register: netbird_crowdsec_bouncer_ready
+  changed_when: false
+  until: netbird_crowdsec_bouncer_ready.rc == 0
+  retries: "{{ netbird_health_retries }}"
+  delay: "{{ netbird_health_delay }}"
+  when:
+    - netbird_traefik_bouncer_requested | bool
+    - not netbird_traefik_bouncer_key_stat.stat.exists
+    - not ansible_check_mode
+
+- name: Create CrowdSec Traefik bouncer credentials
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -p
+      - netbird
+      - -f
+      - "{{ netbird_compose_file }}"
+      - exec
+      - -T
+      - crowdsec
+      - cscli
+      - bouncers
+      - add
+      - netbird-traefik
+      - -o
+      - raw
+  register: netbird_traefik_bouncer_command
+  changed_when: true
+  no_log: true
+  when:
+    - netbird_traefik_bouncer_requested | bool
+    - not netbird_traefik_bouncer_key_stat.stat.exists
+    - not ansible_check_mode
+
+- name: Store CrowdSec Traefik bouncer credentials
+  ansible.builtin.copy:
+    content: "{{ netbird_traefik_bouncer_command.stdout | trim }}\n"
+    dest: "{{ netbird_traefik_bouncer_key_file }}"
+    owner: "{{ netbird_container_owner }}"
+    group: "{{ netbird_container_group }}"
+    mode: "0600"
+  no_log: true
+  when:
+    - netbird_traefik_bouncer_requested | bool
+    - not netbird_traefik_bouncer_key_stat.stat.exists
+    - not ansible_check_mode
+
+- name: Render Traefik configuration with CrowdSec bouncer
+  ansible.builtin.template:
+    src: traefik-dynamic.yaml.j2
+    dest: "{{ netbird_base_dir }}/traefik-dynamic.yaml"
+    owner: "{{ netbird_container_owner }}"
+    group: "{{ netbird_container_group }}"
+    mode: "0644"
+  vars:
+    netbird_traefik_bouncer_enabled: "{{ netbird_traefik_bouncer_requested | bool }}"
+  notify: Restart NetBird containers
+  when:
+    - netbird_traefik_bouncer_requested | bool
+    - not netbird_traefik_bouncer_key_stat.stat.exists
+    - not ansible_check_mode
+
+- name: Start Traefik after bouncer bootstrap
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -p
+      - netbird
+      - -f
+      - "{{ netbird_compose_file }}"
+      - up
+      - -d
+      - traefik
+  changed_when: true
+  when:
+    - not netbird_proxy_env_stat.stat.exists
+    - not ansible_check_mode
+
+- name: List installed CrowdSec collections
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -p
+      - netbird
+      - -f
+      - "{{ netbird_compose_file }}"
+      - exec
+      - -T
+      - crowdsec
+      - cscli
+      - collections
+      - list
+      - -o
+      - json
+  register: netbird_crowdsec_installed_collections
+  changed_when: false
+  when: not ansible_check_mode
+
+- name: Remove persisted CrowdSec SSH collection
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -p
+      - netbird
+      - -f
+      - "{{ netbird_compose_file }}"
+      - exec
+      - -T
+      - crowdsec
+      - cscli
+      - collections
+      - remove
+      - crowdsecurity/linux
+      - --purge
+  changed_when: true
+  when:
+    - >-
+      (netbird_crowdsec_installed_collections.stdout | from_json).collections
+      | selectattr('name', 'equalto', 'crowdsecurity/linux') | list | length > 0
+    - not ansible_check_mode
+  notify: Restart NetBird containers
+
+- name: List installed CrowdSec parsers
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -p
+      - netbird
+      - -f
+      - "{{ netbird_compose_file }}"
+      - exec
+      - -T
+      - crowdsec
+      - cscli
+      - parsers
+      - list
+      - -o
+      - json
+  register: netbird_crowdsec_installed_parsers
+  changed_when: false
+  when: not ansible_check_mode
+
+- name: Install non-syslog parser for Traefik Docker logs
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -p
+      - netbird
+      - -f
+      - "{{ netbird_compose_file }}"
+      - exec
+      - -T
+      - crowdsec
+      - cscli
+      - parsers
+      - install
+      - crowdsecurity/syslog-logs
+  changed_when: true
+  when:
+    - >-
+      (netbird_crowdsec_installed_parsers.stdout | from_json).parsers
+      | selectattr('name', 'equalto', 'crowdsecurity/syslog-logs') | list | length == 0
+    - not ansible_check_mode
+  notify: Restart NetBird containers
 
 - name: Wait for NetBird server before proxy bootstrap
   ansible.builtin.uri:
@@ -359,6 +562,76 @@
     enabled: "{{ netbird_enabled | bool }}"
     state: "{{ 'started' if netbird_enabled | bool else 'stopped' }}"
     daemon_reload: true
+  when: not ansible_check_mode
+
+- name: Remove obsolete CrowdSec firewall bouncer registration
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -p
+      - netbird
+      - -f
+      - "{{ netbird_compose_file }}"
+      - exec
+      - -T
+      - crowdsec
+      - cscli
+      - bouncers
+      - delete
+      - netbird-firewall
+      - --ignore-missing
+  register: netbird_firewall_bouncer_delete
+  changed_when: netbird_firewall_bouncer_delete.stdout | length > 0
+  when: not ansible_check_mode
+
+- name: Gather installed package facts for firewall bouncer cleanup
+  ansible.builtin.package_facts:
+    manager: auto
+  when: not ansible_check_mode
+
+- name: Disable and stop obsolete CrowdSec firewall bouncer
+  ansible.builtin.systemd_service:
+    name: crowdsec-firewall-bouncer
+    enabled: false
+    state: stopped
+    daemon_reload: true
+  when:
+    - "'crowdsec-firewall-bouncer' in ansible_facts.packages"
+    - not ansible_check_mode
+
+- name: Remove residual CrowdSec firewall IP sets
+  ansible.builtin.command:
+    argv:
+      - ipset
+      - destroy
+      - "{{ item }}"
+  loop:
+    - crowdsec-blacklists
+    - crowdsec6-blacklists
+  register: netbird_crowdsec_ipset_remove
+  changed_when: netbird_crowdsec_ipset_remove.rc == 0
+  failed_when: netbird_crowdsec_ipset_remove.rc not in [0, 1]
+  when:
+    - "'ipset' in ansible_facts.packages"
+    - not ansible_check_mode
+
+- name: Remove CrowdSec firewall bouncer packages
+  ansible.builtin.apt:
+    name:
+      - crowdsec-firewall-bouncer
+      - ipset
+    state: absent
+    purge: true
+
+- name: Remove obsolete CrowdSec firewall bouncer files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/crowdsec/bouncers/netbird-firewall-bouncer.key
+    - /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+    - /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml.local
   when: not ansible_check_mode
 
 - name: Enable NetBird automatic update timer

--- a/ansible/roles/containers/netbird/templates/crowdsec-acquis.yaml.j2
+++ b/ansible/roles/containers/netbird/templates/crowdsec-acquis.yaml.j2
@@ -1,0 +1,8 @@
+---
+source: docker
+container_name:
+  - netbird-traefik
+follow_stdout: true
+follow_stderr: false
+labels:
+  type: traefik

--- a/ansible/roles/containers/netbird/templates/docker-compose.yml.j2
+++ b/ansible/roles/containers/netbird/templates/docker-compose.yml.j2
@@ -21,12 +21,22 @@ services:
       - --certificatesresolvers.letsencrypt.acme.email={{ netbird_secrets.netbird_acme_email }}
       - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
       - --certificatesresolvers.letsencrypt.acme.tlschallenge=true
+{% if netbird_traefik_bouncer_requested | bool %}
+      - --experimental.plugins.crowdsec-bouncer-traefik-plugin.modulename=github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin
+      - --experimental.plugins.crowdsec-bouncer-traefik-plugin.version={{ netbird_traefik_bouncer_plugin_version }}
+{% endif %}
     ports:
       - "80:80"
       - "443:443"
+    depends_on:
+      crowdsec:
+        condition: service_healthy
     volumes:
       - netbird_traefik_letsencrypt:/letsencrypt
       - ./traefik-dynamic.yaml:/etc/traefik/dynamic.yaml:ro
+{% if netbird_traefik_bouncer_requested | bool %}
+      - ./crowdsec:/etc/traefik/crowdsec:ro
+{% endif %}
 
   dashboard:
     image: "{{ netbird_dashboard_image }}"
@@ -55,10 +65,11 @@ services:
     restart: unless-stopped
     networks: [netbird]
     environment:
-      COLLECTIONS: crowdsecurity/linux
+      COLLECTIONS: {{ netbird_crowdsec_collections | join(' ') }}
     volumes:
       - ./crowdsec:/etc/crowdsec
       - crowdsec_db:/var/lib/crowdsec/data
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     healthcheck:
       test: [CMD, cscli, lapi, status]
       interval: 10s

--- a/ansible/roles/containers/netbird/templates/traefik-dynamic.yaml.j2
+++ b/ansible/roles/containers/netbird/templates/traefik-dynamic.yaml.j2
@@ -5,6 +5,10 @@ http:
       entryPoints:
         - websecure
       service: netbird-dashboard
+{% if netbird_traefik_bouncer_enabled | bool %}
+      middlewares:
+        - crowdsec-bouncer
+{% endif %}
       tls:
         certResolver: letsencrypt
     netbird-grpc:
@@ -45,6 +49,20 @@ http:
       loadBalancer:
         servers:
           - url: "h2c://netbird-server:80"
+{% if netbird_traefik_bouncer_enabled | bool %}
+  middlewares:
+    crowdsec-bouncer:
+      plugin:
+        crowdsec-bouncer-traefik-plugin:
+          enabled: true
+          crowdsecMode: live
+          crowdsecLapiHost: crowdsec:8080
+          crowdsecLapiKeyFile: /etc/traefik/crowdsec/traefik-bouncer.key
+          crowdsecLapiScheme: http
+          forwardedHeadersCustomName: ""
+          defaultDecisionSeconds: 60
+          logLevel: INFO
+{% endif %}
 
 tcp:
   routers:


### PR DESCRIPTION
## Summary
- collect Traefik HTTP logs and enable HTTP CVE and DoS scenarios
- enforce CrowdSec decisions only on the NetBird dashboard router with a bounded live-decision cache
- remove CrowdSec SSH processing and all firewall-bouncer state while retaining Fail2ban and CAPI

## Validation
- `ansible-playbook playbooks/netbird.yml --syntax-check`
- `ansible-lint roles/containers/netbird`
- applied the NetBird role successfully; a follow-up run reported `changed=0`
- verified dashboard-only blocking with a temporary decision, plus public SSH, mesh SSH, mesh health, CAPI, and HTTP parsing