### PR TITLE
chore(opencode): add jcodemunch integration

### DIFF
--- a/.jcodemunch.jsonc
+++ b/.jcodemunch.jsonc
@@ -1,0 +1,13 @@
+{
+  // Keep the MCP tool schema compact while retaining core code-navigation tools.
+  "tool_surface": "full",
+  "tool_profile": "core",
+
+  // Do not send usage telemetry or select remote AI summarization.
+  "share_savings": false,
+  "use_ai_summaries": false,
+  "summarizer_provider": "none",
+  "cross_repo_default": false,
+  "redact_source_root": true,
+  "stats_file_interval": 0
+}

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "jcodemunch": {
+      "type": "local",
+      "command": [
+        "/bin/sh",
+        "-c",
+        "exec env CODE_INDEX_PATH=\"${XDG_DATA_HOME:-$HOME/.local/share}/jcodemunch\" uvx --from jcodemunch-mcp==1.108.144 jcodemunch-mcp"
+      ],
+      "enabled": true,
+      "timeout": 30000
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@ This file defines durable repo-wide behavior. Read the nearest subtree `AGENTS.m
 - Keep changes narrowly scoped to the user's request.
 - Validate changes with the most direct evidence available for the kind of change you made.
 
+## jCodeMunch Exploration
+- When jCodeMunch MCP tools are available and this repository is indexed, prefer them for unfamiliar code exploration, symbol and text search, dependency/reference tracing, change-impact analysis, and task-context assembly.
+- Use native tools for known paths, complete reads of process-control files such as `AGENTS.md` and `README.md`, command output, test output, files outside the index, and pre-edit line-number verification.
+- Fall back to native tools when the index is unavailable or stale.
+- Never index decrypted secrets, credential material, or local override files. Keep them excluded from the index even when they are ignored by git.
+
 ## What Not To Do
 - Do not patch, apply, edit, scale, or restart Kubernetes resources directly when the repo can express the change.
 - Do not edit generated artifacts as if they were normal source files.

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -1,0 +1,36 @@
+# OpenCode Integration
+
+This repository configures the project-scoped jCodeMunch MCP server in
+`.opencode/opencode.json`. OpenCode starts it only while working in this
+repository or one of its subdirectories.
+
+## Prerequisite
+
+Install [uv](https://docs.astral.sh/uv/) so `uvx` is available on `PATH`.
+The first OpenCode session that starts the MCP downloads the pinned
+`jcodemunch-mcp` version. Later sessions reuse uv's local package cache.
+
+If `uv`, a compatible Python runtime, or network access for the first download
+is unavailable, OpenCode remains usable but jCodeMunch will be unavailable for
+that session.
+
+## Local Data
+
+jCodeMunch stores its index and cached source outside the repository at:
+
+```text
+${XDG_DATA_HOME:-$HOME/.local/share}/jcodemunch
+```
+
+The directory is local to each machine and is not version controlled. A fresh
+clone therefore needs to be indexed independently. Ask OpenCode to index the
+current project before using jCodeMunch exploration tools.
+
+The project configuration disables anonymous savings telemetry, remote AI
+summaries, cross-repository traversal, and persistent session statistics.
+
+## Updates
+
+The MCP version is intentionally pinned in `.opencode/opencode.json`. Update
+that pin deliberately after reviewing the jCodeMunch release and restart
+OpenCode for a configuration change to take effect.


### PR DESCRIPTION
## Summary
- add project-scoped jCodeMunch MCP configuration for OpenCode
- document local index storage, prerequisites, and update workflow
- add repository guidance for indexed code exploration

## Validation
- pre-commit hooks run during commit
- git diff --check