### PR TITLE
docs(agents): improve project rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,14 @@ repos:
       - id: check-added-large-files
       - id: check-yaml
         args: ["--allow-multiple-documents"]
-        exclude: ^kubernetes/clusters/homelab/flux-system/
+        exclude: ^kubernetes/clusters/production/flux-system/
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
       - id: yamllint
         files: \.ya?ml$
-        exclude: (^kubernetes/clusters/homelab/flux-system/|\.sops\.ya?ml$)
+        exclude: (^kubernetes/clusters/production/flux-system/|\.sops\.ya?ml$)
 
   - repo: local
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-./AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Guidelines for contributing to the home-lab-iac repository.
 
 ```bash
 # Clone the repository
-git clone https://github.com/<user>/home-lab-iac.git
+git clone https://github.com/nreymundo/home-lab-iac.git
 cd home-lab-iac
 
 # Check required host tools
@@ -22,13 +22,15 @@ pre-commit install
 
 1. Create a new branch: `git checkout -b feature/my-change`
 2. Make your changes
-3. Run pre-commit hooks: `pre-commit run --all-files`
+3. Run applicable pre-commit hooks: `pre-commit run --files <changed-file> [<changed-file>...]`
 4. Test locally when possible
+
+Some hooks format files or encrypt and stage `*.sops.yaml` files. Review `git diff` after running them.
 
 ### 3. Commit and Push
 
 ```bash
-git add .
+git add <changed-paths>
 git commit -m "feat: descriptive commit message"
 git push origin feature/my-change
 ```
@@ -68,7 +70,7 @@ The repository uses pre-commit to enforce code quality:
 ### Running Hooks
 
 ```bash
-# Run all hooks on all files
+# Run all hooks on all files. Some hooks can format, encrypt, and stage files.
 pre-commit run --all-files
 
 # Run specific hook
@@ -93,7 +95,7 @@ The `forbid-commit-attribution` hook runs during `git commit` as a `commit-msg` 
 ### YAML
 
 - Use 2-space indentation
-- Use `---` at the start of files
+- Use `---` for multi-document YAML; follow the existing local style for single-document manifests and Kustomizations
 - Prefer explicit `true`/`false` over `yes`/`no`
 - Keep lines under 120 characters
 
@@ -126,7 +128,7 @@ The `forbid-commit-attribution` hook runs during `git commit` as a `commit-msg` 
 
 | Directory | Purpose | Notes |
 |-----------|---------|-------|
-| `packer/<distro>-<version>-base/` | VM template definitions | One folder per template |
+| `packer/<template-name>/` | VM template definitions | One folder per template |
 | `terraform/instances/vm/<instance>/` | Terraform VM instance roots | Concrete VM deployments using shared modules |
 | `terraform/instances/lxc/<instance>/` | Terraform LXC instance roots | Concrete container deployments using shared modules |
 | `ansible/roles/<role>/` | Reusable Ansible roles | Standard role structure |
@@ -140,33 +142,44 @@ The `forbid-commit-attribution` hook runs during `git commit` as a `commit-msg` 
 ### Packer
 
 ```bash
-packer validate packer/ubuntu-24.04-base
-packer validate packer/fedora-43-server
+for template in packer/ubuntu-24.04-base packer/ubuntu-26.04-base packer/fedora-43-server; do
+  packer init "$template"
+  packer fmt -check -recursive "$template"
+  packer validate "$template"
+done
 ```
 
 ### Terraform
 
 ```bash
-terraform -chdir=terraform/instances/vm/k3s_nodes validate
-terraform -chdir=terraform/instances/vm/k3s_nodes plan
-terraform -chdir=terraform/instances/vm/openclaw validate
-terraform -chdir=terraform/instances/vm/openclaw plan
+ROOT=terraform/instances/vm/k3s_nodes
+terraform -chdir="$ROOT" init
+terraform -chdir="$ROOT" fmt -check
+terraform -chdir="$ROOT" validate
+terraform -chdir="$ROOT" plan
 ```
+
+Set `ROOT` to each modified Terraform root. `plan` requires the configured backend and provider credentials.
 
 ### Ansible
 
 ```bash
-ansible-lint ansible/playbooks/ ansible/roles/
-ansible-playbook ansible/playbooks/<playbook>.yml --check
+ANSIBLE_CONFIG=ansible/ansible.cfg ansible-lint ansible/playbooks/ ansible/roles/
+ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook ansible/playbooks/<playbook>.yml --syntax-check
+# With reachable target hosts:
+ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook ansible/playbooks/<playbook>.yml --check
 ```
 
 ### Kubernetes
 
 ```bash
-# Dry-run apply
-kubectl apply --dry-run=client -f <path>
+# Render a Kustomize path, then dry-run its rendered resources
+kubectl kustomize <path> | kubectl apply --dry-run=client -f -
 
-# Wait for Flux reconciliation
+# Validate all rendered Kustomizations
+scripts/kubeconform.sh
+
+# Intentional live reconciliation of committed state
 flux reconcile kustomization flux-system --with-source
 ```
 
@@ -208,7 +221,7 @@ chore(deps): update helm chart versions
 
 The repository uses Renovate for dependency updates:
 
-- Minor/patch updates are auto-merged on Sundays
+- Package rules define automerge eligibility and minimum release age; see `renovate.json` for the current policy
 - Major updates require manual review
 - Updates are grouped by category (observability, networking)
 

--- a/ansible/AGENTS.md
+++ b/ansible/AGENTS.md
@@ -3,7 +3,7 @@
 Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers Ansible-local editing rules.
 
 ## What This Subtree Owns
-- `ansible/` is responsible for host and cluster configuration after Terraform has provisioned infrastructure.
+- `ansible/` configures Terraform-provisioned infrastructure and independently managed hosts and clusters.
 - Roles are the durable unit of reuse; playbooks should stay thin and primarily compose roles.
 - `ansible.cfg` is part of the execution contract because it defines role paths, inventory defaults, and command expectations.
 
@@ -20,8 +20,10 @@ Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers
 
 ## Validation
 ```bash
-ansible-lint ansible/playbooks/ ansible/roles/
-ansible-playbook ansible/playbooks/k3s_cluster.yml --check
+ANSIBLE_CONFIG=ansible/ansible.cfg ansible-lint ansible/playbooks/ ansible/roles/
+ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook ansible/playbooks/k3s_cluster.yml --syntax-check
+# With reachable target hosts:
+ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook ansible/playbooks/k3s_cluster.yml --check
 ```
 
 - Treat the playbook command above as a representative example; for subtree-local validation, run the specific playbook(s) you modified with `--check` when possible.

--- a/kubernetes/AGENTS.md
+++ b/kubernetes/AGENTS.md
@@ -3,12 +3,12 @@
 Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers Kubernetes-wide rules that apply across the subtree.
 
 ## What This Subtree Owns
-- Everything under `kubernetes/` is desired cluster state reconciled by Flux.
+- Kubernetes manifests become active desired state only through Flux `spec.path` targets and Kustomize resource or component inclusion chains.
 - Child AGENTS files under `clusters/production/`, `infrastructure/`, `apps/`, and `components/` own the more specific local editing rules.
 
 ## Source Of Truth Boundaries
 - Edit hand-authored manifests, not generated Flux bootstrap output.
-- Parent `kustomization.yaml` files are authoritative inclusion boundaries; file presence alone does not make an object active.
+- Flux `spec.path` targets and parent `kustomization.yaml` files are authoritative inclusion boundaries; file presence alone does not make an object active.
 - Shared Helm/OCI source definitions belong in `kubernetes/infrastructure/sources/` unless a child subtree documents a real exception.
 - `*.sops.yaml` is the normal committed form for Kubernetes secrets in this repo.
 
@@ -19,10 +19,10 @@ Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers
 
 ## Validation
 ```bash
-kubectl apply --dry-run=client -f <path>
+kubectl kustomize <path> | kubectl apply --dry-run=client -f -
 flux get all -A
 flux get helmreleases -A
-flux reconcile kustomization flux-system --with-source
 ```
 
 - Read the closer child AGENTS before editing `clusters/production`, `infrastructure`, `apps`, or `components`; those files should answer the subtree-local gotchas this parent file intentionally omits.
+- Treat `flux reconcile kustomization flux-system --with-source` as an intentional live reconciliation of committed state, not local validation.

--- a/kubernetes/apps/AGENTS.md
+++ b/kubernetes/apps/AGENTS.md
@@ -3,20 +3,26 @@
 Read the repo root `AGENTS.md` and `kubernetes/AGENTS.md` first. This file only covers workload-layer composition rules.
 
 ## What This Subtree Owns
-- `kubernetes/apps/` owns workload overlays, deployable applications, and storage manifests that support those workloads.
+- `kubernetes/apps/` owns workload overlays, deployable applications, and manually declared PVC manifests that support those workloads.
 - The subtree is intentionally split between `apps/apps/` for workload manifests and `apps/storage/` for PVC and storage-state concerns.
 
 ## Source Of Truth Boundaries
 - Workload membership is controlled by the relevant parent `kustomization.yaml`, not by file presence alone.
-- App deploy logic and app persistence are intentionally split across the two child subtrees; changing one often requires checking the other.
+- App deploy logic and manually declared app PVCs are intentionally split across the two child subtrees; changing one often requires checking the other.
 - Most app-level secrets should stay SOPS-encrypted and colocated with the app or storage object that consumes them.
-- `kubernetes/apps/storage/` owns PVC and persistence state, while `kubernetes/apps/apps/storage/` is just a workload category; do not confuse the two because they have different contracts.
+- `kubernetes/apps/storage/` owns manually declared PVC catalogs, while controller-managed storage such as `CNPG Cluster.spec.storage` remains workload-local. `kubernetes/apps/apps/storage/` is just a workload category; do not confuse the two because they have different contracts.
+- `ks/90-storage.yaml` reconciles `kubernetes/apps/storage/production` as `apps-storage`; `ks/91-apps.yaml` reconciles `kubernetes/apps/production` as `apps-manifests`, which depends on storage and Traefik configuration.
+- Both Flux Kustomizations use `prune: true`; removing an inclusion can delete its rendered resources.
 
 ## Local Anti-Patterns
 - Do not add an app directory without wiring it into the relevant parent `kustomization.yaml`.
-- Do not put PVC catalogs beside workload manifests when `apps/storage/` already owns that persistence layer.
+- Do not put manually declared PVC catalogs beside workload manifests when `apps/storage/` already owns that persistence layer.
 - Do not treat this file as the detailed editing guide; use `apps/apps/AGENTS.md` for workload-shape rules and `apps/storage/AGENTS.md` for persistence-specific rules.
 
 ## Validation
-- For workload-tree changes, dry-run the smallest affected subtree rather than the whole cluster.
-- For app changes that depend on persistence, verify both the workload manifest path and the storage inclusion path before claiming the change is complete.
+```bash
+kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/production >/dev/null
+kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/storage/production >/dev/null
+```
+
+- For app changes that use manually declared PVCs, verify both the workload manifest path and the storage inclusion path before claiming the change is complete.

--- a/kubernetes/apps/apps/AGENTS.md
+++ b/kubernetes/apps/apps/AGENTS.md
@@ -8,19 +8,20 @@ Read the repo root `AGENTS.md`, `kubernetes/AGENTS.md`, and `kubernetes/apps/AGE
 
 ## Source Of Truth Boundaries
 - Workload-local resources that directly travel with an app stay here.
-- PVC catalogs and persistent storage ownership stay in `kubernetes/apps/storage/` unless a nearer child file explicitly documents an exception.
+- Manually declared PVC catalogs stay in `kubernetes/apps/storage/`, while controller-managed storage such as `CNPG Cluster.spec.storage` remains workload-local unless a nearer child file documents an exception.
 - Shared defaults and shared ingress behavior often come from `kubernetes/components/`, so local app edits may have shared-component dependencies.
 
 ## Local Anti-Patterns
 - Do not invent a new app scaffold when the existing category already shows a stable pattern.
-- Do not put PVC definitions here when the persistence belongs in `kubernetes/apps/storage/`.
-- Do not overlook sibling resources such as `cnpg-cluster.yaml`, backup jobs, extra HelmReleases, or app variants in the same folder.
+- Do not put manually declared PVC definitions here when the persistence belongs in `kubernetes/apps/storage/`.
+- Do not overlook sibling resources or Kustomize behavior such as `cnpg-cluster.yaml`, backup jobs, extra HelmReleases, app variants, components, patches, generators, and namespace transforms.
 - Do not assume `external-proxy/` follows the normal HelmRelease-heavy pattern; it is intentionally higher-variance and more direct-YAML-oriented.
 
 ## Validation
 ```bash
-kubectl apply --dry-run=client -f kubernetes/apps/apps/<category>/<app>
+kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/apps/<category>/<app> >/dev/null
 flux get helmreleases -A
 ```
 
-- Check parent production kustomizations whenever adding or removing apps, and check storage wiring whenever persistence is part of the change.
+- `flux get helmreleases -A` applies only to Helm-managed workloads; validate direct-YAML workloads such as `external-proxy` through the `apps-manifests` Kustomization and their rendered resources.
+- Check `kubernetes/apps/production` whenever adding or removing apps, and check storage wiring whenever manually declared PVCs are part of the change.

--- a/kubernetes/apps/storage/AGENTS.md
+++ b/kubernetes/apps/storage/AGENTS.md
@@ -3,12 +3,13 @@
 Read the repo root `AGENTS.md`, `kubernetes/AGENTS.md`, and `kubernetes/apps/AGENTS.md` first. This file only covers workload-persistence rules.
 
 ## What This Subtree Owns
-- `kubernetes/apps/storage/` owns workload PVC catalogs and storage overlays.
+- `kubernetes/apps/storage/` owns manually declared workload PVC catalogs and storage overlays.
 - PVCs are grouped by workload domain rather than copied into every app directory.
 
 ## Source Of Truth Boundaries
 - File naming should stay explicit and workload-tied, typically `<app>-pvc.yaml`.
-- Persistence ownership stays here even when the consuming workload manifest lives under `kubernetes/apps/apps/`.
+- Manually declared PVC ownership stays here even when the consuming workload manifest lives under `kubernetes/apps/apps/`; controller-managed storage remains with its workload.
+- Verify each PVC's `metadata.name` and namespace against every consuming workload `claimName`; filenames are not the binding contract.
 - `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` is a special create-only or migration-oriented contract, not a normal default for new PVCs.
 
 ## Local Anti-Patterns
@@ -19,8 +20,9 @@ Read the repo root `AGENTS.md`, `kubernetes/AGENTS.md`, and `kubernetes/apps/AGE
 
 ## Validation
 ```bash
-kubectl apply --dry-run=client -f kubernetes/apps/storage
+kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/storage/pvcs/<domain> >/dev/null
 ```
 
 - When changing app persistence, inspect both this subtree and the workload subtree; they are intentionally split.
 - When changing a PVC that already has `ssa: IfNotPresent`, call out any required manual live step explicitly instead of presenting the Git change as self-sufficient.
+- `ssa: IfNotPresent` does not prevent Flux pruning a PVC removed from the rendered inventory; treat removal from a storage Kustomization as a possible delete operation.

--- a/kubernetes/clusters/production/AGENTS.md
+++ b/kubernetes/clusters/production/AGENTS.md
@@ -8,20 +8,20 @@ Read the repo root `AGENTS.md` and `kubernetes/AGENTS.md` first. This file only 
 - `flux-system/` is generated bootstrap output and is not the routine edit surface.
 
 ## Source Of Truth Boundaries
-- `ks/kustomization.yaml` and the numbered `ks/*.yaml` files communicate dependency order and are part of the production bring-up contract.
-- Install/config pairs often appear as adjacent numbers; preserve that ordering intent unless the dependency model itself is changing.
+- `ks/kustomization.yaml` controls inclusion, while Flux `spec.dependsOn` defines reconciliation dependencies. Numbered `ks/*.yaml` files communicate human-facing ordering intent.
+- Install/config pairs often appear as adjacent numbers; preserve that convention unless the dependency model itself is changing.
 - Service-specific implementation details should stay in `kubernetes/infrastructure/` or `kubernetes/apps/`; this subtree should mostly wire ordering and inclusion.
 
 ## Local Anti-Patterns
 - Never hand-edit `flux-system/gotk-components.yaml` or `flux-system/gotk-sync.yaml` during routine changes.
-- Do not reorder `ks/kustomization.yaml` casually; bootstrap and reconciliation dependencies rely on that sequence.
+- Do not reorder `ks/kustomization.yaml` casually; inclusion changes affect the rendered inventory. Model reconciliation dependencies with `spec.dependsOn`.
 - Do not solve local service problems by stuffing service-specific config into the cluster ordering layer.
 
 ## Validation
 ```bash
-kubectl apply --dry-run=client -f kubernetes/clusters/production/ks
+kubectl kustomize kubernetes/clusters/production/ks >/dev/null
 flux get kustomizations
-flux reconcile kustomization flux-system --with-source
 ```
 
 - Most routine edits here should answer one of three questions: are you changing ordering, changing inclusion, or intentionally re-bootstrapping Flux?
+- Treat `flux reconcile kustomization flux-system --with-source` as an intentional live reconciliation of committed state, not local validation.

--- a/kubernetes/components/AGENTS.md
+++ b/kubernetes/components/AGENTS.md
@@ -18,7 +18,7 @@ Read the repo root `AGENTS.md` and `kubernetes/AGENTS.md` first. This file only 
 
 ## Validation
 - Before editing a shared component, inspect its downstream references in workload and infrastructure manifests.
-- Use `kubectl apply --dry-run=client -f <consumer-path>` on one or more representative consumers when the change affects rendered manifests.
+- Use `kubectl kustomize <consumer-path> >/dev/null` on one or more representative consumers when the change affects rendered manifests.
 
 ## Notes
-- Most consumers live under `kubernetes/apps/apps/`, but infrastructure manifests can depend on shared components too.
+- All current active consumers live under `kubernetes/apps/apps/`; search workload and infrastructure manifests before assuming a component has no wider impact.

--- a/kubernetes/infrastructure/AGENTS.md
+++ b/kubernetes/infrastructure/AGENTS.md
@@ -20,9 +20,10 @@ Read the repo root `AGENTS.md` and `kubernetes/AGENTS.md` first. This file only 
 
 ## Validation
 ```bash
-kubectl apply --dry-run=client -f kubernetes/infrastructure
+kubectl kustomize kubernetes/infrastructure >/dev/null
 flux get helmreleases -A
-pre-commit run --all-files
+pre-commit run --files <changed-file> [<changed-file>...]
 ```
 
 - Security and storage subtrees usually have the most local nuance because they mix install objects, policies, ingress, and secrets in the same service tree.
+- Some pre-commit hooks can format files or encrypt and stage `*.sops.yaml` files; inspect `git diff` afterward.

--- a/packer/AGENTS.md
+++ b/packer/AGENTS.md
@@ -20,10 +20,11 @@ Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers
 
 ## Validation
 ```bash
-packer validate packer/ubuntu-24.04-base
-packer validate packer/ubuntu-26.04-base
-packer validate packer/fedora-43-server
+TEMPLATE=packer/ubuntu-24.04-base
+packer init "$TEMPLATE"
+packer fmt -check -recursive "$TEMPLATE"
+packer validate "$TEMPLATE"
 ```
 
-- Treat those commands as representative examples of validating template roots; keep this file aligned when new template directories are added.
+- Set `TEMPLATE` to each modified template root. `packer init` is required on a fresh plugin cache.
 - After changing a base template used by Terraform, call out the downstream impact on cloned node builds and any image compatibility assumptions.

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -4,11 +4,11 @@ Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers
 
 ## What This Subtree Owns
 - `terraform/modules/` holds reusable infrastructure building blocks.
-- Concrete root modules live under both `terraform/instances/` and `terraform/cloud/`; those roots are allowed to produce downstream artifacts such as Ansible inventory or cloud-specific infrastructure state.
+- Concrete root modules live under both `terraform/instances/` and `terraform/cloud/`; those roots can produce downstream artifacts such as Ansible inventory or cloud-specific infrastructure state.
 - Secrets belong in Bitwarden-backed flows, not inline Terraform values or plaintext files.
 
 ## Source Of Truth Boundaries
-- Treat instance roots as the source of truth for generated inventory under `ansible/inventories/`.
+- Treat Terraform roots, including cloud roots, as the source of truth for generated inventory under `ansible/inventories/`.
 - Treat Terraform Cloud workspace settings in each root module's `providers.tf` as part of the root-module contract.
 - For the K3s node fleet, prefer the current `local.k3s.nodes`-driven topology instead of reintroducing older count-based patterns.
 
@@ -20,13 +20,12 @@ Read the repo root `AGENTS.md` first for repo-wide policy. This file only covers
 
 ## Validation
 ```bash
-terraform -chdir=terraform/instances/vm/k3s_nodes fmt
-terraform -chdir=terraform/instances/vm/k3s_nodes validate
-terraform -chdir=terraform/instances/vm/k3s_nodes plan
-terraform -chdir=terraform/instances/vm/openclaw fmt
-terraform -chdir=terraform/instances/vm/openclaw validate
-terraform -chdir=terraform/instances/vm/openclaw plan
+ROOT=terraform/instances/vm/k3s_nodes
+terraform -chdir="$ROOT" init
+terraform -chdir="$ROOT" fmt -check
+terraform -chdir="$ROOT" validate
+terraform -chdir="$ROOT" plan
 ```
 
-- Treat those commands as representative root-module examples, not an exhaustive list of every Terraform root in the repo.
+- Set `ROOT` to each modified root module, including cloud roots. `plan` requires the configured backend and provider credentials.
 - After changing Terraform that feeds Ansible, inspect the generated inventory diff and any host labels, users, or topology assumptions consumed downstream.


### PR DESCRIPTION
## Summary
- correct project and contributor validation guidance for Ansible, Terraform, Packer, and Kubernetes
- document Flux ordering, prune, PVC ownership, and mutation-capable pre-commit behavior
- remove the shadowed CLAUDE.md symlink and repair stale bootstrap exclusions

## Validation
- pre-commit YAML validation
- Ansible lint and syntax check
- Terraform and Packer formatting checks
- Kustomize renders and scripts/kubeconform.sh