### PR TITLE
feat(kubernetes): add Karakeep

### DIFF
--- a/kubernetes/apps/apps/utils/karakeep/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/karakeep/helmrelease.yaml
@@ -1,0 +1,337 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: karakeep
+  namespace: utils
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsUser: 1000
+        runAsGroup: 1000
+
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              # renovate: datasource=docker depName=karakeep-app/karakeep registryUrl=https://ghcr.io
+              repository: ghcr.io/karakeep-app/karakeep
+              tag: "0.32.0"
+            env:
+              TZ: Europe/Berlin
+              # --- Core ---
+              PORT: "3000"
+              DATA_DIR: /data
+              NEXTAUTH_URL: https://keep.${CLUSTER_DOMAIN}
+              NEXTAUTH_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: karakeep-secrets
+                    key: NEXTAUTH_SECRET
+              DB_WAL_MODE: "true"
+              DISABLE_NEW_RELEASE_CHECK: "true"
+              LOG_LEVEL: notice
+              # App-wide asset + request guardrails.
+              MAX_ASSET_SIZE_MB: "25"
+              RATE_LIMITING_ENABLED: "true"
+              # OCR text extraction from images; cache lives under /data.
+              OCR_CACHE_DIR: /data/ocr-cache
+              OCR_LANGS: eng,deu,spa
+              # --- Search ---
+              MEILI_ADDR: http://karakeep-meilisearch:7700
+              MEILI_MASTER_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: karakeep-secrets
+                    key: MEILI_MASTER_KEY
+              # --- Browser crawler ---
+              BROWSER_WEB_URL: http://karakeep-chrome:9222
+              # Per-domain crawl rate limiting.
+              CRAWLER_DOMAIN_RATE_LIMIT_WINDOW_MS: "60000"
+              CRAWLER_DOMAIN_RATE_LIMIT_MAX_REQUESTS: "20"
+              # --- Auth: native OIDC against Authentik ---
+              # TEMPORARY bootstrap: DISABLE_SIGNUPS is opened so the intended
+              # Authentik-authorized user can perform the first OIDC login and
+              # become the Karakeep admin. Flip DISABLE_SIGNUPS back to "true"
+              # in Git immediately after that first login lands.
+              DISABLE_SIGNUPS: "false"
+              DISABLE_PASSWORD_AUTH: "true"
+              OAUTH_AUTO_REDIRECT: "true"
+              # Permit linking an existing local account to an OIDC subject on
+              # first SSO login when the Authentik email matches. Required here
+              # because signups/password auth are disabled above, so the only
+              # way to attach pre-existing accounts to SSO identities is via
+              # this documented Karakeep escape hatch. Safe because Authentik
+              # is the sole, locally-trusted OIDC provider for this cluster.
+              OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING: "true"
+              OAUTH_WELLKNOWN_URL: https://sso.${CLUSTER_DOMAIN}/application/o/karakeep/.well-known/openid-configuration
+              OAUTH_SCOPE: openid email profile
+              OAUTH_PROVIDER_NAME: Authentik
+              OAUTH_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: karakeep-oidc-secrets
+                    key: OAUTH_CLIENT_ID
+              OAUTH_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: karakeep-oidc-secrets
+                    key: OAUTH_CLIENT_SECRET
+              # --- AI via LiteLLM (enabled; virtual key in karakeep-ai-secrets) ---
+              OPENAI_BASE_URL: http://litellm-main.ai.svc.cluster.local:4000/v1
+              OPENAI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: karakeep-ai-secrets
+                    key: LITELLM_API_KEY
+              INFERENCE_TEXT_MODEL: local/automation-lite
+              INFERENCE_IMAGE_MODEL: local/camera-analysis
+              EMBEDDING_TEXT_MODEL: local/embedding
+              # AI enrichment is on: auto-tagging and summarization run
+              # against LiteLLM via the karakeep-ai-secrets virtual key
+              # (see plan.md).
+              INFERENCE_ENABLE_AUTO_TAGGING: "true"
+              INFERENCE_ENABLE_AUTO_SUMMARIZATION: "true"
+              # Inference tuning: context/output caps and worker pool.
+              INFERENCE_CONTEXT_LENGTH: "4096"
+              INFERENCE_MAX_OUTPUT_TOKENS: "512"
+              INFERENCE_JOB_TIMEOUT_SEC: "120"
+              INFERENCE_NUM_WORKERS: "1"
+            ports:
+              - name: http
+                containerPort: 3000
+            probes:
+              # Karakeep exposes no documented dedicated health endpoint.
+              # Root "/" is the only viable documented target on port 3000.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 200m
+                memory: 512Mi
+              limits:
+                cpu: 2000m
+                memory: 2Gi
+
+      meilisearch:
+        containers:
+          meilisearch:
+            image:
+              # renovate: datasource=docker depName=getmeili/meilisearch registryUrl=https://docker.io
+              repository: docker.io/getmeili/meilisearch
+              tag: v1.41.0
+            env:
+              TZ: Europe/Berlin
+              MEILI_NO_ANALYTICS: "true"
+              MEILI_ENV: production
+              MEILI_MASTER_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: karakeep-secrets
+                    key: MEILI_MASTER_KEY
+            ports:
+              - name: http
+                containerPort: 7700
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 7700
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 7700
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 7700
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+
+      chrome:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
+        containers:
+          chrome:
+            image:
+              # renovate: datasource=docker depName=zenika-hub/alpine-chrome registryUrl=https://gcr.io
+              repository: gcr.io/zenika-hub/alpine-chrome
+              tag: "124"
+            # Pass flags as args so the image ENTRYPOINT (chromium-browser)
+            # is preserved instead of being overwritten.
+            args:
+              - --no-sandbox
+              - --disable-gpu
+              - --disable-dev-shm-usage
+              - --remote-debugging-address=0.0.0.0
+              - --remote-debugging-port=9222
+              - --hide-scrollbars
+              - --disable-blink-features=AutomationControlled
+              - --window-size=1440,900
+            ports:
+              - name: cdp
+                containerPort: 9222
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /json/version
+                    port: 9222
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /json/version
+                    port: 9222
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /json/version
+                    port: 9222
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 2Gi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 3000
+      meilisearch:
+        controller: meilisearch
+        ports:
+          http:
+            port: 7700
+      chrome:
+        controller: chrome
+        ports:
+          cdp:
+            port: 9222
+
+    ingress:
+      main:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: keep.${CLUSTER_DOMAIN}
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Karakeep
+          gethomepage.dev/description: Self-hosted bookmark manager
+          gethomepage.dev/group: "Kubernetes"
+          gethomepage.dev/icon: karakeep.png
+        hosts:
+          - host: keep.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+
+    persistence:
+      data:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: karakeep
+        # Scope /data to the main Karakeep container only. Meilisearch mounts
+        # its own PVC below; the headless Chrome container needs no data mount.
+        advancedMounts:
+          main:
+            main:
+              - path: /data
+      meilisearch:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: karakeep-meilisearch
+        advancedMounts:
+          meilisearch:
+            meilisearch:
+              - path: /meili_data

--- a/kubernetes/apps/apps/utils/karakeep/karakeep-ai-secrets.sops.yaml
+++ b/kubernetes/apps/apps/utils/karakeep/karakeep-ai-secrets.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: karakeep-ai-secrets
+    namespace: utils
+type: Opaque
+stringData:
+    LITELLM_API_KEY: ENC[AES256_GCM,data:G7c2I/zHtZ98EigMtuRH9StxrXdVWM7X4Q==,iv:2+w6Ij8oT+IcgdnsZRYuNVHkPSng0zEzmd9Nhgr1W30=,tag:7wDj3EYMu46KYuEZsP2qyA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkbk1FV2c2cFA0NTd4d3BY
+            VjNYSVA4MnJ0OEdTNGg3RXgzeE5HWG02MkQ0CkxsMlJSYmgrcFRpRVljY1BjQzBz
+            a3F6Q0xTckwvVjRsbWxlWExvbUN5Z0kKLS0tIGhsckJZMCszZ2ZMZG9aa2svYXJE
+            Z25WZWNrZzVKQndKbDl0THdGdXl6WlUKyq9ODDvYEpkYCrU8cYiFG41PYK6zWW0+
+            +uRA1zcBZwYkQBm0QhwsWxqJeCOAdVl1YuOcHtDCYKy0dxY9K+2WZA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-21T23:13:23Z"
+    mac: ENC[AES256_GCM,data:tRt9C34bMjGHuG9h+JFxzhFP4kDaNsGQ8Sx6msyoHKV65dIiPnuXV7+S/jEI/6fsFqp9GH7X8r9zt6jkAyFTgetbQxVIG9qToXYZ1iq2WbtSeVFwVzOl0BwrGsXuoAMu6H7CZJSsMmOHBs5G85+7xBCwBcYnnutA0A9+VuNvxgM=,iv:6bJfJUuBQAoMGGQHX2gt83t/pmcdjEobbo5jjalPqf8=,tag:cScu+h2BEfRgKi+ghgNzOQ==,type:str]
+    version: 3.13.2

--- a/kubernetes/apps/apps/utils/karakeep/karakeep-oidc-secrets.sops.yaml
+++ b/kubernetes/apps/apps/utils/karakeep/karakeep-oidc-secrets.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: karakeep-oidc-secrets
+    namespace: utils
+type: Opaque
+stringData:
+    OAUTH_CLIENT_ID: ENC[AES256_GCM,data:lhyXsbaJ2hxjuoKDvIgTL8zXZIn4NHBQVV205ad0Q+DKLdaNuJumXgfR/EdIZc8x,iv:Bz/6a9fpoaPOtiGreMsCg5dQWjzPRjp0h6iBMNSA75E=,tag:jSFBN2peiE5D9qktDK88+Q==,type:str]
+    OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:YfeCrZ95P/VabCBUBA6zM4z4yjOmdrjv8/MNrlYZOaN062Lvgyr05hziR6g3oXJ/,iv:dRV9hb+IeH/7f32T60GvySL/2Ci5aG5cGnxegUiBbtw=,tag:tToUPmYXZQtOgll5R/3GLw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRSHlxQzhvK2c5MDlSbER3
+            MWhtQ1VpVVhQTFBKbTdXZVBIU0NVdnpKalVVCkFudE9TZWRDTjhrdDkva3RGZEJP
+            RlhvWmd3cFAvUXFxOEt5R3FOay91TDgKLS0tIGlXdjErcUlMeE43bkprWDRkNUVx
+            N2R4T1ZpbEc0RTM3VzRwMlkwZHV2dU0KBwpiaWjzunep7fLXwtvAFOouPsvFmDyT
+            b9HcWnpI9cj5C2Jm4tsgGa0Mdzf91xQAz5eZcVgNHY5JKKWcNk1hdA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-21T22:40:29Z"
+    mac: ENC[AES256_GCM,data:38dxpUAVJA7Zuf7JvS24wVvVW4kfk4+myBj6V/xFSVQoD9hWljwCBXkX/RkAlY61I5WJHHqzS2s+sEmfGsNDIJzYbbX6nWZBbM/m3yjeT/dwKkDcBacT/fM8lqF07xrMzW2Vhms9dqkI9GKaH6aMESYQY5F6bCChKIMC3GikScA=,iv:oapHoLpK41gd0E2DqMoqaI1XFZbq0brCJRSM5ALZN98=,tag:Nsc7qGJeY312D0Gt3uZumg==,type:str]
+    version: 3.13.2

--- a/kubernetes/apps/apps/utils/karakeep/karakeep-secrets.sops.yaml
+++ b/kubernetes/apps/apps/utils/karakeep/karakeep-secrets.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: karakeep-secrets
+    namespace: utils
+type: Opaque
+stringData:
+    NEXTAUTH_SECRET: ENC[AES256_GCM,data:3BVUpVw6I4YkjCMrbp5Jvyya+rdW5GY+yF1LhsiKpWbspoOyA2zL70BwrRsM26M+,iv:TBLzWR2FIr3PoTN1vn6i5ncb7DrqMEVa5FZtIzmY8mQ=,tag:pcvZXN6VD7hY1B6vLW6kzA==,type:str]
+    MEILI_MASTER_KEY: ENC[AES256_GCM,data:bOC1OCnH6QcVv9Jxvd+Ik6ZKjWqmE0uvWmeUI4vEu8sgtebyZDjhJPB4nSV+NSh2,iv:/aHWsBUEoZSVi6ZfsNbOIaicXXIOcz2RMZ6uYKlc16Q=,tag:LSR6yS5py+eLix/rKKWKwA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5aTNGWEdmdjZEYlhPaDRK
+            Uk1XZlFiMHZBclNyd0J5MitpZnhyVjhpcTB3CllxWWNPR25LR0h0TEhEcDhHb3ND
+            ZmlCQy9scnYxdTVLd3ZDTFN1VldTc1kKLS0tIEVSWmpMdVJBbjg0ZmxMd2R3YXlW
+            R1VxblRFMmY0QmRRNWd0UVk5c1p6ZXMKUwNqKNi16452x/vVNNq0rHVHi+PN6Ga9
+            G4/8ur5RelvfMf/7A//KES3xSmmTjhNPVX26/hxMZIbBrzfTymwRpQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-21T22:40:29Z"
+    mac: ENC[AES256_GCM,data:Gnojm/01Zo+hk8KLJ36Ba7ILhqqtlwzFSSOqGpXZWYMG5ODeMbvF+hGU5dOTdExIVpTh/6mjtyDBOeaYMtioS2MqKzLR7k7WJ29BkdnLkbmha1wvMwiK6JpdT/nJiUQby90qlMjVUvR+sGufwLC9BwvBA1Gu8gTgGpl8FJob2jg=,iv:u/9NgMq3RmYDF3jzY/Amkm+HP+hcdFfJyPYUzLqWiyo=,tag:ykmhDEmHVNIlDTaF7x3JzA==,type:str]
+    version: 3.13.2

--- a/kubernetes/apps/apps/utils/karakeep/kustomization.yaml
+++ b/kubernetes/apps/apps/utils/karakeep/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+  - ../../../../components/ingress/traefik-base
+
+resources:
+  - karakeep-secrets.sops.yaml
+  - karakeep-oidc-secrets.sops.yaml
+  - karakeep-ai-secrets.sops.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ../apps/utils/searxng
   - ../apps/utils/dawarich
   - ../apps/utils/airtrail
+  - ../apps/utils/karakeep
   - ../apps/nextcloud
   - ../apps/media/audiobookshelf
   - ../apps/media/jellyfin

--- a/kubernetes/apps/storage/pvcs/utils/karakeep-meilisearch-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/utils/karakeep-meilisearch-pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: karakeep-meilisearch
+  namespace: utils
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/storage/pvcs/utils/karakeep-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/utils/karakeep-pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: karakeep
+  namespace: utils
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/storage/pvcs/utils/kustomization.yaml
+++ b/kubernetes/apps/storage/pvcs/utils/kustomization.yaml
@@ -8,4 +8,6 @@ resources:
   - dawarich-redis-pvc.yaml
   - discord-presence-alternate-pvc.yaml
   - discord-presence-main-pvc.yaml
+  - karakeep-pvc.yaml
+  - karakeep-meilisearch-pvc.yaml
   - searxng-pvc.yaml

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -826,6 +826,64 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "Nextcloud Admins"]]
 
+  256-karakeep.yaml: |
+    version: 1
+    metadata:
+      name: karakeep-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Karakeep Users group
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Karakeep Users"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # OAuth2 Provider for Karakeep
+      - model: authentik_providers_oauth2.oauth2provider
+        id: karakeep-provider
+        identifiers:
+          name: "Karakeep"
+        attrs:
+          client_id: !Env KARAKEEP_CLIENT_ID
+          client_secret: !Env KARAKEEP_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          encryption_key: null
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_basic
+          redirect_uris:
+            - url: "https://keep.${CLUSTER_DOMAIN}/api/auth/callback/custom"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+
+      # Karakeep Application
+      - model: authentik_core.application
+        identifiers:
+          slug: "karakeep"
+        attrs:
+          name: "Karakeep"
+          provider: !KeyOf karakeep-provider
+          group: "Utils"
+
+      # Restrict access to Karakeep Users
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "karakeep"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Karakeep Users"]]
+
   500-frigate.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -132,6 +132,16 @@ spec:
             secretKeyRef:
               name: airtrail-sso-secret
               key: CLIENT_SECRET
+        - name: KARAKEEP_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: karakeep-sso-secret
+              key: CLIENT_ID
+        - name: KARAKEEP_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: karakeep-sso-secret
+              key: CLIENT_SECRET
         - name: NEXTCLOUD_CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/karakeep-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/karakeep-sso-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: karakeep-sso-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:Tjb3hY1ynV9WwAbW6/fCEVMqX4yYwETld7ewZCvRxpLa2hrdy0aRQ2Mz9FRqb43C,iv:XApUPVK00zEK4YZdYD37U7UBgaSE/oc+lvPeQSqHa08=,tag:5e8f/o67dWmAPMTrGKMPjw==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:jSz8LzEUOB++F66eCwBMJIBBjyVduaWX/EhL5gOv6k6AVaXApMo0XdCBcggtYzPp,iv:tnWWS7n3GYgEaDLywcCnggFqX0AlDQvRwt1wSq2fcAU=,tag:4BTiYmTo4e1mOgomDSdPIQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAybHVubytpT3IrVWkyMEVu
+            OXVEcGdCRmc0Qk1ZWVduMTdwMWtDYllmQ2dzCjNFdWQzUkUyTEh2SCtNeU1iUTh1
+            Y1ZxRVFMOXc3Q0szZkZpWGpqZ0RIVUUKLS0tIDdFeVJlT25iNWd1ZVlWbzd6T2x6
+            SCs0dndadzFBVXdpRm9SYU1YT0FVWE0KNubdKYfjohkKLb6TOQ+REsoXLTXpMtSL
+            NJ3wZsSozy/g6/XM1hr8gMPkx0tGL5YmN2+/nrF+jjVjpWZN9c439w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age189vx0wdx4q2hjdzqm3j5yxjjupfun5y3a7ajj40t3cl6lttmz9wsv36vck
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-21T22:40:29Z"
+    mac: ENC[AES256_GCM,data:3NBleJZ8SdpGSCmwTxK81Mc9r5xXRPuAxCPDgl+itOBOvO4EIyQWoDuG3tDG+HBT+aRjrN5qaRbk4GzQ5kTapT2+DzXrdb9PoCR1vpiplqEQWMmr7GtaVrzIeeVqdyiHNU8zcm5rVyk1zjtsM8YdROLCHKGeYu9nxUuIXK2fUXQ=,iv:AERtYzYcffLcW7Fm0k9CiFdhUvknQns0izMXLbCsx5s=,tag:43r8DpvVpKH74xzYPdRdXA==,type:str]
+    version: 3.13.2

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - paperless-sso-secret.sops.yaml
   - dawarich-sso-secret.sops.yaml
   - airtrail-sso-secret.sops.yaml
+  - karakeep-sso-secret.sops.yaml
   - nextcloud-sso-secret.sops.yaml
   - litellm-sso-secret.sops.yaml
   - librechat-sso-secret.sops.yaml


### PR DESCRIPTION
## Summary
- Deploy Karakeep with Meilisearch, headless Chrome, two 5Gi Longhorn PVCs, and `keep.${CLUSTER_DOMAIN}` ingress.
- Add Authentik OIDC application, scoped user group, and SOPS-encrypted credentials.
- Route AI enrichment through the scoped LiteLLM key with local model aliases and OCR/crawler guardrails.

## Validation
- `scripts/opencode/validate-changed.sh --include-untracked kubernetes/apps/apps/utils/karakeep --include-untracked kubernetes/apps/storage/pvcs/utils/karakeep-pvc.yaml --include-untracked kubernetes/apps/storage/pvcs/utils/karakeep-meilisearch-pvc.yaml --include-untracked kubernetes/infrastructure/security/authentik/install/karakeep-sso-secret.sops.yaml`
- Independent R2 review approved.

## Controlled post-merge steps
- Verify Authentik denies the OIDC flow to non-members, then let the intended group member perform the first OIDC login.
- Immediately restore `DISABLE_SIGNUPS: "true"` in Git and reconcile.
- Verify Flux/HelmRelease readiness, PVC binding, SSO callback, Chrome/Meilisearch health, and LiteLLM inference.