### PR TITLE
fix(kubernetes): correct Karakeep browser and OIDC

### DIFF
--- a/kubernetes/apps/apps/utils/karakeep/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/karakeep/helmrelease.yaml
@@ -67,10 +67,12 @@ spec:
               OAUTH_AUTO_REDIRECT: "true"
               # Permit linking an existing local account to an OIDC subject on
               # first SSO login when the Authentik email matches. Required here
-              # because signups/password auth are disabled above, so the only
-              # way to attach pre-existing accounts to SSO identities is via
-              # this documented Karakeep escape hatch. Safe because Authentik
-              # is the sole, locally-trusted OIDC provider for this cluster.
+              # because password auth is disabled above and signups are only
+              # temporarily open for the bootstrap first-login (see
+              # DISABLE_SIGNUPS), so the only way to attach pre-existing
+              # accounts to SSO identities is via this documented Karakeep
+              # escape hatch. Safe because Authentik is the sole,
+              # locally-trusted OIDC provider for this cluster.
               OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING: "true"
               OAUTH_WELLKNOWN_URL: https://sso.${CLUSTER_DOMAIN}/application/o/karakeep/.well-known/openid-configuration
               OAUTH_SCOPE: openid email profile
@@ -221,8 +223,8 @@ spec:
         containers:
           chrome:
             image:
-              # renovate: datasource=docker depName=zenika-hub/alpine-chrome registryUrl=https://gcr.io
-              repository: gcr.io/zenika-hub/alpine-chrome
+              # renovate: datasource=docker depName=zenika/alpine-chrome registryUrl=https://docker.io
+              repository: docker.io/zenika/alpine-chrome
               tag: "124"
             # Pass flags as args so the image ENTRYPOINT (chromium-browser)
             # is preserved instead of being overwritten.

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -854,6 +854,8 @@ data:
           client_secret: !Env KARAKEEP_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
           encryption_key: null
           client_type: confidential
           grant_types:


### PR DESCRIPTION
## Root causes
- The Chrome controller could not pull `gcr.io/zenika-hub/alpine-chrome:124`: the registry returned `NotFound`.
- Karakeep OIDC callbacks failed with `unexpected JWT alg received, expected RS256, got: HS256`.

## Changes
- Move Chrome to `docker.io/zenika/alpine-chrome:124` and update Renovate metadata.
- Configure the Karakeep Authentik provider with the established signing certificate and explicit `jwt_algorithm: RS256`.
- Correct the OIDC account-linking comment to reflect the temporary signup bootstrap state.

## Validation
- `scripts/opencode/validate-changed.sh --json /tmp/opencode/karakeep-chrome-oidc-rs256-validation.json` — pass.
- Independent R2 review — approved.

## Post-merge live verification
- Confirm `authentik-install`, `apps-manifests`, and Karakeep HelmRelease are Ready.
- Confirm Chrome pulls and serves `/json/version` without `ImagePullBackOff`.
- Complete an OIDC login as a `Karakeep Users` member; verify an RS256 ID token and no prior JWT-algorithm error in Karakeep logs.
- Immediately re-lock `DISABLE_SIGNUPS: "true"` in Git after the first admin account is created.