### PR TITLE
fix(kubernetes): reset Karakeep search index on upgrade

### DIFF
--- a/kubernetes/apps/apps/utils/karakeep/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/karakeep/helmrelease.yaml
@@ -153,6 +153,30 @@ spec:
                 memory: 2Gi
 
       meilisearch:
+        initContainers:
+          auto-wipe:
+            image:
+              # renovate: datasource=docker depName=getmeili/meilisearch registryUrl=https://docker.io
+              repository: docker.io/getmeili/meilisearch
+              tag: v1.49.0
+            command:
+              - /bin/sh
+              - -c
+              - |
+                if [ -f /meili_data/data.ms/VERSION ]; then
+                  DB_VER=$(cat /meili_data/data.ms/VERSION)
+                  IMG_VER=$(meilisearch --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+                  if [ "$DB_VER" != "$IMG_VER" ]; then
+                    echo "Wiping data.ms: DB version $DB_VER != image version $IMG_VER"
+                    rm -rf /meili_data/data.ms
+                  else
+                    echo "Version match ($DB_VER), keeping data"
+                  fi
+                else
+                  echo "No existing database, clean start"
+                fi
+            securityContext:
+              runAsUser: 0
         containers:
           meilisearch:
             image:
@@ -278,7 +302,7 @@ spec:
                 memory: 256Mi
               limits:
                 cpu: 1000m
-                memory: 2Gi
+                memory: 4Gi
 
     service:
       main:
@@ -335,5 +359,7 @@ spec:
             claimName: karakeep-meilisearch
         advancedMounts:
           meilisearch:
+            auto-wipe:
+              - path: /meili_data
             meilisearch:
               - path: /meili_data


### PR DESCRIPTION
## Summary
- Mirror LibreChat’s Meilisearch version-aware `auto-wipe` init container for Karakeep.
- Delete only `/meili_data/data.ms` when the persisted database version differs from the Meilisearch image.
- Raise the Chrome memory limit from 2Gi to 4Gi.

## Validation
- `scripts/opencode/validate-changed.sh --json /tmp/opencode/karakeep-meilisearch-chrome-validation.json` — pass.

## Post-merge verification
- Confirm the Karakeep HelmRelease and Meilisearch pod become Ready.
- Inspect the `auto-wipe` init-container log and verify Meilisearch `/health`.
- Confirm Karakeep search rebuilds from its primary `/data` store.