### PR TITLE
fix(kubernetes): document exec job exceptions

### DIFF
--- a/kubernetes/apps/apps/media/plextraktsync/sync-job.yaml
+++ b/kubernetes/apps/apps/media/plextraktsync/sync-job.yaml
@@ -37,7 +37,7 @@ metadata:
   name: plextraktsync-sync
   namespace: media
   annotations:
-    checkov.io/skip1: CKV_K8S_38=This job intentionally needs a token to run kubectl exec.
+    checkov.io/skip1: CKV_K8S_38=PlexTraktSync maintains upstream authentication in its long-running watcher; a standalone job sharing the PVC cannot reliably batch-sync after auth expiry. This hardened CronJob locates the active controller-managed pod and runs the batch sync in-process; its Role is namespace-scoped and limited to pods get/list and pods/exec create.
     checkov.io/skip2: CKV_K8S_40=Kubectl job runs under explicit non-root UID 1001.
 spec:
   schedule: "0 */12 * * *"

--- a/kubernetes/apps/apps/paperless/backup-job.yaml
+++ b/kubernetes/apps/apps/paperless/backup-job.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["list"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]
@@ -37,7 +37,7 @@ metadata:
   name: paperless-backup
   namespace: paperless
   annotations:
-    checkov.io/skip1: CKV_K8S_38=Paperless has no supported external backup interface; this hardened non-root CronJob needs a projected token to locate the controller-managed pod and run the supported in-pod export. Role is namespace-scoped and limited to pods list and pods/exec create.
+    checkov.io/skip1: CKV_K8S_38=Paperless has no supported external backup interface; this hardened non-root CronJob needs a projected token to locate the controller-managed pod and run the supported in-pod export. Role is namespace-scoped and limited to pods get/list and pods/exec create.
     checkov.io/skip2: CKV_K8S_40=Kubectl job runs under explicit non-root UID 1001.
 spec:
   schedule: "0 3 */3 * *"

--- a/kubernetes/apps/apps/paperless/backup-job.yaml
+++ b/kubernetes/apps/apps/paperless/backup-job.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list"]
+    verbs: ["list"]
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]
@@ -37,7 +37,7 @@ metadata:
   name: paperless-backup
   namespace: paperless
   annotations:
-    checkov.io/skip1: CKV_K8S_38=This job intentionally needs a token to run kubectl exec.
+    checkov.io/skip1: CKV_K8S_38=Paperless has no supported external backup interface; this hardened non-root CronJob needs a projected token to locate the controller-managed pod and run the supported in-pod export. Role is namespace-scoped and limited to pods list and pods/exec create.
     checkov.io/skip2: CKV_K8S_40=Kubectl job runs under explicit non-root UID 1001.
 spec:
   schedule: "0 3 */3 * *"


### PR DESCRIPTION
## Summary
- Document why the Paperless backup and PlexTraktSync sync jobs require narrowly scoped `pods/exec` access.
- Remove unused `pods/get` access from the Paperless backup Role.

## Validation
- `kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/apps/paperless`
- `kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/apps/media/plextraktsync`
- `checkov --config-file .checkov.yaml --quiet --compact`

Refs #676