### PR TITLE
fix(harbor): mount bootstrap secrets as files

### DIFF
--- a/kubernetes/infrastructure/registry/harbor/config/bootstrap-configmap.yaml
+++ b/kubernetes/infrastructure/registry/harbor/config/bootstrap-configmap.yaml
@@ -16,11 +16,17 @@ data:
 
     api = os.environ.get("HARBOR_API", "http://harbor-harbor-core/api/v2.0").rstrip("/")
     username = os.environ.get("HARBOR_USERNAME", "admin")
-    password = os.environ["HARBOR_PASSWORD"]
-    gib = 1024 ** 3
+    def read_secret(path, default=""):
+        try:
+            with open(path, encoding="utf-8") as secret_file:
+                return secret_file.read().strip()
+        except FileNotFoundError:
+            return default
 
-    def env(name, default=""):
-        return os.environ.get(name, default).strip()
+    password = read_secret("/secrets/harbor/password")
+    if not password:
+        raise RuntimeError("Harbor admin password is unavailable")
+    gib = 1024 ** 3
 
     def auth_header():
         token = base64.b64encode(f"{username}:{password}".encode()).decode()
@@ -57,12 +63,12 @@ data:
         raise TimeoutError("Harbor did not become healthy")
 
     def configure_oidc():
-        client_id = env("HARBOR_OIDC_CLIENT_ID")
-        client_secret = env("HARBOR_OIDC_CLIENT_SECRET")
+        client_id = read_secret("/secrets/oidc/client-id")
+        client_secret = read_secret("/secrets/oidc/client-secret")
         if not client_id or not client_secret:
             raise RuntimeError("Harbor OIDC client secret is unavailable")
 
-        oidc_endpoint = env("HARBOR_OIDC_ENDPOINT")
+        oidc_endpoint = os.environ.get("HARBOR_OIDC_ENDPOINT", "").strip()
         payload = {
             "auth_mode": "oidc_auth",
             "primary_auth_mode": True,
@@ -305,8 +311,8 @@ data:
             "description": "Docker Hub proxy cache upstream",
             "type": "docker-hub",
             "url": "https://hub.docker.com",
-            "access_key": env("DOCKERHUB_USERNAME"),
-            "access_secret": env("DOCKERHUB_TOKEN"),
+            "access_key": read_secret("/secrets/dockerhub/username"),
+            "access_secret": read_secret("/secrets/dockerhub/token"),
             "storage_limit": 40 * gib,
         },
         {

--- a/kubernetes/infrastructure/registry/harbor/config/bootstrap-cronjob.yaml
+++ b/kubernetes/infrastructure/registry/harbor/config/bootstrap-cronjob.yaml
@@ -3,8 +3,6 @@ kind: CronJob
 metadata:
   name: harbor-bootstrap
   namespace: harbor
-  annotations:
-    checkov.io/skip1: CKV_K8S_35=Harbor bootstrap script consumes API credentials from environment variables.
 spec:
   schedule: "17 3 * * *"
   concurrencyPolicy: Forbid
@@ -43,38 +41,20 @@ spec:
                   value: http://harbor-harbor-core/api/v2.0
                 - name: HARBOR_USERNAME
                   value: admin
-                - name: HARBOR_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: harbor-secrets
-                      key: HARBOR_ADMIN_PASSWORD
                 - name: HARBOR_OIDC_ENDPOINT
                   value: https://sso.${CLUSTER_DOMAIN}/application/o/harbor/
-                - name: HARBOR_OIDC_CLIENT_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: harbor-sso-secret
-                      key: CLIENT_ID
-                - name: HARBOR_OIDC_CLIENT_SECRET
-                  valueFrom:
-                    secretKeyRef:
-                      name: harbor-sso-secret
-                      key: CLIENT_SECRET
-                - name: DOCKERHUB_USERNAME
-                  valueFrom:
-                    secretKeyRef:
-                      name: harbor-bootstrap-secret
-                      key: DOCKERHUB_USERNAME
-                      optional: true
-                - name: DOCKERHUB_TOKEN
-                  valueFrom:
-                    secretKeyRef:
-                      name: harbor-bootstrap-secret
-                      key: DOCKERHUB_TOKEN
-                      optional: true
               volumeMounts:
                 - name: script
                   mountPath: /scripts
+                  readOnly: true
+                - name: harbor-admin
+                  mountPath: /secrets/harbor
+                  readOnly: true
+                - name: harbor-oidc
+                  mountPath: /secrets/oidc
+                  readOnly: true
+                - name: dockerhub
+                  mountPath: /secrets/dockerhub
                   readOnly: true
                 - name: tmp
                   mountPath: /tmp
@@ -89,6 +69,34 @@ spec:
             - name: script
               configMap:
                 name: harbor-bootstrap
+            - name: harbor-admin
+              secret:
+                secretName: harbor-secrets
+                defaultMode: 288
+                items:
+                  - key: HARBOR_ADMIN_PASSWORD
+                    path: password
+            - name: harbor-oidc
+              secret:
+                secretName: harbor-sso-secret
+                defaultMode: 288
+                items:
+                  - key: CLIENT_ID
+                    path: client-id
+                  - key: CLIENT_SECRET
+                    path: client-secret
+            - name: dockerhub
+              secret:
+                secretName: harbor-bootstrap-secret
+                optional: true
+                defaultMode: 288
+                items:
+                  - key: DOCKERHUB_USERNAME
+                    path: username
+                    optional: true
+                  - key: DOCKERHUB_TOKEN
+                    path: token
+                    optional: true
             - name: tmp
               emptyDir:
                 sizeLimit: 64Mi


### PR DESCRIPTION
## Summary
- Mount the Harbor bootstrap admin, OIDC, and optional Docker Hub credentials as read-only Secret files.
- Read those files directly in the bootstrap script and remove the secret-environment-variable Checkov exception.

## Validation
- Rendered the Harbor config and compiled the embedded `bootstrap.py`.
- `scripts/kubeconform.sh`
- `checkov --config-file .checkov.yaml --quiet --compact`

Refs #676