### PR TITLE
feat(speedtest): add exporter

### DIFF
--- a/kubernetes/apps/apps/external-observability/speedtest-exporter/helmrelease.yaml
+++ b/kubernetes/apps/apps/external-observability/speedtest-exporter/helmrelease.yaml
@@ -1,0 +1,79 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: speedtest-exporter
+  namespace: external-observability
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    controllers:
+      main:
+        containers:
+          main:
+            image:
+              # renovate: datasource=docker depName=heathcliff26/speedtest-exporter registryUrl=https://ghcr.io
+              repository: ghcr.io/heathcliff26/speedtest-exporter
+              tag: v1.6.2
+            args:
+              - -config
+              - /config/config.yaml
+            ports:
+              - name: metrics
+                containerPort: 8080
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /metrics
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /metrics
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 15
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /metrics
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 3
+                  failureThreshold: 12
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                cpu: 200m
+                memory: 128Mi
+    persistence:
+      config:
+        enabled: true
+        type: configMap
+        name: speedtest-exporter-config
+        globalMounts:
+          - path: /config
+            readOnly: true
+    service:
+      main:
+        controller: main
+        ports:
+          metrics:
+            port: 8080

--- a/kubernetes/apps/apps/external-observability/speedtest-exporter/kustomization.yaml
+++ b/kubernetes/apps/apps/external-observability/speedtest-exporter/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+resources:
+  - helmrelease.yaml
+  - speedtest-exporter-config.yaml
+  - servicemonitor.yaml

--- a/kubernetes/apps/apps/external-observability/speedtest-exporter/servicemonitor.yaml
+++ b/kubernetes/apps/apps/external-observability/speedtest-exporter/servicemonitor.yaml
@@ -13,5 +13,5 @@ spec:
   endpoints:
     - port: metrics
       path: /metrics
-      interval: 60m
+      interval: 30s
       scrapeTimeout: 1m

--- a/kubernetes/apps/apps/external-observability/speedtest-exporter/servicemonitor.yaml
+++ b/kubernetes/apps/apps/external-observability/speedtest-exporter/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: speedtest-exporter
+  namespace: external-observability
+  labels:
+    release: observability-kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: speedtest-exporter
+      app.kubernetes.io/name: speedtest-exporter
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 60m
+      scrapeTimeout: 1m

--- a/kubernetes/apps/apps/external-observability/speedtest-exporter/speedtest-exporter-config.yaml
+++ b/kubernetes/apps/apps/external-observability/speedtest-exporter/speedtest-exporter-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: speedtest-exporter-config
+  namespace: external-observability
+data:
+  config.yaml: |
+    logLevel: info
+    port: 8080
+    instance: home-wan
+    cache: 60m
+    persistCache: false

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../apps/external-proxy
   - ../apps/external-observability/opnsense-exporter
   - ../apps/external-observability/omada-exporter
+  - ../apps/external-observability/speedtest-exporter
   - ../apps/automation/n8n
   - ../apps/utils/homepage
   - ../apps/utils/bambuddy


### PR DESCRIPTION
## Summary
- deploy the speedtest exporter through the bjw-s app-template
- run hourly home-WAN speed tests and expose Prometheus metrics
- include the workload in the production Kustomization

## Validation
- pre-commit hooks
- kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/apps/external-observability/speedtest-exporter
- kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/production
- kubectl apply --dry-run=client -f -