### PR TITLE
fix(speedtest): remove invalid scrape timeout

### DIFF
--- a/kubernetes/apps/apps/external-observability/speedtest-exporter/servicemonitor.yaml
+++ b/kubernetes/apps/apps/external-observability/speedtest-exporter/servicemonitor.yaml
@@ -14,4 +14,3 @@ spec:
     - port: metrics
       path: /metrics
       interval: 30s
-      scrapeTimeout: 1m


### PR DESCRIPTION
## Summary
- remove the ServiceMonitor timeout that exceeds the 30-second scrape interval
- allow the Prometheus Operator to select and scrape the speedtest exporter

## Validation
- pre-commit hooks
- kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/apps/external-observability/speedtest-exporter
- kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/production
- kubectl apply --dry-run=client -f -

## Live evidence
The Prometheus Operator rejected the deployed ServiceMonitor with `scrapeTimeout "1m" greater than scrapeInterval "30s"`. The exporter endpoint itself returns successful speed-test metrics.