### PR TITLE
fix(immich): synchronize image releases

### DIFF
--- a/kubernetes/apps/apps/immich/helmrelease.yaml
+++ b/kubernetes/apps/apps/immich/helmrelease.yaml
@@ -19,9 +19,9 @@ spec:
         containers:
           server:
             image:
-              # renovate: datasource=docker depName=immich-app/immich-server registryUrl=https://ghcr.io
+              # renovate: datasource=github-releases depName=immich-app/immich
               repository: ghcr.io/immich-app/immich-server
-              tag: v3.0.3
+              tag: v3.1.0
             env:
               TZ: Europe/Berlin
               IMMICH_HELMET_FILE: true
@@ -86,9 +86,9 @@ spec:
         containers:
           machine-learning:
             image:
-              # renovate: datasource=docker depName=immich-app/immich-machine-learning registryUrl=https://ghcr.io
+              # renovate: datasource=github-releases depName=immich-app/immich
               repository: ghcr.io/immich-app/immich-machine-learning
-              tag: v3.0.3
+              tag: v3.1.0
             env:
               TZ: Europe/Berlin
               TRANSFORMERS_CACHE: /cache

--- a/renovate.json
+++ b/renovate.json
@@ -103,12 +103,10 @@
       "allowedVersions": "/^\\d+\\.\\d+\\.\\d+$/"
     },
     {
-      "description": "Keep Immich images on exact release tags",
-      "matchDatasources": ["docker"],
-      "matchDepNames": [
-        "immich-app/immich-server",
-        "immich-app/immich-machine-learning"
-      ],
+      "description": "Keep both Immich images in sync with the immich-app/immich GitHub release",
+      "matchDatasources": ["github-releases"],
+      "matchDepNames": ["immich-app/immich"],
+      "matchPackageNames": ["immich-app/immich"],
       "groupName": "Immich",
       "versioning": "semver",
       "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+$/"


### PR DESCRIPTION
Updates both Immich images to v3.1.0 and tracks both tags as one immich-app/immich GitHub release dependency, so Renovate updates them together.