### PR TITLE
fix(grafana): sync dashboard updates

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-k8s-views-global.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-k8s-views-global.yaml
@@ -40,7 +40,7 @@ data:
           "collapsed": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -56,7 +56,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -117,7 +117,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -130,7 +130,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"}) / clamp_min(((count(node_cpu_seconds_total{mode=\"idle\",job=~\"$job\"}) or on() vector(0)) + (count(windows_cpu_time_total{mode=\"idle\", job=~\"$job\"}) or on() vector(0))), 1)",
@@ -142,7 +142,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"}) / clamp_min(((count(node_cpu_seconds_total{mode=\"idle\",job=~\"$job\"}) or on() vector(0)) + (count(windows_cpu_time_total{mode=\"idle\", job=~\"$job\"}) or on() vector(0))), 1)",
@@ -176,7 +176,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -235,7 +235,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -249,7 +249,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"}) / clamp_min(((sum(node_memory_MemTotal_bytes{job=~\"$job\"}) or on() vector(0)) + (sum(windows_os_visible_memory_bytes{job=~\"$job\"}) or on() vector(0))), 1)",
@@ -261,7 +261,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"}) / clamp_min(((sum(node_memory_MemTotal_bytes{job=~\"$job\"}) or on() vector(0)) + (sum(windows_os_visible_memory_bytes{job=~\"$job\"}) or on() vector(0))), 1)",
@@ -295,7 +295,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -343,7 +343,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -360,7 +360,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -448,7 +448,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "count(kube_namespace_created) or vector(0)",
@@ -459,7 +459,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "sum(kube_pod_container_status_running)",
               "interval": "",
@@ -469,7 +469,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
               "interval": "",
@@ -479,7 +479,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "sum(kube_service_info)",
               "interval": "",
@@ -489,7 +489,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "count(kube_endpointslice_info) or vector(0)",
               "interval": "",
@@ -499,7 +499,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "sum(kube_ingress_info)",
               "interval": "",
@@ -509,7 +509,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "count(kube_deployment_created) or vector(0)",
               "interval": "",
@@ -519,7 +519,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "count(kube_statefulset_created) or vector(0)",
               "interval": "",
@@ -529,7 +529,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "count(kube_daemonset_created) or vector(0)",
               "interval": "",
@@ -539,7 +539,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "sum(kube_persistentvolumeclaim_info)",
               "interval": "",
@@ -549,7 +549,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "count(kube_horizontalpodautoscaler_info) or vector(0)",
               "interval": "",
@@ -559,7 +559,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "sum(kube_configmap_info)",
               "interval": "",
@@ -569,7 +569,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "sum(kube_secret_info)",
               "interval": "",
@@ -579,7 +579,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "count(kube_networkpolicy_created) or vector(0)",
               "interval": "",
@@ -589,7 +589,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "count(count by (node) (kube_node_info))",
@@ -605,7 +605,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -653,7 +653,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "count(kube_namespace_created)",
               "interval": "",
@@ -667,7 +667,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -707,7 +707,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -720,7 +720,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -734,7 +734,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -748,7 +748,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -762,7 +762,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -816,7 +816,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -865,7 +865,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -878,7 +878,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -892,7 +892,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -906,7 +906,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -920,7 +920,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -975,7 +975,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1023,7 +1023,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
               "interval": "",
@@ -1038,7 +1038,7 @@ data:
           "collapsed": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -1054,7 +1054,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1145,7 +1145,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1163,7 +1163,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1254,7 +1254,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1272,7 +1272,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1364,7 +1364,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1383,7 +1383,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1471,7 +1471,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1488,7 +1488,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1577,7 +1577,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1590,7 +1590,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1608,7 +1608,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1696,7 +1696,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1710,7 +1710,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1728,7 +1728,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "description": "No data is generally a good thing here.",
           "fieldConfig": {
@@ -1821,7 +1821,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1838,7 +1838,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "description": "No data is generally a good thing here.",
           "fieldConfig": {
@@ -1931,7 +1931,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1961,7 +1961,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2049,7 +2049,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2062,7 +2062,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(kube_pod_info)",
@@ -2078,7 +2078,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2166,7 +2166,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2183,7 +2183,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "description": "No data is generally a good thing here.",
           "fieldConfig": {
@@ -2272,7 +2272,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2289,7 +2289,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "description": "No data is generally a good thing here.",
           "fieldConfig": {
@@ -2378,7 +2378,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2396,7 +2396,7 @@ data:
           "collapsed": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -2412,7 +2412,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "description": "Dropped noisy virtual devices for readability.",
           "fieldConfig": {
@@ -2495,7 +2495,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2508,7 +2508,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2521,7 +2521,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2535,7 +2535,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2553,7 +2553,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2635,7 +2635,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2648,7 +2648,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2661,7 +2661,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2675,7 +2675,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2738,7 +2738,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2820,7 +2820,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2833,7 +2833,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "- ((\nsum(rate(container_network_transmit_bytes_total[$__rate_interval])) by (namespace)\n or on(namespace) (sum(kube_namespace_created) by (namespace) * 0)\n)\n+ on(namespace)\n(\nsum(rate(windows_container_network_transmit_bytes_total{container_id!=\"\", job=~\"$job\"}[$__rate_interval]) * on (container_id) group_left (container, pod, namespace) max by ( container, container_id, pod, namespace) (kube_pod_container_info{container_id!=\"\"})) by (namespace)\n or on(namespace) (sum(kube_namespace_created) by (namespace) * 0)\n))",
@@ -2850,7 +2850,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2932,7 +2932,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2945,7 +2945,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "- sum(rate(node_network_transmit_bytes_total{job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -2958,7 +2958,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -2972,7 +2972,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "- sum(rate(windows_net_bytes_sent_total{job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -2989,7 +2989,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "description": "Dropped noisy virtual devices for readability.",
           "fieldConfig": {
@@ -3072,7 +3072,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3085,7 +3085,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "- sum(rate(node_network_transmit_bytes_total{device!~\"(veth|azv|lxc|lo).*\", job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -3098,7 +3098,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3112,7 +3112,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3130,7 +3130,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "description": "Dropped noisy virtual devices for readability.",
           "fieldConfig": {
@@ -3213,7 +3213,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3226,7 +3226,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "- sum(rate(node_network_transmit_bytes_total{device=\"lo\", job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -3274,7 +3274,7 @@ data:
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${datasource}"
+              "uid": "$${datasource}"
             },
             "definition": "label_values({__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\",job=~\"node-exporter|windows-exporter\"}, job)",
             "hide": 0,

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-k8s-views-pods.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-k8s-views-pods.yaml
@@ -138,7 +138,7 @@ data:
                 "type": "prometheus",
                 "uid": "$${datasource}"
               },
-              "expr": "max by (namespace, pod, node, pod_ip, host_ip, created_by_kind, created_by_name, priority_class, qos_class) (max by (namespace, pod, node, pod_ip, host_ip, created_by_kind, created_by_name, priority_class, uid) (kube_pod_info{namespace=\"$namespace\", pod=~\"$pod\"}) * on (namespace, pod, uid) group_left(qos_class) (max by (namespace, pod, uid, qos_class) (kube_pod_status_qos_class{namespace=\"$namespace\", pod=~\"$pod\"}) == 1))",
+              "expr": "max by (namespace, pod, node, pod_ip, host_ip, created_by_kind, created_by_name, priority_class, qos_class) (((max by (namespace, pod, node, pod_ip, host_ip, created_by_kind, created_by_name, priority_class, uid) (kube_pod_info{namespace=\"$namespace\", pod=~\"$pod\"}) * on (namespace, pod, uid) group_left(qos_class) (max by (namespace, pod, uid, qos_class) (kube_pod_status_qos_class{namespace=\"$namespace\", pod=~\"$pod\"}) == 1)) or (max by (namespace, pod, node, pod_ip, host_ip, created_by_kind, created_by_name, priority_class, uid) (kube_pod_info{namespace=\"$namespace\", pod=~\"$pod\"}) unless on (namespace, pod, uid) (max by (namespace, pod, uid, qos_class) (kube_pod_status_qos_class{namespace=\"$namespace\", pod=~\"$pod\"}) == 1))))",
               "format": "table",
               "instant": true,
               "legendFormat": "{{namespace}}/{{pod}}",

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-k8s-views-pods.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-k8s-views-pods.yaml
@@ -31,7 +31,7 @@ data:
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${datasource}"
+              "uid": "$${datasource}"
             },
             "enable": true,
             "hide": false,
@@ -52,7 +52,7 @@ data:
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${datasource}"
+              "uid": "$${datasource}"
             },
             "enable": true,
             "hide": false,
@@ -93,7 +93,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "description": "One readable row per selected pod, including namespace, node, IP, creator, priority, and QoS class.",
           "fieldConfig": {
@@ -105,23 +105,18 @@ data:
                 },
                 "filterable": true,
                 "footer": {
-                  "reducers": [
-                    "countAll"
-                  ]
+                  "reducers": []
                 },
                 "inspect": false
               },
-              "decimals": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": 0
+                    "color": "green"
                   }
                 ]
-              },
-              "unit": "short"
+              }
             }
           },
           "gridPos": {
@@ -136,62 +131,50 @@ data:
             "enablePagination": true,
             "showHeader": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
-              "expr": "kube_pod_info{namespace=\"$namespace\", pod=~\"$pod\"}",
+              "expr": "max by (namespace, pod, node, pod_ip, host_ip, created_by_kind, created_by_name, priority_class, qos_class) (max by (namespace, pod, node, pod_ip, host_ip, created_by_kind, created_by_name, priority_class, uid) (kube_pod_info{namespace=\"$namespace\", pod=~\"$pod\"}) * on (namespace, pod, uid) group_left(qos_class) (max by (namespace, pod, uid, qos_class) (kube_pod_status_qos_class{namespace=\"$namespace\", pod=~\"$pod\"}) == 1))",
               "format": "table",
               "instant": true,
               "legendFormat": "{{namespace}}/{{pod}}",
               "range": false,
               "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "kube_pod_status_qos_class{namespace=\"$namespace\", pod=~\"$pod\"} > 0",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "{{namespace}}/{{pod}}",
-              "range": false,
-              "refId": "B"
             }
           ],
           "title": "Pod Identity",
           "transformations": [
             {
-              "id": "joinByField",
-              "options": {
-                "byField": "pod",
-                "mode": "outer"
-              }
-            },
-            {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true,
-                  "__name__": true,
-                  "container": true,
-                  "endpoint": true,
-                  "instance": true,
-                  "job": true,
-                  "namespace": false,
-                  "pod": false,
-                  "service": true,
-                  "uid": true
+                  "Value": true,
+                  "Value #A": true,
+                  "__name__": true
                 },
-                "indexByName": {},
+                "indexByName": {
+                  "created_by_kind": 5,
+                  "created_by_name": 6,
+                  "host_ip": 4,
+                  "namespace": 1,
+                  "node": 2,
+                  "pod": 0,
+                  "pod_ip": 3,
+                  "priority_class": 7,
+                  "qos_class": 8
+                },
                 "renameByName": {
                   "created_by_kind": "Created by kind",
                   "created_by_name": "Created by name",
+                  "host_ip": "Host IP",
+                  "namespace": "Namespace",
                   "node": "Node",
+                  "pod": "Pod",
                   "pod_ip": "Pod IP",
                   "priority_class": "Priority class",
                   "qos_class": "QoS class"
@@ -204,7 +187,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "description": "Selected containers with a recorded last termination reason.",
           "fieldConfig": {
@@ -247,12 +230,12 @@ data:
             "enablePagination": true,
             "showHeader": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "expr": "kube_pod_container_status_last_terminated_reason{namespace=\"$namespace\", pod=~\"$pod\"}",
               "format": "table",
@@ -303,7 +286,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -369,12 +352,12 @@ data:
             "sparkline": false,
             "textMode": "auto"
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -391,7 +374,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -453,12 +436,12 @@ data:
             "sparkline": false,
             "textMode": "auto"
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -475,7 +458,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -541,12 +524,12 @@ data:
             "sparkline": false,
             "textMode": "auto"
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -563,7 +546,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -625,12 +608,12 @@ data:
             "sparkline": false,
             "textMode": "auto"
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -647,7 +630,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -738,12 +721,12 @@ data:
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -758,7 +741,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -773,7 +756,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -787,7 +770,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -801,7 +784,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -815,7 +798,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -853,6 +836,7 @@ data:
                   "endpoint 2": true,
                   "endpoint 3": true,
                   "endpoint 4": true,
+                  "identity": true,
                   "instance": true,
                   "instance 2": true,
                   "instance 3": true,
@@ -888,8 +872,7 @@ data:
                   "unit 1": true,
                   "unit 2": true,
                   "unit 3": true,
-                  "unit 4": true,
-                  "identity": true
+                  "unit 4": true
                 },
                 "indexByName": {
                   "Time 1": 7,
@@ -927,7 +910,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1024,12 +1007,12 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1042,7 +1025,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", image!=\"\"}[$__rate_interval])) by (namespace, pod, container) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$pod\", resource=\"cpu\", job=~\"$job\"} and on(namespace, pod) max by (namespace, pod) (kube_pod_status_phase{phase=\"Running\", namespace=\"$namespace\", pod=~\"$pod\", job=~\"$job\"} == 1)) by (namespace, pod, container)",
@@ -1057,7 +1040,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1158,12 +1141,12 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1176,7 +1159,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", image!=\"\"}) by (namespace, pod, container) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$pod\", resource=\"memory\", job=~\"$job\"} and on(namespace, pod) max by (namespace, pod) (kube_pod_status_phase{phase=\"Running\", namespace=\"$namespace\", pod=~\"$pod\", job=~\"$job\"} == 1)) by (namespace, pod, container)",
@@ -1191,7 +1174,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1300,12 +1283,12 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1322,7 +1305,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1413,12 +1396,12 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1435,7 +1418,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1528,12 +1511,12 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1562,7 +1545,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1647,12 +1630,12 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1669,7 +1652,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1754,12 +1737,12 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1776,7 +1759,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1866,12 +1849,12 @@ data:
             "cellHeight": "sm",
             "showHeader": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1941,7 +1924,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2026,12 +2009,12 @@ data:
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2108,7 +2091,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2191,12 +2174,12 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
@@ -2207,7 +2190,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "- sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
@@ -2222,7 +2205,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2305,12 +2288,12 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "sum(rate(container_network_receive_packets_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
@@ -2321,7 +2304,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "- sum(rate(container_network_transmit_packets_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
@@ -2336,7 +2319,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2419,12 +2402,12 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "sum(rate(container_network_receive_packets_dropped_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
@@ -2435,7 +2418,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "- sum(rate(container_network_transmit_packets_dropped_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
@@ -2450,7 +2433,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2533,12 +2516,12 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
@@ -2549,7 +2532,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${datasource}"
+                "uid": "$${datasource}"
               },
               "exemplar": true,
               "expr": "- sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
@@ -2586,7 +2569,7 @@ data:
             "allowCustomValue": true,
             "datasource": {
               "type": "prometheus",
-              "uid": "${datasource}"
+              "uid": "$${datasource}"
             },
             "definition": "label_values(kube_pod_info, namespace)",
             "hide": 0,
@@ -2609,7 +2592,7 @@ data:
             "allowCustomValue": true,
             "datasource": {
               "type": "prometheus",
-              "uid": "${datasource}"
+              "uid": "$${datasource}"
             },
             "definition": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
             "hide": 0,
@@ -2642,7 +2625,7 @@ data:
             "allowCustomValue": true,
             "datasource": {
               "type": "prometheus",
-              "uid": "${datasource}"
+              "uid": "$${datasource}"
             },
             "definition": "label_values(kube_pod_info{namespace=\"$namespace\"},job)",
             "hide": 0,

--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-network-edge-lan-trial.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-network-edge-lan-trial.yaml
@@ -51,6 +51,21 @@ data:
           "fieldConfig": {
             "defaults": {
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "text": "Down"
+                    },
+                    "1": {
+                      "color": "green",
+                      "text": "Up"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
@@ -65,22 +80,7 @@ data:
                   }
                 ]
               },
-              "unit": "none",
-              "mappings": [
-                {
-                  "type": "value",
-                  "options": {
-                    "0": {
-                      "text": "Down",
-                      "color": "red"
-                    },
-                    "1": {
-                      "text": "Up",
-                      "color": "green"
-                    }
-                  }
-                }
-              ]
+              "unit": "none"
             }
           },
           "gridPos": {
@@ -107,7 +107,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -175,7 +175,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -242,7 +242,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -308,7 +308,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -374,7 +374,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -437,7 +437,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -463,6 +463,21 @@ data:
           "fieldConfig": {
             "defaults": {
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "text": "Down"
+                    },
+                    "1": {
+                      "color": "green",
+                      "text": "Up"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
@@ -477,22 +492,7 @@ data:
                   }
                 ]
               },
-              "unit": "none",
-              "mappings": [
-                {
-                  "type": "value",
-                  "options": {
-                    "0": {
-                      "text": "Down",
-                      "color": "red"
-                    },
-                    "1": {
-                      "text": "Up",
-                      "color": "green"
-                    }
-                  }
-                }
-              ]
+              "unit": "none"
             }
           },
           "gridPos": {
@@ -519,7 +519,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -587,7 +587,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -654,7 +654,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -720,7 +720,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -786,7 +786,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -849,7 +849,7 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -871,9 +871,12 @@ data:
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "Total default WAN download and upload for the dashboard time-picker range.",
+          "description": "Total download and upload across the selected interfaces for the dashboard time-picker range.",
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
               "decimals": 1,
               "min": 0,
               "thresholds": {
@@ -912,16 +915,17 @@ data:
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "increase(opnsense_interfaces_received_bytes_total{interface=~\"$interface\"}[$__range])",
+              "editorMode": "code",
+              "expr": "sum(increase(opnsense_interfaces_received_bytes_total{interface=~\"$interface\"}[$__range]))",
               "instant": true,
-              "legendFormat": "{{interface}} Download",
+              "legendFormat": "Download",
               "range": false,
               "refId": "A"
             },
@@ -930,9 +934,10 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "increase(opnsense_interfaces_transmitted_bytes_total{interface=~\"$interface\"}[$__range])",
+              "editorMode": "code",
+              "expr": "sum(increase(opnsense_interfaces_transmitted_bytes_total{interface=~\"$interface\"}[$__range]))",
               "instant": true,
-              "legendFormat": "{{interface}} Upload",
+              "legendFormat": "Upload",
               "range": false,
               "refId": "B"
             }
@@ -1042,7 +1047,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -1149,7 +1154,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -1257,7 +1262,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -1375,7 +1380,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -1494,7 +1499,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -1646,7 +1651,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -1753,7 +1758,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -1845,7 +1850,7 @@ data:
             "enablePagination": true,
             "showHeader": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -1985,7 +1990,7 @@ data:
             "xTickLabelRotation": 0,
             "xTickLabelSpacing": 0
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -2105,7 +2110,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -2211,7 +2216,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -2330,7 +2335,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -2436,7 +2441,7 @@ data:
               "sort": "desc"
             }
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -2560,7 +2565,7 @@ data:
             "enablePagination": true,
             "showHeader": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -2693,17 +2698,17 @@ data:
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "0": {
-                            "text": "Down",
-                            "color": "red"
+                            "color": "red",
+                            "text": "Down"
                           },
                           "1": {
-                            "text": "Up",
-                            "color": "green"
+                            "color": "green",
+                            "text": "Up"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   },
@@ -2775,7 +2780,7 @@ data:
             "enablePagination": true,
             "showHeader": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -2956,17 +2961,17 @@ data:
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "0": {
-                            "text": "No",
-                            "color": "green"
+                            "color": "green",
+                            "text": "No"
                           },
                           "1": {
-                            "text": "Yes",
-                            "color": "orange"
+                            "color": "orange",
+                            "text": "Yes"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   },
@@ -2990,7 +2995,7 @@ data:
             "enablePagination": true,
             "showHeader": true
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {
@@ -3057,13 +3062,13 @@ data:
                   "Time": true,
                   "__name__": true,
                   "container": true,
+                  "device_identity": true,
                   "endpoint": true,
                   "instance": true,
                   "job": true,
                   "namespace": true,
                   "pod": true,
-                  "service": true,
-                  "device_identity": true
+                  "service": true
                 },
                 "indexByName": {},
                 "renameByName": {
@@ -3106,7 +3111,7 @@ data:
             "wrapLines": false,
             "wrapLogMessage": false
           },
-          "pluginVersion": "13.1.0",
+          "pluginVersion": "13.1.1",
           "targets": [
             {
               "datasource": {


### PR DESCRIPTION
## Summary
- sync the Network Edge & LAN and Kubernetes Views / Pods Grafana dashboards from their exports
- preserve Grafana datasource variables through Flux post-build substitution
- escape datasource references in Kubernetes Views / Global for the same Flux behavior

## Validation
- pre-commit hooks passed during commit
- ConfigMap YAML and embedded dashboard JSON parsed successfully
- `kubectl kustomize kubernetes/infrastructure/observability/kube-prometheus-stack/config` passed
- Flux substitution simulation retained all 155 literal `${datasource}` references