### PR TITLE
fix(grafana): pin annotation datasource

### DIFF
--- a/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-k8s-views-pods.yaml
+++ b/kubernetes/infrastructure/observability/kube-prometheus-stack/config/grafana-dashboard-k8s-views-pods.yaml
@@ -31,7 +31,7 @@ data:
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "$${datasource}"
+              "uid": "prometheus"
             },
             "enable": true,
             "hide": false,
@@ -52,7 +52,7 @@ data:
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "$${datasource}"
+              "uid": "prometheus"
             },
             "enable": true,
             "hide": false,


### PR DESCRIPTION
## Summary
- use the literal Prometheus datasource for Pods dashboard restart and deployment annotations
- retain the selectable datasource variable for panels and dashboard variables

## Validation
- YAML and embedded dashboard JSON parsed
- `kubectl kustomize kubernetes/infrastructure/observability/kube-prometheus-stack/config` passed
- pre-commit passed for the changed dashboard