### PR TITLE
chore(terraform): migrate non-bootstrap state to garage

### DIFF
--- a/terraform/cloud/hetzner/firewall/providers.tf
+++ b/terraform/cloud/hetzner/firewall/providers.tf
@@ -5,13 +5,17 @@ terraform {
       version = "~> 1.61"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.10"
 
-  cloud {
-    organization = "home-lab-iac"
-    workspaces {
-      name = "hetzner-firewall"
-    }
+  backend "s3" {
+    bucket                      = "terraform"
+    key                         = "states/hetzner-firewall/terraform.tfstate"
+    use_path_style              = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
   }
 }
 

--- a/terraform/cloud/hetzner/servers/netbird/main.tf
+++ b/terraform/cloud/hetzner/servers/netbird/main.tf
@@ -3,13 +3,17 @@ data "bitwarden-secrets_secret" "ssh_public_keys" {
 }
 
 data "terraform_remote_state" "firewall" {
-  backend = "remote"
+  backend = "s3"
 
   config = {
-    organization = "home-lab-iac"
-    workspaces = {
-      name = "hetzner-firewall"
-    }
+    bucket = "terraform"
+    key    = "states/hetzner-firewall/terraform.tfstate"
+
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
   }
 }
 

--- a/terraform/cloud/hetzner/servers/netbird/providers.tf
+++ b/terraform/cloud/hetzner/servers/netbird/providers.tf
@@ -13,13 +13,17 @@ terraform {
       version = "0.5.4-pre"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.10"
 
-  cloud {
-    organization = "home-lab-iac"
-    workspaces {
-      name = "hetzner-servers"
-    }
+  backend "s3" {
+    bucket                      = "terraform"
+    key                         = "states/hetzner-servers/terraform.tfstate"
+    use_path_style              = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
   }
 }
 

--- a/terraform/cloud/hetzner/ssh_keys/providers.tf
+++ b/terraform/cloud/hetzner/ssh_keys/providers.tf
@@ -9,13 +9,17 @@ terraform {
       version = "0.5.4-pre"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.10"
 
-  cloud {
-    organization = "home-lab-iac"
-    workspaces {
-      name = "hetzner-ssh-keys"
-    }
+  backend "s3" {
+    bucket                      = "terraform"
+    key                         = "states/hetzner-ssh-keys/terraform.tfstate"
+    use_path_style              = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
   }
 }
 

--- a/terraform/instances/lxc/garage_s3/providers.tf
+++ b/terraform/instances/lxc/garage_s3/providers.tf
@@ -13,13 +13,22 @@ terraform {
       version = "0.5.4-pre"
     }
   }
-  required_version = ">= 1.4"
+  required_version = ">= 1.10"
 
-  cloud {
-    organization = "home-lab-iac"
-    workspaces {
-      name = "garage-s3-lxc"
-    }
+  # Bootstrap dependency: this root manages the Garage LXC that hosts this backend.
+  # For first creation, use a temporary local backend; migrate state here only after
+  # Garage and the `terraform` bucket are healthy. Never apply from empty recovery state.
+  backend "s3" {
+    bucket = "terraform"
+    key    = "states/garage-s3-lxc/terraform.tfstate"
+
+    use_path_style = true
+    use_lockfile   = true
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
   }
 }
 
@@ -28,6 +37,8 @@ terraform {
 # - Local compatibility mapping:
 #   export PROXMOX_VE_ENDPOINT="$PM_API_URL"
 #   export PROXMOX_VE_API_TOKEN="$PM_API_TOKEN_ID=$PM_API_TOKEN_SECRET"
+# - Backend (S3/Garage), env-sourced: AWS_ENDPOINT_URL_S3, AWS_REGION,
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 
 provider "proxmox" {
   insecure = true

--- a/terraform/instances/lxc/garage_s3/providers.tf
+++ b/terraform/instances/lxc/garage_s3/providers.tf
@@ -13,22 +13,13 @@ terraform {
       version = "0.5.4-pre"
     }
   }
-  required_version = ">= 1.10"
+  required_version = ">= 1.4"
 
-  # Bootstrap dependency: this root manages the Garage LXC that hosts this backend.
-  # For first creation, use a temporary local backend; migrate state here only after
-  # Garage and the `terraform` bucket are healthy. Never apply from empty recovery state.
-  backend "s3" {
-    bucket = "terraform"
-    key    = "states/garage-s3-lxc/terraform.tfstate"
-
-    use_path_style = true
-    use_lockfile   = true
-
-    skip_credentials_validation = true
-    skip_metadata_api_check     = true
-    skip_region_validation      = true
-    skip_requesting_account_id  = true
+  cloud {
+    organization = "home-lab-iac"
+    workspaces {
+      name = "garage-s3-lxc"
+    }
   }
 }
 
@@ -37,8 +28,6 @@ terraform {
 # - Local compatibility mapping:
 #   export PROXMOX_VE_ENDPOINT="$PM_API_URL"
 #   export PROXMOX_VE_API_TOKEN="$PM_API_TOKEN_ID=$PM_API_TOKEN_SECRET"
-# - Backend (S3/Garage), env-sourced: AWS_ENDPOINT_URL_S3, AWS_REGION,
-#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 
 provider "proxmox" {
   insecure = true

--- a/terraform/instances/lxc/llm/providers.tf
+++ b/terraform/instances/lxc/llm/providers.tf
@@ -13,13 +13,17 @@ terraform {
       version = "0.5.4-pre"
     }
   }
-  required_version = ">= 1.4"
+  required_version = ">= 1.10"
 
-  cloud {
-    organization = "home-lab-iac"
-    workspaces {
-      name = "llm-lxc"
-    }
+  backend "s3" {
+    bucket                      = "terraform"
+    key                         = "states/llm-lxc/terraform.tfstate"
+    use_path_style              = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
   }
 }
 

--- a/terraform/instances/lxc/photon/providers.tf
+++ b/terraform/instances/lxc/photon/providers.tf
@@ -13,13 +13,17 @@ terraform {
       version = "0.5.4-pre"
     }
   }
-  required_version = ">= 1.4"
+  required_version = ">= 1.10"
 
-  cloud {
-    organization = "home-lab-iac"
-    workspaces {
-      name = "photon-lxc"
-    }
+  backend "s3" {
+    bucket                      = "terraform"
+    key                         = "states/photon-lxc/terraform.tfstate"
+    use_path_style              = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
   }
 }
 

--- a/terraform/instances/vm/k3s_nodes/providers.tf
+++ b/terraform/instances/vm/k3s_nodes/providers.tf
@@ -13,18 +13,26 @@ terraform {
       version = "0.5.4-pre"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.10"
 
-  cloud {
-    organization = "home-lab-iac"
-    workspaces {
-      name = "k3s-nodes"
-    }
+  backend "s3" {
+    bucket = "terraform"
+    key    = "states/k3s-nodes/terraform.tfstate"
+
+    use_path_style = true
+    use_lockfile   = true
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
   }
 }
 
 # Environment inputs:
 # - Provider auth/endpoint: PM_API_URL, PM_API_TOKEN_ID, PM_API_TOKEN_SECRET
+# - Backend (S3/Garage), env-sourced: AWS_ENDPOINT_URL_S3, AWS_REGION,
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 
 provider "proxmox" {
   pm_tls_insecure = true

--- a/terraform/instances/vm/openclaw/providers.tf
+++ b/terraform/instances/vm/openclaw/providers.tf
@@ -13,13 +13,17 @@ terraform {
       version = "0.5.4-pre"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.10"
 
-  cloud {
-    organization = "home-lab-iac"
-    workspaces {
-      name = "openclaw-vm"
-    }
+  backend "s3" {
+    bucket                      = "terraform"
+    key                         = "states/openclaw-vm/terraform.tfstate"
+    use_path_style              = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
   }
 }
 

--- a/terraform/modules/proxmox/lxc/main.tf
+++ b/terraform/modules/proxmox/lxc/main.tf
@@ -221,5 +221,9 @@ resource "proxmox_virtual_environment_container" "this" {
       condition     = !try(each.value.ssh_bootstrap.enabled, false) || var.ssh_bootstrap_cluster_ssh_host != null
       error_message = "ssh_bootstrap_cluster_ssh_host is required when any container enables ssh_bootstrap."
     }
+
+    ignore_changes = [
+      initialization[0].user_account,
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- migrate non-bootstrap Terraform root states from HCP Terraform to Garage S3
- keep the Garage LXC root on its independent HCP Terraform workspace
- move NetBird firewall remote-state reads to S3
- ignore immutable LXC create-time SSH key drift

## Validation
- pre-commit on all changed Terraform files
- initialized, copied, and refreshed each Garage-migrated state
- clean refresh plans: SSH keys, firewall, NetBird, K3s nodes, and Garage on HCP

## Follow-up
- LLM retains a manually set Proxmox description and needs generated inventory regeneration; intentionally left unchanged in this PR.