### PR TITLE
fix(ansible): stabilize llm runtime updates

### DIFF
--- a/ansible/roles/llama_swap/defaults/main.yml
+++ b/ansible/roles/llama_swap/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
 llama_swap_enabled: true
 
-llama_swap_version: "214"
+llama_swap_version: "246"
 llama_swap_tag: "v{{ llama_swap_version }}"
 llama_swap_archive_name: "llama-swap_{{ llama_swap_version }}_linux_amd64.tar.gz"
 llama_swap_archive_url: >-
   https://github.com/mostlygeek/llama-swap/releases/download/{{ llama_swap_tag }}/{{ llama_swap_archive_name }}
-llama_swap_archive_checksum: "sha256:7cd132f1e232f203db7d90e8bf62f341213587d38b6dab47d875ec68220c127c"
+llama_swap_archive_checksum: "sha256:92ea5c37f66a7ed31bd83ffb1b1b46b7f033881f742fead6c6e64a6601013352"
 
 llama_swap_install_dir: /opt/llama-swap
 llama_swap_release_dir: "{{ llama_swap_install_dir }}/releases/{{ llama_swap_tag }}"

--- a/ansible/roles/llm_runtime/README.md
+++ b/ansible/roles/llm_runtime/README.md
@@ -26,6 +26,8 @@ Important parameters:
 - `llm_runtime_cmake_hip_flags`
 - `llm_runtime_enable_rpc`
 - `llm_runtime_enable_unified_memory`
+- `llm_runtime_enable_ui`
+- `llm_runtime_use_prebuilt_ui`
 - `llm_runtime_force_rebuild`
 - `llm_runtime_extra_packages`
 - `llm_runtime_vram_estimator_url`
@@ -39,6 +41,14 @@ true. When both are enabled, `llama.cpp` is configured with both `GGML_HIP` and
 The current `llama.cpp` build always includes HIP/ROCm, so enabling it requires
 `llm_runtime_enable_rocm`; Vulkan support is added when
 `llm_runtime_enable_vulkan` is true.
+
+`llm_runtime_enable_ui` and `llm_runtime_use_prebuilt_ui` map to the upstream
+`LLAMA_BUILD_UI` and `LLAMA_USE_PREBUILT_UI` CMake flags. Both default to false
+even though upstream defaults them to ON: the prebuilt UI download has failed
+inside constrained LXCs and leaves stale assets under `build/tools/ui/dist` that
+abort `llama-ui-embed` on the next configure. When the UI is disabled and a
+rebuild is required, the role removes those stale generated UI asset directories
+before configuring so llama.cpp falls back to its no-UI build cleanly.
 
 The role writes `{{ llm_runtime_llama_marker_path }}` after a successful build.
 Changing the ROCm version, llama.cpp ref, build flags, or patch settings causes

--- a/ansible/roles/llm_runtime/defaults/main.yml
+++ b/ansible/roles/llm_runtime/defaults/main.yml
@@ -78,6 +78,14 @@ llm_runtime_force_rebuild: false
 
 llm_runtime_enable_rpc: true
 llm_runtime_enable_unified_memory: true
+
+# The upstream llama.cpp embedded UI (LLAMA_BUILD_UI) and its prebuilt asset
+# download (LLAMA_USE_PREBUILT_UI) both default to ON. The prebuilt UI download
+# has failed in constrained LXCs and leaves stale assets under
+# build/tools/ui/dist that abort llama-ui-embed on the next configure. The role
+# disables both by default so llama.cpp falls back to its no-UI build.
+llm_runtime_enable_ui: false
+llm_runtime_use_prebuilt_ui: false
 llm_runtime_cmake_hip_flags: "--rocm-path={{ llm_runtime_rocm_path }} -mllvm --amdgpu-unroll-threshold-local=600"
 
 llm_runtime_install_vram_estimator: true

--- a/ansible/roles/llm_runtime/tasks/main.yml
+++ b/ansible/roles/llm_runtime/tasks/main.yml
@@ -269,6 +269,19 @@
       }}
   when: llm_runtime_enable_llama | bool
 
+- name: Remove stale llama.cpp embedded UI assets when UI disabled
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ llm_runtime_llama_build_dir }}/tools/ui/dist"
+    - "{{ llm_runtime_llama_dir }}/tools/ui/dist"
+    - "{{ llm_runtime_llama_build_dir }}/tools/ui/.ui-stamp"
+  when:
+    - llm_runtime_enable_llama | bool
+    - llm_runtime_rebuild_required | bool
+    - not (llm_runtime_enable_ui | bool)
+
 - name: Configure llama.cpp ROCm/Vulkan build
   ansible.builtin.command: >-
     cmake -S . -B {{ llm_runtime_llama_build_dir | quote }}
@@ -278,6 +291,8 @@
     -DAMDGPU_TARGETS={{ llm_runtime_amdgpu_targets | quote }}
     -DCMAKE_BUILD_TYPE={{ llm_runtime_build_type | quote }}
     -DGGML_RPC={{ 'ON' if llm_runtime_enable_rpc | bool else 'OFF' }}
+    -DLLAMA_BUILD_UI={{ 'ON' if llm_runtime_enable_ui | bool else 'OFF' }}
+    -DLLAMA_USE_PREBUILT_UI={{ 'ON' if llm_runtime_use_prebuilt_ui | bool else 'OFF' }}
     -DROCM_PATH={{ llm_runtime_rocm_path | quote }}
     -DHIP_PATH={{ llm_runtime_rocm_path | quote }}
     -DHIP_PLATFORM=amd

--- a/ansible/roles/llm_runtime/templates/build-marker.json.j2
+++ b/ansible/roles/llm_runtime/templates/build-marker.json.j2
@@ -10,5 +10,7 @@
   "amdgpu_targets": {{ llm_runtime_amdgpu_targets | to_json }},
   "build_type": {{ llm_runtime_build_type | to_json }},
   "enable_rpc": {{ llm_runtime_enable_rpc | bool | to_json }},
+  "enable_ui": {{ llm_runtime_enable_ui | bool | to_json }},
+  "use_prebuilt_ui": {{ llm_runtime_use_prebuilt_ui | bool | to_json }},
   "cmake_hip_flags": {{ llm_runtime_cmake_hip_flags | to_json }}
 }


### PR DESCRIPTION
## Summary
- disable llama.cpp embedded UI asset provisioning and clear stale generated assets before rebuilds
- include UI settings in the llama.cpp build marker and document the role defaults
- bump llama-swap from v214 to v246 with the release checksum

## Validation
- ansible-lint roles/llm_runtime/ roles/llama_swap/ playbooks/llm_lxc.yml
- ansible-playbook playbooks/llm_lxc.yml --syntax-check
- deployed and verified on ct-llm: llama.cpp and whisper.cpp rebuilds, llama-swap v246 health, ComfyUI health/timer, OpenAI sidecar, and Chatterbox service