### PR TITLE
fix(kubernetes): disable netbird reconciliation

### DIFF
--- a/kubernetes/clusters/production/ks/kustomization.yaml
+++ b/kubernetes/clusters/production/ks/kustomization.yaml
@@ -10,8 +10,10 @@ resources:
   - 21-traefik-config.yaml
   - 25-external-dns-install.yaml
   - 26-cloudflared-install.yaml
-  - 27-netbird-operator-install.yaml
-  - 28-netbird-config.yaml
+  # NetBird is intentionally disabled. Retain its Flux manifests for a future
+  # re-enable, but do not reconcile its zero-replica operator or webhook.
+  # - 27-netbird-operator-install.yaml
+  # - 28-netbird-config.yaml
   - 30-kube-replicator-install.yaml
   - 31-reloader-install.yaml
   - 42-authentik-install.yaml

--- a/kubernetes/infrastructure/networking/traefik/config/kustomization.yaml
+++ b/kubernetes/infrastructure/networking/traefik/config/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - service-netbird.yaml
+  # NetBird is intentionally disabled; retain the service manifest for a
+  # future re-enable without exposing it through Traefik meanwhile.
+  # - service-netbird.yaml
   - middlewares/default-headers.yaml
   - middlewares/nextcloud-office-headers.yaml
   - middlewares/rate-limit.yaml


### PR DESCRIPTION
## Summary
- disable NetBird Flux and Traefik inclusion while retaining manifests for a future re-enable
- prevent its zero-replica operator from recreating an endpoint-less blocking admission webhook

## Validation
- `kubectl kustomize kubernetes/clusters/production/ks`
- `kubectl kustomize kubernetes/infrastructure/networking/traefik/config`
- `checkov --config-file .checkov.yaml`
- affected pre-commit hooks