### PR TITLE
feat(kubernetes): add scrob

### DIFF
--- a/kubernetes/apps/apps/media/scrob/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/media/scrob/cnpg-cluster.yaml
@@ -1,0 +1,59 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: scrob-pg
+  namespace: media
+  labels:
+    release: observability-kube-prometheus-stack
+spec:
+  inheritedMetadata:
+    labels:
+      recurring-job.longhorn.io/backup-daily: enabled
+      recurring-job.longhorn.io/backup-weekly: enabled
+  instances: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  monitoring:
+    enablePodMonitor: true
+  storage:
+    size: 5Gi
+    storageClass: longhorn-r2
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+
+  postgresql:
+    parameters:
+      wal_level: "replica"
+      archive_timeout: "21600" # Wait 6 hours before shipping WALs when no activity
+      archive_mode: "on"
+
+  bootstrap:
+    initdb:
+      database: scrob
+      owner: scrob
+      secret:
+        name: scrob-db-secrets
+
+  backup:
+    barmanObjectStore:
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-backup-s3
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-backup-s3
+          key: ACCESS_SECRET_KEY
+        region:
+          name: cnpg-backup-s3
+          key: AWS_DEFAULT_REGION
+      destinationPath: "s3://cloudnative-pg/scrob"
+      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
+      serverName: "scrob-pg-v1"
+    retentionPolicy: "14d"

--- a/kubernetes/apps/apps/media/scrob/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/scrob/helmrelease.yaml
@@ -1,0 +1,135 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: scrob
+  namespace: media
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    defaultPodOptions:
+      # The upstream entrypoint starts as root to run init/chown on the data
+      # volume, then drops its own process privileges to PUID/PGID 1000. Do not
+      # impose a runAsNonRoot/runAsUser security context that would conflict
+      # with that root init phase; PUID/PGID below drive the in-container drop.
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      main:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              # renovate: datasource=docker depName=bellamy/scrob registryUrl=https://docker.io
+              repository: docker.io/bellamy/scrob
+              tag: 1.53.0
+              digest: sha256:aaebbbe88a2f93276314238885f749a7f21f30b7d6dcd758937d9147058779de
+            env:
+              TZ: Europe/Berlin
+              PUID: "1000"
+              PGID: "1000"
+              SERVER_URL: https://scrob.lan.${CLUSTER_DOMAIN}
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: scrob-db-secrets
+                    key: DATABASE_URL
+              SECRET_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: scrob-secrets
+                    key: SECRET_KEY
+              OIDC_ENABLED: "true"
+              OIDC_PROVIDER_NAME: Authentik
+              OIDC_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: scrob-sso-secret
+                    key: CLIENT_ID
+              OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: scrob-sso-secret
+                    key: CLIENT_SECRET
+              OIDC_AUTH_URL: https://sso.${CLUSTER_DOMAIN}/application/o/authorize/
+              OIDC_TOKEN_URL: https://sso.${CLUSTER_DOMAIN}/application/o/token/
+              OIDC_USERINFO_URL: https://sso.${CLUSTER_DOMAIN}/application/o/userinfo/
+              OIDC_REDIRECT_URL: https://scrob.lan.${CLUSTER_DOMAIN}/oidc-callback
+              OIDC_SCOPES: openid email profile
+              OIDC_AUTO_CREATE_USERS: "true"
+              OIDC_DISABLE_PASSWORD_LOGIN: "false"
+            ports:
+              - name: http
+                containerPort: 7330
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/proxy/auth/has-users
+                    port: 7330
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/proxy/auth/has-users
+                    port: 7330
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/proxy/auth/has-users
+                    port: 7330
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 7330
+
+    ingress:
+      main:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: scrob.lan.${CLUSTER_DOMAIN}
+        hosts:
+          - host: scrob.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: http
+
+    persistence:
+      data:
+        enabled: true
+        type: custom
+        volumeSpec:
+          persistentVolumeClaim:
+            claimName: scrob
+        globalMounts:
+          - path: /app/backend/data

--- a/kubernetes/apps/apps/media/scrob/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/scrob/helmrelease.yaml
@@ -28,7 +28,6 @@ spec:
               # renovate: datasource=docker depName=bellamy/scrob registryUrl=https://docker.io
               repository: docker.io/bellamy/scrob
               tag: 1.53.0
-              digest: sha256:aaebbbe88a2f93276314238885f749a7f21f30b7d6dcd758937d9147058779de
             env:
               TZ: Europe/Berlin
               PUID: "1000"

--- a/kubernetes/apps/apps/media/scrob/kustomization.yaml
+++ b/kubernetes/apps/apps/media/scrob/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+  - ../../../../components/ingress/traefik-base
+
+resources:
+  - scrob-db-secrets.sops.yaml
+  - scrob-secrets.sops.yaml
+  - cnpg-cluster.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/apps/media/scrob/scrob-db-secrets.sops.yaml
+++ b/kubernetes/apps/apps/media/scrob/scrob-db-secrets.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: scrob-db-secrets
+    namespace: media
+type: Opaque
+stringData:
+    username: ENC[AES256_GCM,data:S2+KnQU=,iv:K17vJZexm1SK8F2Fbj8BC9eDU+hDngxnwIebt0rTi0I=,tag:efKZq+9r7bDgKxrexaiXbg==,type:str]
+    password: ENC[AES256_GCM,data:Ewq6eI3gZvRX2F0gwJOyGP8b9WZRUmCQVnTiSYK+CYS128TsaZu/3dOEaDnfxBbUVHTEzFhauoKMkwpFrUTo+Q==,iv:cGEu9B52TU/mHhB4SBr4Nt09oYbWvoniS8PVydIuh6Y=,tag:7yTWQ/6LAzhlA27ExC52mg==,type:str]
+    DATABASE_URL: ENC[AES256_GCM,data:Z79SxdkMfDRRo9kQzKUVbF4qqwF1HyESCxvVbmKYqqUx19TQo2MCRxuiaKTcUR/iFs3nLz3rAcP/PffC1j+srS84Imm4GGlWE/oIaIwg3AVuYeMEGnzcFIe0HKNp319x1owkgYttPMsS4nOQd/V7BGWQzL7yhpyzRye7mF5dPCxyPA==,iv:pqmgsWk18xYTcsEkuLKUcVc2ONs8RJ1ZgCU5lcSFhT8=,tag:ZIFIDyYE5MFaIqYINwgyLQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMmJ5T3dIeG5HNnAyaUEr
+            WTYyc3dHU3dYcjJhbmFCeGtPanpJK2VJeEJvCmZDeHRNZFV4TEh5RFlBdS9Vd0dV
+            T1J6dGNya0VYL2QvOU5TNXlxaVRpUjAKLS0tIG5qU0Fjb1c0ekYzS2hIUmhxWDh1
+            ajU2dEtkMWsrczJkQlJPTmxCR2N6UjgK/9Y2iU03KD5zGfghCJSqE/Op30y7S1XP
+            29prwzt1G/k//xBVQUGOXVnGGCWCx1QG02GOodApxt12hYo22BG7Ew==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-07T15:51:47Z"
+    mac: ENC[AES256_GCM,data:IRcUB02Alae5dQhfwCi3THLNDkJ2Ms0zHcSrfMlKEexZd0Xrf66sWCBkwZywUihqg9qnDXPjJZ0txWROW6qZIXKwugeaArzD+IRc7QQCQ4t/VqAxaRC+1YZQyhlkWmFkoMLCTMPFoBxkXSysJRiOSFP+p8dAZeQjffrX44gEB7s=,iv:4elwWVKrY2UVUVwz+UT9SxZ7pdPL4D5hATJbfQ8jp1w=,tag:CE0gV8sXH/OYssgv2bNs9Q==,type:str]
+    version: 3.13.3

--- a/kubernetes/apps/apps/media/scrob/scrob-secrets.sops.yaml
+++ b/kubernetes/apps/apps/media/scrob/scrob-secrets.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: scrob-secrets
+    namespace: media
+type: Opaque
+stringData:
+    SECRET_KEY: ENC[AES256_GCM,data:ul8fUAq0AxwOaZBFp/GH6AuACBv284XsbHrYHO6wfOV0Fpe32PakbRt36iMyhpnJ6bz9fHWwuV/pjVooktz3vPtp+PNpc3DzvHBKDlpYwkyev+FDf+RJZSKmEi7V6S3J/dhe2RcNMFsJnhnEF33/l3T1C88L4pRLWTPnJU+F1gU=,iv:1bLdE6U2ZUhI84cFrfNJNriUPowAjlfHbV9RD0KSee4=,tag:1ffUtcB730jEjWGFq2ThCg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5eDVEY3NEbkhlNjFMczlZ
+            YVdrYW43dUlTQ0ZzTzhxODAyaCs1Z3VCYkJNCnBiSEtDcmRmUkNpQ1hCNVNxNUFM
+            WFM5WnFvWnFhcERkRFBtYXphcmF1WGcKLS0tIFRMUFdOQm96R2F1Tit6eUxIU1Fz
+            Q2VDSFYvdXJCcmg1WHE3bEpkODBxSFUK5RNm/AMI4f+FoZfbBDfb+RcJr4H8wP1M
+            AXSkqsiGOtEBZ2nO8b+UXqE3536r9e3fE5lex033LmxkSvWwoWDprQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-07T15:51:47Z"
+    mac: ENC[AES256_GCM,data:Yb5wWWurK6PhczDgRTVLKLQACnmPEoznN3xoTzhp7N4j+d4E8LBk++TyQwxGV6i0xhsjXpBdRCZ8BwEl28WfFlDPa+ZwzyncxPVHritOjG3CC9HI/HXLdu0BAX8diHmge7WG6zEVG+a+ioJhEm3wbGwSgCKzuXqkz7sdlxplQPM=,iv:+5FUlkd9PegWDsBw7wdtgk+yQbpbWaTYJ9jSfWF077U=,tag:PhMwEQJKJwEmphDufiSgpg==,type:str]
+    version: 3.13.3

--- a/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
@@ -387,6 +387,10 @@ spec:
                 icon: sabnzbd.png
                 description: "Usenet downloader"
                 href: https://sabnzbd.lan.${CLUSTER_DOMAIN}
+            - Scrob:
+                icon: scrob.png
+                description: "Self-hosted media tracking"
+                href: https://scrob.lan.${CLUSTER_DOMAIN}
             - SearXNG:
                 icon: searxng.png
                 description: "Privacy-focused meta search"

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -41,4 +41,5 @@ resources:
   - ../apps/media/plex-exporter
   - ../apps/media/tidarr
   - ../apps/media/seerr
+  - ../apps/media/scrob
   - ../apps/paperless

--- a/kubernetes/apps/storage/pvcs/media/kustomization.yaml
+++ b/kubernetes/apps/storage/pvcs/media/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - radarr-pvc.yaml
   - sabnzbd-pvc.yaml
   - seerr-pvc.yaml
+  - scrob-pvc.yaml
   - sonarr-pvc.yaml
   - tautulli-pvc.yaml
   - tidarr-pvc.yaml

--- a/kubernetes/apps/storage/pvcs/media/scrob-pvc.yaml
+++ b/kubernetes/apps/storage/pvcs/media/scrob-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scrob
+  namespace: media
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/backup-daily: enabled
+    recurring-job.longhorn.io/backup-weekly: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-r2
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/infrastructure/database/cloudnative-pg/install/cnpg-backup-s3.sops.yaml
+++ b/kubernetes/infrastructure/database/cloudnative-pg/install/cnpg-backup-s3.sops.yaml
@@ -4,24 +4,24 @@ metadata:
     name: cnpg-backup-s3
     namespace: cnpg-system
     annotations:
-        replicator.v1.mittwald.de/replicate-to: authentik,security,automation,immich,paperless,nextcloud,ai
+        replicator.v1.mittwald.de/replicate-to: authentik,security,automation,immich,paperless,nextcloud,ai,media
 type: Opaque
 stringData:
-    ACCESS_KEY_ID: ENC[AES256_GCM,data:06b8YomIByy36xm57/FQNwpaG9s+JQnK350=,iv:FSznzdC8KItFVWlWMNifn49ucK594y0f7ZGoYBlXrVU=,tag:469qtNa4tru+BynIgjwJxQ==,type:str]
-    ACCESS_SECRET_KEY: ENC[AES256_GCM,data:hIPGENvjuKEv1Z22DwJFO2GywPs4vUvLzV9m2Ie/py+uDYDjgPVqojWYQ1PU4S/YNaZc9EccWnIFLIg8yThStw==,iv:VYInYa7UUdztpJrX+6rsei3pe77W9OD9ZjCM+FE6oRQ=,tag:Ce2n3GQrPPCSyttXzyhWJg==,type:str]
-    AWS_DEFAULT_REGION: ENC[AES256_GCM,data:QJ7r376m,iv:utOKwfpSSD2MantA6Io/8VtCsCeJk5KHYr3d9VpfW90=,tag:/8hgLEVBzmNYhNR61ZX86g==,type:str]
+    ACCESS_KEY_ID: ENC[AES256_GCM,data:+h4VmIAIl9LBtEC5QDPmIVhj3M9xXCfudmQ=,iv:BWQxrKtKy1KWmv4XpdOPnhdYlpykZQAXaPURg2MpqSo=,tag:qJztYNSaQ0XsM7eeSyB2lQ==,type:str]
+    ACCESS_SECRET_KEY: ENC[AES256_GCM,data:st+aqJ8gQ4AAybtfPf+3PVzpDhLTG6cRU6D4LVH78BbUSoFaQkx006xIfMImlTlydWBkX4HsBXrgQei1w1/i9A==,iv:GYesTSMSvmGi2R0o5+5Y/sSpxnQKRpwssze0XsMFGIQ=,tag:z8sVjlOnofmi0ZOmyHaZ9w==,type:str]
+    AWS_DEFAULT_REGION: ENC[AES256_GCM,data:CZuaDp/R,iv:Gij05qNc0VedMHwgHnT42tO4yuq1a3UwcAuaiV4FrGQ=,tag:0vFhbbHrZ4mu4VcUGzsdpQ==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQYW1va01XOGhxNk1jQ0s5
-            WktMYStiMXFobHNuR1YwNXg4OXQ5UDVXckRFCmpYVVRzYTdHWlprcmRsTTNjd0J5
-            elZtOWlEU3U2Y2dYMG1ZU0svSm5mNVkKLS0tIE15VGliWnlhaTd2N200T09mYnhC
-            Q1pwNDAyYXpTREd5MlI2QS9hN3R2akUK9OUPNQx2a8WjLUB6u7k+QNaU87FXaMZw
-            nevZrEPZ1C3MxHcy+f9kq3iLzVxooqeXP1amBa+vg+xf/WnVU/RCHA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPV1ZlOEd4cm91eVZJZURI
+            cGtxa3l0bVU4VnlZZ0xjV3BsWlhGVGJBNUVJClJwRjhIUkZlcGhsa0ZOWDZnZFNV
+            TlVGVjNudG1TWHdic1pkRjdWNEdHeU0KLS0tIEZUcWpkbENUUEJIYjZTeXhkUThl
+            V2hudElzeDNyVFFuQnR6QThSWEFlZ1kK19LsT07dK4ycJ4+8lH5mKz/COTODwPUY
+            3zQ/DbXZHo3dyFp0UbG7N0hS8ZU4UHH87+0ZIeIE92ZHZt4/mo8a6Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-20T21:25:23Z"
-    mac: ENC[AES256_GCM,data:WYVjtkEff+r99eNTeRpXIatg8EMiYrkL4Fjh2Hu43g3lryE3kzyNK4nJ/gFIHCWggEDYcBdPQ1rK/AMAT3XlRriPepQcfuz7/vmFd2OM/FQHeyYfwHzo6LVVHh5V5WDCBBJiiYF/vUAc23fwmVOVREUZO5EvMOy8CEuB9t4vUsQ=,iv:rjHHlMZGk9z62WqwPmMgM3x9lHq27IlLIPwDDcrr9jQ=,tag:oJTH9WelNoBwy1WDX3f+nw==,type:str]
-    version: 3.11.0
+    lastmodified: "2026-08-08T10:39:18Z"
+    mac: ENC[AES256_GCM,data:WqozQRoPC43m4IIlO8myDiaHF1IYEYVKl0/q1IDvkONd5VzpK+AWsOIpMWLFkLGpnde76B2cDJLQgmIH27vVJYmLlJ7yL5rSbimElofJ5Rf5RQLco8t6PSFNSV4qSy2k/UD1SsNeZNTVSuVEnXOECxiq2nZiSC9uHY1zbbZFct4=,iv:Bikuc1Eh2FH+wnV1df0LGd1t7p1EDzI4Gub2lqZBaPg=,tag:7itlwEiFc7nOsd+M4UGI/A==,type:str]
+    version: 3.13.3

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -886,6 +886,53 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "Karakeep Users"]]
 
+  257-scrob.yaml: |
+    version: 1
+    metadata:
+      name: scrob-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # OAuth2 Provider for Scrob
+      - model: authentik_providers_oauth2.oauth2provider
+        id: scrob-provider
+        identifiers:
+          name: "Scrob"
+        attrs:
+          client_id: !Env SCROB_CLIENT_ID
+          client_secret: !Env SCROB_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          encryption_key: null
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_basic
+          redirect_uris:
+            - url: "https://scrob.lan.${CLUSTER_DOMAIN}/oidc-callback"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+
+      # Scrob Application
+      - model: authentik_core.application
+        identifiers:
+          slug: "scrob"
+        attrs:
+          name: "Scrob"
+          provider: !KeyOf scrob-provider
+          group: "Media"
+
+      # Restrict access to existing Media group (no admin mapping; Scrob has no OIDC group admin support)
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "scrob"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Media"]]
+
   500-frigate.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -192,6 +192,16 @@ spec:
             secretKeyRef:
               name: netbird-sso-secret
               key: CLIENT_SECRET
+        - name: SCROB_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: scrob-sso-secret
+              key: CLIENT_ID
+        - name: SCROB_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: scrob-sso-secret
+              key: CLIENT_SECRET
         - name: DISCORD_BASIC_AUTH
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - dawarich-sso-secret.sops.yaml
   - airtrail-sso-secret.sops.yaml
   - karakeep-sso-secret.sops.yaml
+  - scrob-sso-secret.sops.yaml
   - nextcloud-sso-secret.sops.yaml
   - litellm-sso-secret.sops.yaml
   - librechat-sso-secret.sops.yaml

--- a/kubernetes/infrastructure/security/authentik/install/scrob-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/scrob-sso-secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: scrob-sso-secret
+    namespace: authentik
+    annotations:
+        replicator.v1.mittwald.de/replicate-to: media
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:ZM84evIlK9sYZbqh1NQNXrLLw/00A3EHnUxt24ZZLvE=,iv:wdU2dtreodSNCJbU1D/gkksKm2azmUkygEpehzwclc4=,tag:PDF3NEZ50YXhl7psv2v/yg==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:+HYVWTeNSOofai8rxsnFrpryAgfG0DpewOah1QmYVgkNtGX1Og5Lb1xLyl3/DWFwsl+VQ8qijN8MFGzRgCXBwA==,iv:YQdBtX/MSV+bnF9PcxKPjuVnf7p3ndYkgum7hmh6ri8=,tag:vCg15SJMBZ4HnYZzl+Yvkw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTS015OWwyOVRZQ3Uvb2pU
+            dHNlTDZnaWNWQ0ZuOTJtL1VVYU5uZDdDd0RjClhnZFl4UkRpTElkMThjVFRKQm4z
+            MWphbit5bkl1d3I0M2x0R1NsVlNZQ1UKLS0tIGFLME4xcnJ4V0lIbHBlM1VSc210
+            UXoyZysvSVRubEJkUE9wMW9CQ3VkUjQK05EVFhDJiSvNk38NR1Omz7aZdJkK6UI5
+            EDU1eS1aV2s9S+InYeugJBozHG6nQtgSMGr8uQVguY1fjbgGHcKLHA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-07T15:51:47Z"
+    mac: ENC[AES256_GCM,data:i/2xdSV3my9iD5VP9fGnptIyvIx8jimFVg0isyPdNA7Vo7Wr0nCoQI/qZCxEmM8RL6w3tjoMbIwgyyFH/J5Xj+c6oexNjZRDOBhSR6u+ggBPOkRzGk+UWoaucNacCYYF+A121zpJjfQso8YrwW2HHKA6MoBT5XsxLEouW5Rzr0w=,iv:BcCa4ukC6L44lQGWyXMFaGkFj8TzEYBZRzdaFfMFTws=,tag:bGNSFWFY54KqdtqYJ8rCtg==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
## Summary
- deploy Scrob with CNPG, persistent storage, and Homepage integration
- add native Authentik OIDC with a replicated SSO secret
- include Flux/Kustomize storage and application wiring

## Validation
- rendered Scrob, apps production, storage production, and Authentik install Kustomizations
- ran targeted pre-commit hooks