### PR TITLE
fix(kubernetes): use async Scrob database driver

### DIFF
--- a/kubernetes/apps/apps/media/scrob/scrob-db-secrets.sops.yaml
+++ b/kubernetes/apps/apps/media/scrob/scrob-db-secrets.sops.yaml
@@ -5,21 +5,21 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    username: ENC[AES256_GCM,data:S2+KnQU=,iv:K17vJZexm1SK8F2Fbj8BC9eDU+hDngxnwIebt0rTi0I=,tag:efKZq+9r7bDgKxrexaiXbg==,type:str]
-    password: ENC[AES256_GCM,data:Ewq6eI3gZvRX2F0gwJOyGP8b9WZRUmCQVnTiSYK+CYS128TsaZu/3dOEaDnfxBbUVHTEzFhauoKMkwpFrUTo+Q==,iv:cGEu9B52TU/mHhB4SBr4Nt09oYbWvoniS8PVydIuh6Y=,tag:7yTWQ/6LAzhlA27ExC52mg==,type:str]
-    DATABASE_URL: ENC[AES256_GCM,data:Z79SxdkMfDRRo9kQzKUVbF4qqwF1HyESCxvVbmKYqqUx19TQo2MCRxuiaKTcUR/iFs3nLz3rAcP/PffC1j+srS84Imm4GGlWE/oIaIwg3AVuYeMEGnzcFIe0HKNp319x1owkgYttPMsS4nOQd/V7BGWQzL7yhpyzRye7mF5dPCxyPA==,iv:pqmgsWk18xYTcsEkuLKUcVc2ONs8RJ1ZgCU5lcSFhT8=,tag:ZIFIDyYE5MFaIqYINwgyLQ==,type:str]
+    username: ENC[AES256_GCM,data:T7vJfhM=,iv:Y7CPGOfq5qVCJ1EB+v4QBWg0sbD7/zqDLrgBjARrCf8=,tag:AZQ2/wtqE8CeAKdjQjaAjg==,type:str]
+    password: ENC[AES256_GCM,data:i78jeb7Y9tqTQSPQ4N4uOp75UXfyuBQhJgXzp+tUOs1PSXYffvT+pAALKXN0tshZGM+yUtDVQTe0ddrIfY38dQ==,iv:4CvOyne4SZhC5tupoKLnyTRLFT+mcl2dEF3xZq30wx8=,tag:p2zZ6uOI2GBaG3lgmbcyOQ==,type:str]
+    DATABASE_URL: ENC[AES256_GCM,data:qByxuAZf6ak3fVX3T4WupkgOfAwTjnayZNUKjuySmWNrSXppQz5CmAPAVqzC+E1h2L+X3IbzfsvKM6RbfTYg4AO50zmfkcd8F1zEgu0r3uTlA7GD0VdDaFujUVnEIlNdngBTyaoGZTkBchC0fhcqlYp7QYPZpu7Ka+bDUETweGpGI8t60V6oZYoK,iv:6CjTzmeDc/vYn23ZW+5xM6PBO1lHAWUsygk5ljxcUzU=,tag:hyqB8CZoOFrbgJa+BZwSDQ==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMmJ5T3dIeG5HNnAyaUEr
-            WTYyc3dHU3dYcjJhbmFCeGtPanpJK2VJeEJvCmZDeHRNZFV4TEh5RFlBdS9Vd0dV
-            T1J6dGNya0VYL2QvOU5TNXlxaVRpUjAKLS0tIG5qU0Fjb1c0ekYzS2hIUmhxWDh1
-            ajU2dEtkMWsrczJkQlJPTmxCR2N6UjgK/9Y2iU03KD5zGfghCJSqE/Op30y7S1XP
-            29prwzt1G/k//xBVQUGOXVnGGCWCx1QG02GOodApxt12hYo22BG7Ew==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEeEVRR0JoM3ZabFBlajM0
+            VkZzeTRYajREL3Q1UVppMnNJYlY3UzBiTVdRCmV1TjAxWVZWV2pyVnQ5N1QyRndI
+            eWYrdHpDWnQzRzJEMlFrWE5Qb1A5M2sKLS0tIDEyckZrd01jTkpvMlp2K0t1bERW
+            K0pHeWxJcjZLMUF4RHNXYlB4Y0Y4TFkK45rXAUqhzvTaxgiCIF/diPR8pQVs7bm3
+            y5LmaQYgzjrbTpeQ0mzdXht/7/UG5WI9MB+I3Om7ivaeCPsiHf8c+w==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-07T15:51:47Z"
-    mac: ENC[AES256_GCM,data:IRcUB02Alae5dQhfwCi3THLNDkJ2Ms0zHcSrfMlKEexZd0Xrf66sWCBkwZywUihqg9qnDXPjJZ0txWROW6qZIXKwugeaArzD+IRc7QQCQ4t/VqAxaRC+1YZQyhlkWmFkoMLCTMPFoBxkXSysJRiOSFP+p8dAZeQjffrX44gEB7s=,iv:4elwWVKrY2UVUVwz+UT9SxZ7pdPL4D5hATJbfQ8jp1w=,tag:CE0gV8sXH/OYssgv2bNs9Q==,type:str]
+    lastmodified: "2026-08-08T10:56:48Z"
+    mac: ENC[AES256_GCM,data:cfkI5/2uqniWjQyqObwQ40UYAH3PUJGwjckdqZfA7HU4EJOrRsvtBiMyroFB0XiAC0UhO47w0m9Y5FghxK2W4+aKHzhlYylZYE7DJ9CUpFFKD9h9ppio50n8R54pL06c34CkAF03WIFH/DJprGn9Ygggo0h87yHTnBmgpG4sVDE=,iv:0SUr3NJC8E+bQw9Rh3SbgiTcxOExOV4L99st5GAuOFc=,tag:XpL9CCSHHeAw3ZQXsz/MiQ==,type:str]
     version: 3.13.3


### PR DESCRIPTION
## Summary
- use the async PostgreSQL driver URL required by Scrob migrations

## Validation
- rendered the Scrob Kustomization
- ran targeted pre-commit hooks

Fixes the post-deployment migration crash.