### PR TITLE
feat(kubernetes): automate Jellyfin webhooks

### DIFF
--- a/kubernetes/apps/apps/media/jellyfin/automation-config.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/automation-config.yaml
@@ -46,6 +46,48 @@ data:
       "EnableAllFolders": false,
       "EnabledFolders": []
     }
+  webhook.json: |
+    {
+      "pluginId": "71552a5a5c5c4350a2aeebe451a30173",
+      "GenericOptions": [
+        {
+          "WebhookName": "WatchState Global Webhook",
+          "credentialKey": "watchstate-global-webhook-url",
+          "EnableMovies": true,
+          "EnableEpisodes": true,
+          "EnableSeries": false,
+          "EnableSeasons": false,
+          "EnableAlbums": false,
+          "EnableSongs": false,
+          "EnableVideos": false,
+          "EnableWebhook": true,
+          "SendAllProperties": true,
+          "SkipEmptyMessageBody": true,
+          "Template": "",
+          "TrimWhitespace": true,
+          "Fields": [],
+          "Headers": [{"Key": "Content-Type", "Value": "application/json"}],
+          "NotificationTypes": ["ItemAdded", "PlaybackStart", "PlaybackStop", "UserDataSaved"],
+          "UserFilter": ["d2e1d985c73e493cb95fd1dd1e33f69b", "ed446fed6b20403ab4f73de2be261b47"]
+        },
+        {
+          "WebhookName": "Scrob Webhook",
+          "credentialKey": "scrob-webhook-url",
+          "EnableMovies": true,
+          "EnableEpisodes": true,
+          "EnableSeries": false,
+          "EnableSeasons": false,
+          "EnableAlbums": false,
+          "EnableSongs": false,
+          "EnableVideos": false,
+          "EnableWebhook": true,
+          "SendAllProperties": true,
+          "Template": "",
+          "NotificationTypes": ["PlaybackStart", "PlaybackProgress", "PlaybackStop", "UserDataSaved", "ItemAdded", "ItemDeleted"],
+          "UserFilter": []
+        }
+      ]
+    }
   libraries.json: |
     [
       {"name":"Anime Movies","path":"/data/libraries/anime_movies","collectionType":"movies","profile":"anime_movie"},

--- a/kubernetes/apps/apps/media/jellyfin/automation-cronjob.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/automation-cronjob.yaml
@@ -223,6 +223,38 @@ spec:
                           f"{filter_result['Admins']} administrators."
                       )
 
+                  webhook_settings = json.load(open("/config/webhook.json"))
+                  webhook_plugin = installed_plugins.get(webhook_settings.pop("pluginId"))
+                  if webhook_plugin is None:
+                      print("Webhook was installed; restart Jellyfin before configuring it.")
+                  else:
+                      webhook_configuration = request(
+                          "GET", f"/Plugins/{webhook_plugin['Id']}/Configuration"
+                      )
+                      # Reconcile GenericOptions to exactly the declared destinations while
+                      # preserving every other top-level Webhook plugin setting. Each URL is
+                      # read from /credentials via its declared credentialKey, never inline.
+                      desired_options = []
+                      for option in webhook_settings["GenericOptions"]:
+                          credential_key = option.pop("credentialKey")
+                          credential_path = os.path.join("/credentials", credential_key)
+                          if not os.path.exists(credential_path):
+                              raise SystemExit(
+                                  f"Webhook credential '{credential_key}' is unavailable."
+                              )
+                          desired = dict(option)
+                          desired["WebhookUri"] = open(
+                              credential_path, encoding="utf-8"
+                          ).read().strip()
+                          desired_options.append(desired)
+                      webhook_configuration["GenericOptions"] = desired_options
+                      request(
+                          "POST",
+                          f"/Plugins/{webhook_plugin['Id']}/Configuration",
+                          webhook_configuration,
+                      )
+                      print(f"Configured Webhook: {len(desired_options)} destination(s).")
+
                   libraries = json.load(open("/config/libraries.json"))
                   existing = {library["Name"]: library for library in request("GET", "/Library/VirtualFolders")}
                   for library in libraries:

--- a/kubernetes/apps/apps/media/jellyfin/jellyfin-automation-secret.sops.yaml
+++ b/kubernetes/apps/apps/media/jellyfin/jellyfin-automation-secret.sops.yaml
@@ -5,19 +5,21 @@ metadata:
     namespace: media
 type: Opaque
 stringData:
-    api-key: ENC[AES256_GCM,data:vyTW5daaDLz+yA1rF3ybzcjyCQ4JJQQOEMUSquexFdQ=,iv:997u1cHa/6BiHWERGBybwkp61LEvhXLwaDFrkvUvsQw=,tag:zC0SYBJTeYNtF/H8Bdwi2A==,type:str]
+    api-key: ENC[AES256_GCM,data:Qy8wKH34G9Q4dgzzMXxFq46rqbXpuV+HsaiMG5nx04Y=,iv:2OZm1igMAbSrQxA8VGCOrn9cdfd4Vq0qQ5IyII7LGqM=,tag:1cvBodPpnqX06zoomGDb6g==,type:str]
+    watchstate-global-webhook-url: ENC[AES256_GCM,data:2jLvzDj9A4g+JISBb9EhsLzDV2JCxIEnfjv9SXF4+/nNcsWOeWfIOKdAjBwwHzyRyZBbnYMPVSf+tS0wH1p96oyfzpNgDobsVl8UzD2Plpe8WUeeOkt2+qKCnepmvyLSsJSnv1bJVxa7iGRLcYKB0HzqbriF/zT52t171JebaS22X2z5pg==,iv:R+yGYtkiv3YqYnoPV23Qw4/V4D/jHR6B21K0tWLU+vs=,tag:+d7lZCDdHb1r6+d51udGfA==,type:str]
+    scrob-webhook-url: ENC[AES256_GCM,data:aKGOMlnW9PGgRsKAEAHL8cDsTJfwjNDNPZ2Mzb8Nnln8bE6i0kE6cY7xwS+vf++s7jyow6eI8ANEzX7fe4g+v5rbiB/NHaNZhHaUm3XCJky0jVJxgZXfEuVshqJeOrampWZjRNzTi335DYORSkzqil4fT3bOsa1P8NHH,iv:V6WeBNwOCDNj+rYMqBZgsVt/Eu+3rCbtAvsxOtVMEjc=,tag:w35CX+C89rlO5F5gfjldgQ==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Ui9WQ0ZReEdzak05YUkx
-            RXQvRDhySjVuVWVibit2aE44dTRRZmZDZ3dzCjl3a1dWdUJySkR5cHBmc3FLZmpH
-            WU5WUUJIamwwbWY0cldJTXVyaTFaL2MKLS0tIDEyZ1VFRGcrZzlETUtnNldEYzVu
-            NTM2V0psT2lrdnh5N3JRVU1JcXhvVzAKOkDkPP2rUqGwuYy40B5jT8zPx2NRwVhc
-            t0Q0mQsXIcX1HMXlhKGnP6qzXu93dXI6WP/1q9frw4u1hevvgUafVg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjTUI2bXUvRnZYV2Vtdmxo
+            dCtYSHArOUpNMmg4bGtxbVdGWVpNdUZLL2xFCnlqZ3ZQM2xzUm56UkNqTVViazNW
+            Q3F4SWpPRmw2VFo0aDVZcjczckhNRFkKLS0tIDJKbGRzbWhnYXFXVWVuUFFoMnlp
+            WU1qT3dIL04weS96RWhjc0FwRktlblkK8Ioe7lWDQyCUT/NOIJJFKrElqKOnO6I9
+            xcJSkPZG5IF33GKyHNT9iPkyB76smm7gW6HNLsB70fKr3szZsx2Z8w==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-12T22:52:03Z"
-    mac: ENC[AES256_GCM,data:fvfmZkftof/+lSRALHm5vOlvWtRw3lmXjNna7OXTz56+rnEV4DAvN5+DoRYn/liJlXme56br80lRRIlvwlG3fPttwKYkMl+gNoS8vOlhqDD9lnRlpccTibxGYWs+Pa1Zn4yCQuCqL0FKRqGm9zDqm2El7pED/Bx4e0skCsnglps=,iv:cGHrOtbP9EthBIb/MpgcbNqtQLn0wjp2IDM084JaRQY=,tag:dRLyosAqNyFNZS2n+iURzg==,type:str]
-    version: 3.13.2
+    lastmodified: "2026-08-08T13:43:57Z"
+    mac: ENC[AES256_GCM,data:3g7PAcOOOHX66HBbpUY/jXMsaiP8e9vnpCERippRIbvRlknjET725PBaTtFrjkhqMSoRnooH3M98SyhQ5r/DWzI9IBm9ia340fZWbVXHbMRmi3v19HK3J0iPbzNzxJovZtktAtphPa/rfMz2Kwg99H1AZHew0Po6Eqy7ALTWPHs=,iv:/22FpY0RwkrBHtIxrYOJ7d8/3DhZGKecMT7e1pE0yw4=,tag:b/J74gSNb6KDJ96ZrMV/EA==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
## Summary
- manage the retained internal WatchState and new Scrob Jellyfin webhook destinations through the provisioning CronJob
- store webhook endpoints in the SOPS-encrypted automation secret

## Validation
- `kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/apps/media/jellyfin >/dev/null`
- commit hooks, including rendered kubeconform and Checkov checks

## Follow-up
- Replace the encrypted `scrob-webhook-url` placeholder with the Scrob connection URL before merging.