### PR TITLE
feat(unraid): add Authentik SSO

### DIFF
--- a/kubernetes/apps/apps/external-proxy/unraid.yaml
+++ b/kubernetes/apps/apps/external-proxy/unraid.yaml
@@ -29,7 +29,6 @@ metadata:
   name: unraid
   namespace: external-proxy
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-gatekeeper-auth-chain@kubernetescrd
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     external-dns.alpha.kubernetes.io/hostname: unraid.lan.${CLUSTER_DOMAIN}
 spec:

--- a/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
@@ -241,7 +241,7 @@ spec:
             - Unraid:
                 icon: unraid.png
                 description: "Virtual NAS running in Proxmox"
-                href: http://unraid.lan.${CLUSTER_DOMAIN}
+                href: https://unraid.lan.${CLUSTER_DOMAIN}/graphql/api/auth/oidc/authorize/authentik
                 # widget:
                 #   type: unraid
                 #   url: http://192.168.10.4:8001

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -933,6 +933,64 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "Media"]]
 
+  258-unraid.yaml: |
+    version: 1
+    metadata:
+      name: unraid-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Unraid Users group
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Unraid Users"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # OAuth2 Provider for Unraid
+      - model: authentik_providers_oauth2.oauth2provider
+        id: unraid-provider
+        identifiers:
+          name: "Unraid"
+        attrs:
+          client_id: !Env UNRAID_CLIENT_ID
+          client_secret: !Env UNRAID_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          encryption_key: null
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_post
+          redirect_uris:
+            - url: "https://unraid.lan.${CLUSTER_DOMAIN}/graphql/api/auth/oidc/callback"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+
+      # Unraid Application
+      - model: authentik_core.application
+        identifiers:
+          slug: "unraid"
+        attrs:
+          name: "Unraid"
+          provider: !KeyOf unraid-provider
+          group: "Storage"
+
+      # Restrict access to Unraid Users
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "unraid"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Unraid Users"]]
+
   500-frigate.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -202,6 +202,16 @@ spec:
             secretKeyRef:
               name: scrob-sso-secret
               key: CLIENT_SECRET
+        - name: UNRAID_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: unraid-sso-secret
+              key: CLIENT_ID
+        - name: UNRAID_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: unraid-sso-secret
+              key: CLIENT_SECRET
         - name: DISCORD_BASIC_AUTH
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - airtrail-sso-secret.sops.yaml
   - karakeep-sso-secret.sops.yaml
   - scrob-sso-secret.sops.yaml
+  - unraid-sso-secret.sops.yaml
   - nextcloud-sso-secret.sops.yaml
   - litellm-sso-secret.sops.yaml
   - librechat-sso-secret.sops.yaml

--- a/kubernetes/infrastructure/security/authentik/install/unraid-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/unraid-sso-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: unraid-sso-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:HFr54mnctqMiAXeViHxMa43w7QOYvMieSI7wzHGp8lbWs11y3whFfUflKA==,iv:GSTfNbkZS0ei8QFALpRfppiXhAo5dQCMwSDLXB5SzEU=,tag:pMwZ3gzWTeqFpVcMqnfShg==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:7zrtAvG+1u6r+wbrIMQxTZDGe+4dvGzszAC6t5YpWovXXbOBgjD20DI2aHRUwHXBM80ti/A67k6fpD004kmx1Q==,iv:xjPV6f6X+RFhJ/EMJY3AwUJdscJk4YvBxdClfnh1xo0=,tag:fX1lwrCgFGHKVgcOxWRccg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1RXNnZHFlanN1RytGazZ0
+            c29XSjY0bFp5cE52bVNGQmJFKzlDbEkwYVVzCkVvd2RCMXhxem5scmJIRlVJQ1A0
+            U25JT0NWeHdyUHBaK2VPYUVNZU9TTGcKLS0tIENjQmZ0UUl6aGZjU2drcWxLTjlt
+            T2g0K0FRODJEWCt3MWhKNUc1TXM4NzAKTA5OWeTuE7B/A6307C0TnGrkOT2gnJkF
+            me5VDO9x226Xh9eRM76z+1S805HrEAHzRdp1g41dVnDp57Y7lt31Og==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-08T14:51:17Z"
+    mac: ENC[AES256_GCM,data:NQUKE13N/ANLW9NM1nGSPchX0XSmQihoAbE4PA3YIza2y92WxA31vM10qUbAQi+V3L7ds80J6sD0k922afT4BVTEWTRPMV+zsQqUW9N/WxpamCBFdoXjS/vOmT3T2JdcG2DUh3LJZtE0LYqKWo8n6NNU7F0kNAYXYmnewJ1SxDY=,iv:AhSHGJg2oYThJrTgbIQQlWFOculV+9LOdvTel7ka3to=,tag:p8iYNmZWkG5EFUP61JDALA==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
## Summary
- add a single-user Authentik OIDC provider for Unraid with SOPS-encrypted client credentials
- route the Homepage Unraid card through native OIDC login
- remove generic forward-auth from the Unraid ingress

## Validation
- kubectl kustomize for Authentik install, external-proxy, and Homepage
- kubectl apply --dry-run=client for the rendered Authentik install manifests
- pre-commit hooks, including kubeconform and Checkov