### PR TITLE
feat(tautulli): add Authentik proxy provider

### DIFF
--- a/kubernetes/apps/apps/media/tautulli/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/tautulli/helmrelease.yaml
@@ -50,7 +50,6 @@ spec:
       main:
         annotations:
           traefik.ingress.kubernetes.io/router.middlewares: traefik-gatekeeper-auth-chain@kubernetescrd
-          traefik.ingress.kubernetes.io/router.priority: "1000"
           external-dns.alpha.kubernetes.io/hostname: tautulli.lan.${CLUSTER_DOMAIN}
         hosts:
           - host: tautulli.lan.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/apps/media/tautulli/helmrelease.yaml
+++ b/kubernetes/apps/apps/media/tautulli/helmrelease.yaml
@@ -50,6 +50,7 @@ spec:
       main:
         annotations:
           traefik.ingress.kubernetes.io/router.middlewares: traefik-gatekeeper-auth-chain@kubernetescrd
+          traefik.ingress.kubernetes.io/router.priority: "1000"
           external-dns.alpha.kubernetes.io/hostname: tautulli.lan.${CLUSTER_DOMAIN}
         hosts:
           - host: tautulli.lan.${CLUSTER_DOMAIN}

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1736,7 +1736,6 @@ data:
             - !Find [authentik_providers_proxy.proxyprovider, [name, "Kopia"]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, "Llama"]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, "OpenClaw"]]
-            - !Find [authentik_providers_proxy.proxyprovider, [name, "Tautulli"]]
           config:
             authentik_host: "http://authentik-server.authentik.svc.cluster.local"
             authentik_host_browser: "https://sso.${CLUSTER_DOMAIN}"

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -475,6 +475,100 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "Paperless Users"]]
 
+  250-immich.yaml: |
+    version: 1
+    metadata:
+      name: immich-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Immich Admins group (your user gets admin role)
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Immich Admins"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # Immich Users group (regular users)
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Immich Users"
+        attrs:
+          is_superuser: false
+          parent: null
+
+      # Custom scope mapping for immich_role claim
+      - model: authentik_providers_oauth2.scopemapping
+        id: immich-role-scope
+        identifiers:
+          name: "Immich Role Scope"
+        attrs:
+          scope_name: immich_role
+          description: "Immich role claim based on group membership"
+          expression: |
+            immich_claims = {}
+            if request.user.ak_groups.filter(name="Immich Admins").exists():
+                immich_claims["immich_role"] = "admin"
+            elif request.user.ak_groups.filter(name="Immich Users").exists():
+                immich_claims["immich_role"] = "user"
+            return immich_claims
+
+      - model: authentik_providers_oauth2.oauth2provider
+        id: immich-provider
+        identifiers:
+          name: "Immich"
+        attrs:
+          client_id: !Env IMMICH_CLIENT_ID
+          client_secret: !Env IMMICH_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          client_type: confidential
+          client_authentication_method: client_secret_post
+          redirect_uris:
+            - url: "app.immich:///oauth-callback"
+              matching_mode: strict
+            - url: "https://photos.${CLUSTER_DOMAIN}/auth/login"
+              matching_mode: strict
+            - url: "https://photos.${CLUSTER_DOMAIN}/user-settings"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !KeyOf immich-role-scope
+
+      - model: authentik_core.application
+        identifiers:
+          slug: "immich"
+        attrs:
+          name: "Immich"
+          provider: !KeyOf immich-provider
+          group: "Media"
+          meta_launch_url: "https://photos.${CLUSTER_DOMAIN}/auth/login?autoLaunch=1"
+
+      # Allow Immich Users
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "immich"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Immich Users"]]
+
+      # Allow Immich Admins
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "immich"]]
+          order: 1
+        attrs:
+          group: !Find [authentik_core.group, [name, "Immich Admins"]]
+
   252-dawarich.yaml: |
     version: 1
     metadata:
@@ -877,6 +971,33 @@ data:
           order: 0
         attrs:
           group: !Find [authentik_core.group, [name, "Unraid Users"]]
+
+  260-jellyfin.yaml: |
+    version: 1
+    metadata:
+      name: jellyfin-groups
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Jellyfin Admins group (default user gets admin role)
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Jellyfin Admins"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # Jellyfin Users group
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Jellyfin Users"
+        attrs:
+          is_superuser: false
+          parent: null
 
   500-frigate.yaml: |
     version: 1
@@ -1384,127 +1505,6 @@ data:
           order: 0
         attrs:
           group: !Find [authentik_core.group, [name, "OpenClaw"]]
-
-  250-immich.yaml: |
-    version: 1
-    metadata:
-      name: immich-sso
-      labels:
-        blueprints.goauthentik.io/instantiate: "true"
-    entries:
-      # Immich Admins group (your user gets admin role)
-      - model: authentik_core.group
-        state: present
-        identifiers:
-          name: "Immich Admins"
-        attrs:
-          is_superuser: false
-          parent: null
-          users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
-
-      # Immich Users group (regular users)
-      - model: authentik_core.group
-        state: present
-        identifiers:
-          name: "Immich Users"
-        attrs:
-          is_superuser: false
-          parent: null
-
-      # Custom scope mapping for immich_role claim
-      - model: authentik_providers_oauth2.scopemapping
-        id: immich-role-scope
-        identifiers:
-          name: "Immich Role Scope"
-        attrs:
-          scope_name: immich_role
-          description: "Immich role claim based on group membership"
-          expression: |
-            immich_claims = {}
-            if request.user.ak_groups.filter(name="Immich Admins").exists():
-                immich_claims["immich_role"] = "admin"
-            elif request.user.ak_groups.filter(name="Immich Users").exists():
-                immich_claims["immich_role"] = "user"
-            return immich_claims
-
-      - model: authentik_providers_oauth2.oauth2provider
-        id: immich-provider
-        identifiers:
-          name: "Immich"
-        attrs:
-          client_id: !Env IMMICH_CLIENT_ID
-          client_secret: !Env IMMICH_CLIENT_SECRET
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
-          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
-          jwt_algorithm: RS256
-          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
-          client_type: confidential
-          client_authentication_method: client_secret_post
-          redirect_uris:
-            - url: "app.immich:///oauth-callback"
-              matching_mode: strict
-            - url: "https://photos.${CLUSTER_DOMAIN}/auth/login"
-              matching_mode: strict
-            - url: "https://photos.${CLUSTER_DOMAIN}/user-settings"
-              matching_mode: strict
-          property_mappings:
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
-            - !KeyOf immich-role-scope
-
-      - model: authentik_core.application
-        identifiers:
-          slug: "immich"
-        attrs:
-          name: "Immich"
-          provider: !KeyOf immich-provider
-          group: "Media"
-          meta_launch_url: "https://photos.${CLUSTER_DOMAIN}/auth/login?autoLaunch=1"
-
-      # Allow Immich Users
-      - model: authentik_policies.policybinding
-        identifiers:
-          target: !Find [authentik_core.application, [slug, "immich"]]
-          order: 0
-        attrs:
-          group: !Find [authentik_core.group, [name, "Immich Users"]]
-
-      # Allow Immich Admins
-      - model: authentik_policies.policybinding
-        identifiers:
-          target: !Find [authentik_core.application, [slug, "immich"]]
-          order: 1
-        attrs:
-          group: !Find [authentik_core.group, [name, "Immich Admins"]]
-
-  260-jellyfin.yaml: |
-    version: 1
-    metadata:
-      name: jellyfin-groups
-      labels:
-        blueprints.goauthentik.io/instantiate: "true"
-    entries:
-      # Jellyfin Admins group (default user gets admin role)
-      - model: authentik_core.group
-        state: present
-        identifiers:
-          name: "Jellyfin Admins"
-        attrs:
-          is_superuser: false
-          parent: null
-          users:
-            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
-
-      # Jellyfin Users group
-      - model: authentik_core.group
-        state: present
-        identifiers:
-          name: "Jellyfin Users"
-        attrs:
-          is_superuser: false
-          parent: null
 
   540-tautulli.yaml: |
     version: 1

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1506,6 +1506,65 @@ data:
           is_superuser: false
           parent: null
 
+  540-tautulli.yaml: |
+    version: 1
+    metadata:
+      name: tautulli-proxy
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Tautulli users group (bootstrap user is seeded with basic auth attrs)
+      - model: authentik_core.group
+        state: present
+        id: tautulli-users
+        identifiers:
+          name: "Tautulli users"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+          attributes:
+            tautulli_user: !Env TAUTULLI_BASIC_AUTH_USER
+            tautulli_password: !Env TAUTULLI_BASIC_AUTH_PASSWORD
+
+      # Tautulli Proxy Provider (genuine proxy mode with HTTP basic auth)
+      - model: authentik_providers_proxy.proxyprovider
+        id: tautulli-provider
+        identifiers:
+          name: "Tautulli"
+        attrs:
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: proxy
+          external_host: "https://tautulli.lan.${CLUSTER_DOMAIN}"
+          internal_host: "http://tautulli.media.svc.cluster.local:8181"
+          internal_host_ssl_validation: true
+          basic_auth_enabled: true
+          basic_auth_user_attribute: tautulli_user
+          basic_auth_password_attribute: tautulli_password
+          access_token_validity: "hours=24"
+          refresh_token_validity: "days=30"
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "ak-proxy"]]
+
+      # Tautulli Application
+      - model: authentik_core.application
+        identifiers:
+          slug: "tautulli"
+        attrs:
+          name: "Tautulli"
+          provider: !KeyOf tautulli-provider
+          group: "Media"
+
+      # Restrict access to Tautulli users
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "tautulli"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Tautulli users"]]
+
   900-ldap.yaml: |
     version: 1
     metadata:
@@ -1677,6 +1736,7 @@ data:
             - !Find [authentik_providers_proxy.proxyprovider, [name, "Kopia"]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, "Llama"]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, "OpenClaw"]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, "Tautulli"]]
           config:
             authentik_host: "http://authentik-server.authentik.svc.cluster.local"
             authentik_host_browser: "https://sso.${CLUSTER_DOMAIN}"

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -217,6 +217,16 @@ spec:
             secretKeyRef:
               name: openclaw-gateway-secret
               key: OPENCLAW_GATEWAY_PASSWORD
+        - name: TAUTULLI_BASIC_AUTH_USER
+          valueFrom:
+            secretKeyRef:
+              name: tautulli-basic-auth-secret
+              key: USERNAME
+        - name: TAUTULLI_BASIC_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: tautulli-basic-auth-secret
+              key: PASSWORD
 
         # Blueprint variables
         - name: AK_BLUEPRINT_USERNAME

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -28,3 +28,4 @@ resources:
   - llama-auth-secret.sops.yaml
   - frigate-proxy-secret.sops.yaml
   - openclaw-gateway-secret.sops.yaml
+  - tautulli-basic-auth-secret.sops.yaml

--- a/kubernetes/infrastructure/security/authentik/install/tautulli-basic-auth-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/tautulli-basic-auth-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: tautulli-basic-auth-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    USERNAME: ENC[AES256_GCM,data:Cj1PCdb+ZzhI,iv:CSQkk0vBlmYPEVS8oAXXhuFNcrva9AoIeCtfEuhRHNo=,tag:kOx+Za4vS9Leond+rebuSw==,type:str]
+    PASSWORD: ENC[AES256_GCM,data:S5i778eZ6hWHfNMdFInQ84Ibxk4IF0x7SW4TAy312mUuoibpNNnM+4AG8HtK,iv:odCmE1hlhizSSgqlS91h7M0HxU5AAC47PJ9NEQsKKLs=,tag:Bjwn7tb71xtGkuBZXXOGTQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOUkd2TmtvdHBheVFWaDAv
+            aUUzTlJVVnUwVmEwMjZqQjQ1R0FYUGhRWW5vCmhaekRremo4dXdkNjF2WUx3OUk5
+            UlZ6QWpQbk9xMEdNdnloN3hDVGU3djgKLS0tIGN1STdhL1RkSklsakVoTGprd2hH
+            cExIeTVjbnUrVVo3YUordkY3YkxwRnMKWqS24QA3zCHcLk8Map7CsuSwzJ3mN2pG
+            oBOAg25ld5zTbRrek0L1Vqj9W8jK3FGCpmm96ed0rEgAoAFUCIaBPg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-08T21:41:21Z"
+    mac: ENC[AES256_GCM,data:hxYiGEKAvd36JBp5/oGyphs6u/qoC7JiPKMhr2Osu4NqJlagbXMRuOUQIl+N3VHghMYNsMR9+Qx4mqdKn3qqur7GHSmKHOf0KVDHZK8lQzGJ6KO4TlKtdx/kqe5GbTt7VEUCnb3AMwPIajSVYChU71QNOR+cDyWbaLznJEnvdnc=,iv:98WBFVjyoJlOYrlrUXZ9vpCclJ/cdGQmT7/lhjWMUo8=,tag:DAidKexOqZSxtCo8RDpTDQ==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
## Summary
- add the Authentik Proxy-mode provider, restricted Tautulli group, and SOPS-encrypted HTTP Basic credentials
- attach Tautulli to the shared proxy outpost
- retain the existing root Tautulli ingress at higher priority for a staged cutover

## Validation
- kubectl kustomize for Authentik install and Tautulli
- pre-commit hooks, including kubeconform, Checkov, and SOPS encryption checks

## Follow-up
- after this stage is deployed and verified, remove the existing root ingress in a separate cutover change so the Authentik outpost serves the Tautulli UI