### PR TITLE
feat(bambuddy): enable OIDC

### DIFF
--- a/kubernetes/apps/apps/utils/bambuddy/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/bambuddy/helmrelease.yaml
@@ -16,6 +16,8 @@ spec:
     controllers:
       main:
         strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           main:
             image:
@@ -27,7 +29,27 @@ spec:
               PUID: "1000"
               PGID: "1000"
               PORT: "8000"
+              APP_URL: https://bambuddy.lan.${CLUSTER_DOMAIN}
               VIRTUAL_PRINTER_PASV_ADDRESS: ${BAMBUDDY_IP}
+              # --- Auth: native OIDC against Authentik ---
+              BAMBUDDY_OIDC_NAME: Authentik
+              BAMBUDDY_OIDC_ISSUER_URL: https://sso.${CLUSTER_DOMAIN}/application/o/bambuddy/
+              BAMBUDDY_OIDC_SCOPES: "openid email profile"
+              BAMBUDDY_OIDC_ENABLED: "true"
+              BAMBUDDY_OIDC_AUTO_LINK_EXISTING: "true"
+              BAMBUDDY_OIDC_AUTO_CREATE_USERS: "false"
+              BAMBUDDY_OIDC_EMAIL_CLAIM: email
+              BAMBUDDY_OIDC_REQUIRE_EMAIL_VERIFIED: "true"
+              BAMBUDDY_OIDC_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: bambuddy-sso-secret
+                    key: CLIENT_ID
+              BAMBUDDY_OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: bambuddy-sso-secret
+                    key: CLIENT_SECRET
             securityContext:
               capabilities:
                 add:

--- a/kubernetes/apps/apps/utils/bambuddy/kustomization.yaml
+++ b/kubernetes/apps/apps/utils/bambuddy/kustomization.yaml
@@ -3,6 +3,5 @@ kind: Kustomization
 components:
   - ../../../../components/bjw-s-defaults
   - ../../../../components/ingress/traefik-base
-  - ../../../../components/ingress/auth-guard
 resources:
   - helmrelease.yaml

--- a/kubernetes/infrastructure/security/authentik/install/bambuddy-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/bambuddy-sso-secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: bambuddy-sso-secret
+    namespace: authentik
+    annotations:
+        replicator.v1.mittwald.de/replicate-to: utils
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:qgTqDXNLL8Tjo+QdU3uwqCylAicYubY/M8ekDBx5jMU=,iv:YVFK8la+lVmRHZCMDJpW6Cs+jedJ6kgExZaMfuoqWmc=,tag:CVKeztlKIbz/0TAGKjxDyQ==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:HIEs70BRUdcSZQu91hvDILLyxAm5N8ciuQ6iBkkZWLBro6b5ir1vQLhU+rOnwq7vA2f/5h+wzZkjGFZsBTZFFg==,iv:JZEHGl+8LhBqQh+3V0UnoqSY6eR0dPRGSihM8ZoPRRw=,tag:X47f7HRJgvGXQPC9W6rShw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxZU9yMTFBQ0phcGduTUl3
+            NTAydHRiMXdYSlhrVG9NT1VIaEFFRmJQNTI4CkhheC9JdVhJVkNVMnhtWWtsVU1C
+            VUsyQVdQVVplL29vS1hoS2hPVmpvYlEKLS0tIFlGRjVFdXZFNmN2RXR5ZkVua095
+            bUZvYVhjY0xsMlplbmoxTmJ5b3JZNEUKNPK1/I6+BEHL6oNM1sho+HzQuoJIPKeE
+            RN/3Lr5VyKF5uY+ZDsEfoLgt08GgyfemvqlRAymmSEnT26kVZBxkVw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-09T11:00:39Z"
+    mac: ENC[AES256_GCM,data:+JJSrWLAOYpJVThAufBJg48I4h6yz3oaCDLAdgXkyky0rrLYuNQb5c/SXToXXEXZuJgwe0XuLN5DLtMPv5kwVUgQTXaZDePmBffqp729+6zrXDR02CFyZfdOplWF0yFlGZkNuLZExgKbcDKR+6HsNEIP6I/kzJev+iTiTSD+8T4=,iv:/Wvz9UDJDbthGNihZ2v0Jwdq5Zgyx4rRfvdzzNbkXpY=,tag:4+5Z8FrZRSB8HToTD1NF9w==,type:str]
+    version: 3.13.3

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -59,6 +59,25 @@ data:
           name: "Gatekeeper"
           provider: !KeyOf proxy-provider
 
+  105-shared-scopes.yaml: |
+    version: 1
+    metadata:
+      name: shared-scope-mappings
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Generic, cross-blueprint scope mappings shared by multiple applications.
+      - model: authentik_providers_oauth2.scopemapping
+        state: present
+        id: shared-email-verified-scope
+        identifiers:
+          name: "Email (verified)"
+        attrs:
+          scope_name: email
+          description: "Generic email scope mapping with verified flag"
+          expression: |
+            return {"email": request.user.email, "email_verified": True}
+
   110-proxy-scope-mapping.yaml: |
     version: 1
     metadata:
@@ -971,6 +990,64 @@ data:
           order: 0
         attrs:
           group: !Find [authentik_core.group, [name, "Unraid Users"]]
+
+  259-bambuddy.yaml: |
+    version: 1
+    metadata:
+      name: bambuddy-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Bambuddy Users group
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Bambuddy Users"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # OAuth2 Provider for Bambuddy
+      - model: authentik_providers_oauth2.oauth2provider
+        id: bambuddy-provider
+        identifiers:
+          name: "Bambuddy"
+        attrs:
+          client_id: !Env BAMBUDDY_CLIENT_ID
+          client_secret: !Env BAMBUDDY_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          encryption_key: null
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_post
+          redirect_uris:
+            - url: "https://bambuddy.lan.${CLUSTER_DOMAIN}/api/v1/auth/oidc/callback"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [name, "Email (verified)"]]
+
+      # Bambuddy Application
+      - model: authentik_core.application
+        identifiers:
+          slug: "bambuddy"
+        attrs:
+          name: "Bambuddy"
+          provider: !KeyOf bambuddy-provider
+          group: "Utils"
+
+      # Restrict access to Bambuddy Users
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "bambuddy"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Bambuddy Users"]]
 
   260-jellyfin.yaml: |
     version: 1

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -192,6 +192,16 @@ spec:
             secretKeyRef:
               name: unraid-sso-secret
               key: CLIENT_SECRET
+        - name: BAMBUDDY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: bambuddy-sso-secret
+              key: CLIENT_ID
+        - name: BAMBUDDY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: bambuddy-sso-secret
+              key: CLIENT_SECRET
         - name: DISCORD_BASIC_AUTH
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - paperless-sso-secret.sops.yaml
   - dawarich-sso-secret.sops.yaml
   - airtrail-sso-secret.sops.yaml
+  - bambuddy-sso-secret.sops.yaml
   - karakeep-sso-secret.sops.yaml
   - scrob-sso-secret.sops.yaml
   - unraid-sso-secret.sops.yaml


### PR DESCRIPTION
## Summary
- add a native Bambuddy OIDC client and Authentik access group
- provision and replicate encrypted OIDC credentials to the utils namespace
- enable verified-email existing-account linking and remove proxy forward-auth

## Validation
- `kubectl kustomize` for Bambuddy, apps production, Authentik install, and infrastructure
- `pre-commit run --files ...`
- SOPS decryption check without output