### PR TITLE
fix(bambuddy): publish OIDC signing key

### DIFF
--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1019,6 +1019,8 @@ data:
           client_secret: !Env BAMBUDDY_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
           encryption_key: null
           client_type: confidential
           grant_types:


### PR DESCRIPTION
## Summary
- configure the Bambuddy Authentik provider to sign ID tokens with the shared RSA certificate
- publish a matching JWKS for Bambuddy validation

## Validation
- Authentik install and infrastructure Kustomize renders
- `pre-commit run --files kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml`
- live Bambuddy logs confirmed the prior empty-JWKS failure