### PR TITLE
feat(authentik): add Proxmox OIDC provider

### DIFF
--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1094,6 +1094,85 @@ data:
           is_superuser: false
           parent: null
 
+  261-proxmox.yaml: |
+    version: 1
+    metadata:
+      name: proxmox-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Proxmox Admins group (members receive the pve-admins entitlement)
+      - model: authentik_core.group
+        state: present
+        id: proxmox-admins
+        identifiers:
+          name: "Proxmox Admins"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # OAuth2/OIDC Provider for Proxmox VE
+      - model: authentik_providers_oauth2.oauth2provider
+        id: proxmox-provider
+        identifiers:
+          name: "Proxmox"
+        attrs:
+          client_id: !Env PROXMOX_CLIENT_ID
+          client_secret: !Env PROXMOX_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_post
+          redirect_uris:
+            - url: "https://pve1.lan.${CLUSTER_DOMAIN}"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-entitlements"]]
+
+      # Proxmox VE Application
+      - model: authentik_core.application
+        id: proxmox-application
+        identifiers:
+          slug: "proxmox"
+        attrs:
+          name: "Proxmox"
+          icon: "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/proxmox.svg"
+          provider: !KeyOf proxmox-provider
+          group: "Local Services"
+
+      # Restrict application access to Proxmox Admins
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf proxmox-application
+          order: 0
+        attrs:
+          group: !KeyOf proxmox-admins
+
+      # Application entitlement emitted as `entitlements: [pve-admins]` through
+      # the managed scope-entitlements mapping, consumed by PVE for group mapping.
+      - model: authentik_core.applicationentitlement
+        id: proxmox-admin-entitlement
+        identifiers:
+          app: !KeyOf proxmox-application
+          name: pve-admins
+
+      # Grant the pve-admins entitlement to Proxmox Admins members
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf proxmox-admin-entitlement
+          order: 10
+        attrs:
+          group: !KeyOf proxmox-admins
+
   500-frigate.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -202,6 +202,16 @@ spec:
             secretKeyRef:
               name: bambuddy-sso-secret
               key: CLIENT_SECRET
+        - name: PROXMOX_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: proxmox-sso-secret
+              key: CLIENT_ID
+        - name: PROXMOX_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: proxmox-sso-secret
+              key: CLIENT_SECRET
         - name: DISCORD_BASIC_AUTH
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
   - nextcloud-sso-secret.sops.yaml
   - litellm-sso-secret.sops.yaml
   - netbird-sso-secret.sops.yaml
+  - proxmox-sso-secret.sops.yaml
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml
   - llama-auth-secret.sops.yaml

--- a/kubernetes/infrastructure/security/authentik/install/proxmox-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/proxmox-sso-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: proxmox-sso-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:UUe0OnAOQSCIAzkf4X0OCZuovcpDZD1V6PxJc6AyiL93X0oFYmGBqm0krznq,iv:w7h+TmDvI8HNu/7d4jwkVNv02YNl3HY6WX6DxnxEm2c=,tag:jkdcJmRpRNm0c7JkVG68DQ==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:zkca7NSKNFEx9GGOmcrFzBVopsZT/nZxQP+UqGJM17pVTQrQmqTHDtzFn2Vc/oao,iv:zzz2Up8vCeZHYd2xjPe/1swD5gOa0lxxbmHeXcmsWzU=,tag:Gc9z9dosvL4LR82MP4cdOQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOb3pDVmJySE53ZHdTTnRm
+            ajAzdmZpZnZSVlN3WnNkMXRGeWlhSEV6WkY4CjVDSGdHeHlnVUc3WmZxbldSSmZG
+            VlJzN24xV1hxbHVhTklBSHNGS2dBUVkKLS0tIGg5OXlPTmc1VDNLRngyK3Flalhs
+            Z0h5TElxc0ZKQ1dPSHVabW93a0FYZ00KvKJ26WWvQ9I6Bynb5XvNqfcoV/dQ8Eyb
+            DbN+iMcyNqxd283uAc8pMQZk1v7qmJdvV2B5mFMz3niKC8PB5zgSmg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-09T12:47:09Z"
+    mac: ENC[AES256_GCM,data:LJ5C956wnfwErdKgQJAxmytTmLMHp4rociYiMUSzLhvGRXmGGn5Qx48YGpR5cCTxay6Icl2E2V++sCXudHoCCulltcN7EEtQKI7Acax+wpoKE2mZ8LSjIzOkjmF9vcFMZWqJGuLNofIah/hx/axXLjoi7vO6fDcCyYG/4RSAguo=,iv:NR0BJPjV2FaQG05ur1XH5qoPu/v3H4wlXHL8Zh1Lu6s=,tag:U7vMJrrfZJXp6jOvYWrDFQ==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
## Summary
- add the Authentik OAuth2/OIDC provider and gated Proxmox application
- emit the `pve-admins` entitlement for Proxmox group mapping
- add a SOPS-encrypted OIDC client credential and Helm environment wiring

## Validation
- `kubectl kustomize kubernetes/infrastructure/security/authentik/install`
- `kubectl kustomize kubernetes/infrastructure`
- `pre-commit run --files <changed files>`