### PR TITLE
feat(authentik): expose LDAP for OPNsense

### DIFF
--- a/kubernetes/clusters/production/identity/cluster-identity.sops.yaml
+++ b/kubernetes/clusters/production/identity/cluster-identity.sops.yaml
@@ -27,6 +27,7 @@ data:
     BAMBUDDY_IP: ENC[AES256_GCM,data:J9dsd/0L9ZX7BuWIcw==,iv:gv1bbvhj42Nb9c+tVo7AXy/pWsaEZxsXVHjb06CQ/TU=,tag:Mf12ni++RYXJlIzvA7xhnA==,type:str]
     GARAGE_S3_IP: ENC[AES256_GCM,data:iqv9LTSyB6FlXG9tsQ==,iv:MblBb7RReTD+4Xvv8CMwqIRYnlT+ITg849coTKXuBxk=,tag:fo8WFLPcrUowcubtXAWv0A==,type:str]
     PHOTON_IP: ENC[AES256_GCM,data:4Oui5lf1Yx5s/NhXWQ==,iv:ZF9oR7dfhI3NdC8F99NcteET24qF+FTc6UU9GvqUp1k=,tag:DXOpK1DupIIntjnp7RsqPg==,type:str]
+    LDAP_LB_IP: ENC[AES256_GCM,data:fDBQ+3e/0UOT4gvGtxc=,iv:yxEHOTPOiucrcK9dVVZPPTYSb08I1LjvGGZnOvmlC7s=,tag:mNeGLabbOE30KuUffz+HRw==,type:str]
 sops:
     age:
         - enc: |
@@ -39,6 +40,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-27T13:22:58Z"
-    mac: ENC[AES256_GCM,data:A5zEFFl60RofZVSgoXAvXpdcMUqq+UsPocwhZCq7BwL/BFfnocNbUNsBVNs3+dHl7pvYFxxVMwI0aeWezAfYG+wbIfvqMskQugfYXrjqR332ULjjAMdkenpLrHYYbih5YQMJWKqvqj+QVqtortUwfkmf1bnJqW6fKZq4Q2ORTB0=,iv:PiQTY4SzYiF9DKPYN8f+wydwEFe2j2Pax4TLHGWKebE=,tag:Vp/lXfOz2SjGddNaXgrcYg==,type:str]
+    lastmodified: "2026-08-09T14:50:46Z"
+    mac: ENC[AES256_GCM,data:PxRBWSgznN75/cQKHaiq7eJ1Ewb82f+o9U4blpw7tPQBZV9ayFDGxsGUUuE5z2UBg75ahauQ7TuyA6HiKpu6OVL0yG+8ZElyOHAK3iD5fe9t5UBqSyEAnt70Ax2rql0w7/W9p9yq2fl3kxqF9mjmmkD9u0Kk72rmGXqlAwfK1Yk=,iv:dWo5E+3jolQ4mFX3rxw2iUFGYdGug7MiavWeTN9klMk=,tag:HnFyJTA2/bE07BtwXldKMw==,type:str]
     version: 3.13.1

--- a/kubernetes/clusters/production/ks/42-authentik-install.yaml
+++ b/kubernetes/clusters/production/ks/42-authentik-install.yaml
@@ -13,6 +13,7 @@ spec:
   dependsOn:
     - name: cluster-identity
     - name: observability-kube-prometheus-stack-install
+    - name: cert-manager-config
   wait: true
   timeout: 35m
   decryption:

--- a/kubernetes/clusters/production/ks/51-cert-manager-config.yaml
+++ b/kubernetes/clusters/production/ks/51-cert-manager-config.yaml
@@ -14,6 +14,7 @@ spec:
     - name: cluster-identity
     - name: cert-manager-install
     - name: observability-kube-prometheus-stack-install
+    - name: kube-replicator-install
   wait: true
   decryption:
     provider: sops

--- a/kubernetes/infrastructure/networking/external-dns/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/networking/external-dns/install/helmrelease.yaml
@@ -34,6 +34,7 @@ spec:
 
     sources:
       - ingress
+      - service
       - traefik-proxy
 
     policy: sync # WARNING: deletes any records within domainFilters

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1173,6 +1173,33 @@ data:
         attrs:
           group: !KeyOf proxmox-admins
 
+  262-opnsense.yaml: |
+    version: 1
+    metadata:
+      name: opnsense-groups
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # OPNsense Admins group (default user gets admin role)
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "OPNsense Admins"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # OPNsense Users group
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "OPNsense Users"
+        attrs:
+          is_superuser: false
+          parent: null
+
   500-frigate.yaml: |
     version: 1
     metadata:
@@ -1879,8 +1906,8 @@ data:
           name: "LDAP"
           authorization_flow: !KeyOf ldap-authentication-flow
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]
-          certificate: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
-          tls_server_name: "ak-outpost-ldap-outpost.authentik.svc.cluster.local"
+          certificate: !Find [authentik_crypto.certificatekeypair, [managed, "goauthentik.io/crypto/discovered/ldap-lan"]]
+          tls_server_name: "ldap.lan.${CLUSTER_DOMAIN}"
           mfa_support: false
           bind_mode: "direct"
           search_mode: "direct"
@@ -1915,7 +1942,29 @@ data:
             object_naming_template: "ak-outpost-%(name)s"
             kubernetes_namespace: authentik
             kubernetes_replicas: 1
-            kubernetes_service_type: ClusterIP
+            kubernetes_service_type: LoadBalancer
+            kubernetes_json_patches:
+              service:
+                # Static MetalLB address from the production L2 pool.
+                - op: add
+                  path: /spec/loadBalancerIP
+                  value: "${LDAP_LB_IP}"
+                # Restrict exposure to the OPNsense router only.
+                - op: add
+                  path: /spec/loadBalancerSourceRanges
+                  value:
+                    - "${OPNSENSE_IP}/32"
+                - op: add
+                  path: /spec/externalTrafficPolicy
+                  value: Local
+                # Ensure the annotations map exists before adding the
+                # ExternalDNS hostname used to publish ldap.lan.${CLUSTER_DOMAIN}.
+                - op: add
+                  path: /metadata/annotations
+                  value: {}
+                - op: add
+                  path: /metadata/annotations/external-dns.alpha.kubernetes.io~1hostname
+                  value: "ldap.lan.${CLUSTER_DOMAIN}"
 
   999-outpost.yaml: |
     version: 1

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -363,14 +363,27 @@ spec:
         timeoutSeconds: 10
         periodSeconds: 10
         failureThreshold: 6
-      extraVolumes:
+      volumes:
         - name: authentik-shm
           emptyDir:
             medium: Memory
             sizeLimit: 256Mi
-      extraVolumeMounts:
+        # ldap-lan-tls is a dedicated cert-manager Certificate for
+        # ldap.lan.${CLUSTER_DOMAIN}, replicated into the authentik
+        # namespace by the mittwald secret replicator (see cert-manager
+        # ldap-lan-cert.yaml). Mounting it read-only at /certs/ldap-lan
+        # exposes tls.crt/tls.key for Authentik certificate discovery
+        # as the managed goauthentik.io/crypto/discovered/ldap-lan
+        # keypair, without exposing the broad wildcard private key.
+        - name: ldap-lan-cert
+          secret:
+            secretName: ldap-lan-tls
+      volumeMounts:
         - name: authentik-shm
           mountPath: /dev/shm
+        - name: ldap-lan-cert
+          mountPath: /certs/ldap-lan
+          readOnly: true
       pdb:
         enabled: true
         minAvailable: 1

--- a/kubernetes/infrastructure/security/cert-manager/config/kustomization.yaml
+++ b/kubernetes/infrastructure/security/cert-manager/config/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - cloudflare-secrets.sops.yaml
   - clusterissuer-letsencrypt.yaml
+  - ldap-lan-cert.yaml
   - servicemonitor-cainjector.yaml
   - servicemonitor-cert-manager.yaml
   - servicemonitor-webhook.yaml

--- a/kubernetes/infrastructure/security/cert-manager/config/ldap-lan-cert.yaml
+++ b/kubernetes/infrastructure/security/cert-manager/config/ldap-lan-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ldap-lan
+  namespace: cert-manager
+spec:
+  secretName: ldap-lan-tls
+  secretTemplate:
+    annotations:
+      replicator.v1.mittwald.de/replicate-to: "authentik"
+  issuerRef:
+    name: letsencrypt-dns
+    kind: ClusterIssuer
+  dnsNames:
+    - "ldap.lan.${CLUSTER_DOMAIN}"


### PR DESCRIPTION
## Summary
- expose the Authentik LDAP outpost through a dedicated, OPNsense-restricted LoadBalancer
- issue a dedicated LDAPS certificate and publish its LAN DNS record
- add OPNsense Authentik groups and reconciliation ordering

## Validation
- kubectl kustomize for cert-manager, Authentik, infrastructure, and production Kustomizations
- Flux local render checks for Authentik and ExternalDNS substitutions
- pre-commit run on changed files
- SOPS decryption validation