### PR TITLE
feat(authentik): add Home Assistant OIDC provider

### DIFF
--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1200,6 +1200,69 @@ data:
           is_superuser: false
           parent: null
 
+  263-home-assistant.yaml: |
+    version: 1
+    metadata:
+      name: home-assistant-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Home Assistant Users group
+      - model: authentik_core.group
+        state: present
+        id: home-assistant-users
+        identifiers:
+          name: "Home Assistant Users"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # OAuth2/OIDC Provider for Home Assistant
+      - model: authentik_providers_oauth2.oauth2provider
+        id: home-assistant-provider
+        identifiers:
+          name: "Home Assistant"
+        attrs:
+          client_id: !Env HOME_ASSISTANT_CLIENT_ID
+          client_secret: !Env HOME_ASSISTANT_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          encryption_key: null
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_basic
+          redirect_uris:
+            - url: "https://home.${CLUSTER_DOMAIN}/auth/oidc/callback"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+
+      # Home Assistant Application
+      - model: authentik_core.application
+        id: home-assistant-application
+        identifiers:
+          slug: "home-assistant"
+        attrs:
+          name: "Home Assistant"
+          icon: "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/home-assistant.svg"
+          provider: !KeyOf home-assistant-provider
+          group: "Local Services"
+
+      # Restrict access to Home Assistant Users
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf home-assistant-application
+          order: 0
+        attrs:
+          group: !KeyOf home-assistant-users
+
   500-frigate.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -212,6 +212,16 @@ spec:
             secretKeyRef:
               name: proxmox-sso-secret
               key: CLIENT_SECRET
+        - name: HOME_ASSISTANT_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: home-assistant-sso-secret
+              key: CLIENT_ID
+        - name: HOME_ASSISTANT_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: home-assistant-sso-secret
+              key: CLIENT_SECRET
         - name: DISCORD_BASIC_AUTH
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/home-assistant-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/home-assistant-sso-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: home-assistant-sso-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:T99Zmg+6a96koAbt/i0QE+M4sBVO+gNMeAmtoBavtl8=,iv:pwOWIS47ImobMZ7ri6z00cOup97UlF5ii5NUZU5SJMg=,tag:IFjeb9h+Xg4q6djDPqB6ug==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:9fInzvzAE1ep2QRoSpJaAhdfxmvP6V+j82F4NG0BDE4hzwMaT5rUCxOn95bfeY83lZqpDDxpRpIe6VisA9Gvew==,iv:Gl00I18ZWgEjoKyUkj2AFTlYSKZaANrATPxgpptdegQ=,tag:Cm37lrvaY0ubZGx2y9mnTQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArU3BYY29zNGwrYjJmQ2hm
+            QjJMbWpGVU5uSjU2VEV5WGVDd1h4VUh3MUNrCmVMeFNHa2N1UDRuUWhiYVovN3lz
+            dDJ1cnJrcExuMkJLWXhHWC9NY3MyV2sKLS0tIDVyLzFlT0V2cGdCR2Y4ajJJUTBp
+            S2wxT0UyYS9nMk1IQkh6cllyNkk4bG8K3UZ7j3VH+5ZgmBzbDx4oRdwZV2T0FGYD
+            VU/QOfmswIGz+yr1+5AHrUKqL2v00QUBrppawP4X8fTuMJRiXGG5PQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-09T16:40:18Z"
+    mac: ENC[AES256_GCM,data:tgJsemKwPJa38vpiFXNOXqYeDikRLPmydg6XshAMnDCKJzITLQF8Mojc/C/m1a09UphVgLnb59hSs6yS0rjyYJpD1weOgKXkTnxEWNYT9ky3/r3PLerTqTgScq/jMAIV8Dbbm7QLGGyA4WHtyjhVHmvkDkG1yGXbSfKLl2nXzLk=,iv:cqEZWe6VMeS8ym7smY4cb6uDLs8zvs9ufTue9JjzH0s=,tag:2OhMlxax4BA8Gal5tQ4FVg==,type:str]
+    version: 3.13.3

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - litellm-sso-secret.sops.yaml
   - netbird-sso-secret.sops.yaml
   - proxmox-sso-secret.sops.yaml
+  - home-assistant-sso-secret.sops.yaml
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml
   - llama-auth-secret.sops.yaml


### PR DESCRIPTION
## Summary
- add a SOPS-encrypted Home Assistant OIDC client credential
- provision the Authentik Home Assistant application and restricted user group
- wire the credentials into the Authentik HelmRelease blueprint environment

## Validation
- pre-commit hooks (including SOPS encryption, kubeconform, and Checkov)
- kubectl kustomize kubernetes/infrastructure

## Follow-up
- install and configure hass-oidc-auth on the external Home Assistant host after the provider is reconciled
- retain Home Assistant local credentials as break-glass access