### PR TITLE
feat(authentik): add Proxmox Backup OIDC provider

### DIFF
--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1281,6 +1281,68 @@ data:
         attrs:
           group: !KeyOf home-assistant-admins
 
+  264-proxmox-backup.yaml: |
+    version: 1
+    metadata:
+      name: proxmox-backup-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Proxmox Backup Admins group (members get application access)
+      - model: authentik_core.group
+        state: present
+        id: proxmox-backup-admins
+        identifiers:
+          name: "Proxmox Backup Admins"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # OAuth2/OIDC Provider for Proxmox Backup Server
+      - model: authentik_providers_oauth2.oauth2provider
+        id: proxmox-backup-provider
+        identifiers:
+          name: "Proxmox Backup"
+        attrs:
+          client_id: !Env PBS_CLIENT_ID
+          client_secret: !Env PBS_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_post
+          redirect_uris:
+            - url: "https://pbs.lan.${CLUSTER_DOMAIN}"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+
+      # Proxmox Backup Server Application
+      - model: authentik_core.application
+        id: proxmox-backup-application
+        identifiers:
+          slug: "proxmox-backup"
+        attrs:
+          name: "Proxmox Backup"
+          icon: "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/proxmox.svg"
+          provider: !KeyOf proxmox-backup-provider
+          group: "Local Services"
+
+      # Restrict application access to Proxmox Backup Admins
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !KeyOf proxmox-backup-application
+          order: 0
+        attrs:
+          group: !KeyOf proxmox-backup-admins
+
   500-frigate.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -212,6 +212,16 @@ spec:
             secretKeyRef:
               name: proxmox-sso-secret
               key: CLIENT_SECRET
+        - name: PBS_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: proxmox-backup-sso-secret
+              key: CLIENT_ID
+        - name: PBS_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: proxmox-backup-sso-secret
+              key: CLIENT_SECRET
         - name: HOME_ASSISTANT_CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - litellm-sso-secret.sops.yaml
   - netbird-sso-secret.sops.yaml
   - proxmox-sso-secret.sops.yaml
+  - proxmox-backup-sso-secret.sops.yaml
   - home-assistant-sso-secret.sops.yaml
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml

--- a/kubernetes/infrastructure/security/authentik/install/proxmox-backup-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/proxmox-backup-sso-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: proxmox-backup-sso-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:nEzuP6Ljyk8LkXTadYutzkN3z6hK80XmlT5TlpULBNxF3rqrOPTUkmBUc354JOTJYQgvwVdan5e1HoeOkY0NnA==,iv:vfDqbI4dxvG2A9gneWN09jk0Xm6iNLn95QkapQ3F1mA=,tag:KyVieHT3gjlMBdAF04ei7g==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:uc1P9jWS9KqZK/c6RKN/BXmczoqYZv/D9so3JKWmko0WwR1xdGUpc3wOWavke4OOC8bM2+Xh+NtrmJ5ysbj8Kp1Mv0djHkEKnYpfPbiQ4jZq+8C5DoJOXDcM9GWufmzH,iv:gg1WuEICKdNPjxeE182RSPQj7jiU/z7iZFStY4GqTjg=,tag:E+IErelpbqN8uK9mxljcig==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQd05aL3hzOG5Hc1czTzQ5
+            eEtxdlVnMktRcnBtYi92TlU2Mk9LZzdZZURJCnZNdlZadnlaZ3RNamlVZ3hvMGtC
+            YzhsL0dycnNFU1J0aEJ2TmkxRkVoMWMKLS0tIDBXZ21wYnFxZzhWY1R2UXRuMno4
+            MmVvaStaRFpLNjFaV2JqSmR3bWl0T0UKfYWpSxGtg3K3mK+739hY86vbpsXMtvyf
+            fHLwz3dHHNhEp0jU1jZ8Jcu+vvEr4AcqhIrA/H6ZH1tYryRGGMt7oQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-09T21:08:22Z"
+    mac: ENC[AES256_GCM,data:BbXr4oHpVXnzd4/hjW10Ld/Hhg+zvInPPymiwsqxZy8gRFjkBbQD9ZniSBAzEeH+juWpYoxHO4QdLPIVxGJYBaUajBjGZbLDOea/ZWmFI5H1iRhoyLSLG1/uEfcLyHbvs5Xx3mR/kYmXRoSxJS7PNPaKD3rvl4j/2i1ir+sStK0=,iv:IByldVI+l/qc1DIuYD0MHXIkjHtfpQEVsmOaFi+oW6w=,tag:+kwYs83Ye8vmxNdEACXDPA==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
## Summary
- add a confidential Authentik OIDC provider and application for Proxmox Backup Server
- restrict application access with one Proxmox Backup Admins group
- store generated client credentials as a SOPS-encrypted Kubernetes Secret

## Validation
- kubectl kustomize kubernetes/infrastructure/security/authentik/install
- kubectl kustomize kubernetes/infrastructure
- pre-commit hooks