### PR TITLE
fix(packer): stabilize ubuntu 26.04 builds

### DIFF
--- a/packer/scripts/setup-ubuntu-base.sh
+++ b/packer/scripts/setup-ubuntu-base.sh
@@ -71,6 +71,8 @@ echo "==> 6. Cleanup"
 apt-get autoremove -y
 apt-get clean
 rm -rf /var/lib/apt/lists/*
+# Force the first package task on a clone to refresh the deleted APT indexes.
+rm -f /var/lib/apt/periodic/update-success-stamp
 rm -rf /tmp/*
 rm -rf /var/tmp/*
 

--- a/packer/ubuntu-26.04-base/build.sh
+++ b/packer/ubuntu-26.04-base/build.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-"$script_dir/../scripts/build-ubuntu-template.sh" "$script_dir" "$@"
+"$script_dir/../scripts/build-ubuntu-template.sh" "$script_dir" "$@" -parallel-builds=1

--- a/packer/ubuntu-26.04-base/http/user-data.template
+++ b/packer/ubuntu-26.04-base/http/user-data.template
@@ -14,12 +14,6 @@ autoinstall:
     layout: us
   timezone: Europe/Berlin
 
-  network:
-    version: 2
-    ethernets:
-      ens18:
-        dhcp4: true
-
   storage:
     layout:
       name: lvm
@@ -53,5 +47,8 @@ autoinstall:
     - curtin in-target --target=/target -- systemctl enable qemu-guest-agent  # enable qga
     - curtin in-target --target=/target -- sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config  # enforce key-only
     - curtin in-target --target=/target -- sed -i 's/^PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config  # enforce key-only
+
+    - curtin in-target --target=/target -- sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT=/ s/"$/ net.ifnames=0"/' /etc/default/grub  # use eth0 for cloned guests while preserving existing kernel args
+    - curtin in-target --target=/target -- update-grub  # apply the updated kernel command line
 
   shutdown: reboot

--- a/packer/ubuntu-26.04-base/ubuntu-26.04.pkr.hcl
+++ b/packer/ubuntu-26.04-base/ubuntu-26.04.pkr.hcl
@@ -24,10 +24,11 @@ locals {
   network_bridge       = "vmbr0"
   network_firewall     = false
   cloud_init_storage   = "ssd-zfs"
-  boot_wait            = "10s"
+  boot_wait            = "30s"
+  boot_key_interval    = "100ms"
   boot_command = [
     "<wait>c<wait>",
-    "linux /casper/vmlinuz autoinstall ds=nocloud-net\\;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ---",
+    "linux /casper/vmlinuz autoinstall ip=dhcp ds=nocloud-net\\;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ---",
     "<enter><wait>",
     "initrd /casper/initrd",
     "<enter><wait>",
@@ -36,6 +37,7 @@ locals {
   ssh_timeout            = "20m"
   ssh_handshake_attempts = 100
   http_directory         = "${path.root}/${var.http_directory}"
+  http_port              = 18080
 
   # VM ID calculation: Ubuntu base (9010) + node number
   distro_base_id = 9010
@@ -86,14 +88,18 @@ source "proxmox-iso" "ubuntu-base-pve1" {
     iso_file = "${var.iso_storage_pool}:iso/${var.iso_name}"
     unmount  = true
   }
-  boot_wait              = local.boot_wait
-  boot_command           = local.boot_command
-  ssh_username           = "ubuntu"
-  ssh_private_key_file   = var.ssh_private_key_file
-  ssh_timeout            = local.ssh_timeout
-  ssh_handshake_attempts = local.ssh_handshake_attempts
-  http_directory         = local.http_directory
-  qemu_agent             = true
+  boot_wait                    = local.boot_wait
+  boot_key_interval            = local.boot_key_interval
+  boot_command                 = local.boot_command
+  ssh_username                 = "ubuntu"
+  ssh_agent_auth               = true
+  ssh_disable_agent_forwarding = true
+  ssh_timeout                  = local.ssh_timeout
+  ssh_handshake_attempts       = local.ssh_handshake_attempts
+  http_directory               = local.http_directory
+  http_port_min                = local.http_port
+  http_port_max                = local.http_port
+  qemu_agent                   = true
 }
 
 # ------------------------------------------------------------------------------
@@ -138,14 +144,18 @@ source "proxmox-iso" "ubuntu-base-pve2" {
     iso_file = "${var.iso_storage_pool}:iso/${var.iso_name}"
     unmount  = true
   }
-  boot_wait              = local.boot_wait
-  boot_command           = local.boot_command
-  ssh_username           = "ubuntu"
-  ssh_private_key_file   = var.ssh_private_key_file
-  ssh_timeout            = local.ssh_timeout
-  ssh_handshake_attempts = local.ssh_handshake_attempts
-  http_directory         = local.http_directory
-  qemu_agent             = true
+  boot_wait                    = local.boot_wait
+  boot_key_interval            = local.boot_key_interval
+  boot_command                 = local.boot_command
+  ssh_username                 = "ubuntu"
+  ssh_agent_auth               = true
+  ssh_disable_agent_forwarding = true
+  ssh_timeout                  = local.ssh_timeout
+  ssh_handshake_attempts       = local.ssh_handshake_attempts
+  http_directory               = local.http_directory
+  http_port_min                = local.http_port
+  http_port_max                = local.http_port
+  qemu_agent                   = true
 }
 
 
@@ -191,14 +201,18 @@ source "proxmox-iso" "ubuntu-base-pve3" {
     iso_file = "${var.iso_storage_pool}:iso/${var.iso_name}"
     unmount  = true
   }
-  boot_wait              = local.boot_wait
-  boot_command           = local.boot_command
-  ssh_username           = "ubuntu"
-  ssh_private_key_file   = var.ssh_private_key_file
-  ssh_timeout            = local.ssh_timeout
-  ssh_handshake_attempts = local.ssh_handshake_attempts
-  http_directory         = local.http_directory
-  qemu_agent             = true
+  boot_wait                    = local.boot_wait
+  boot_key_interval            = local.boot_key_interval
+  boot_command                 = local.boot_command
+  ssh_username                 = "ubuntu"
+  ssh_agent_auth               = true
+  ssh_disable_agent_forwarding = true
+  ssh_timeout                  = local.ssh_timeout
+  ssh_handshake_attempts       = local.ssh_handshake_attempts
+  http_directory               = local.http_directory
+  http_port_min                = local.http_port
+  http_port_max                = local.http_port
+  qemu_agent                   = true
 }
 
 

--- a/packer/ubuntu-26.04-base/variables.pkr.hcl
+++ b/packer/ubuntu-26.04-base/variables.pkr.hcl
@@ -46,9 +46,3 @@ variable "http_directory" {
   default     = "http"
   description = "Directory served by Packer's HTTP server for autoinstall seed files."
 }
-
-variable "ssh_private_key_file" {
-  type        = string
-  default     = "${env("HOME")}/.ssh/id_ed25519"
-  description = "Private SSH key used by Packer to connect to the guest."
-}


### PR DESCRIPTION
## Summary

- Run Ubuntu 26.04 Packer sources serially so the allowlisted HTTP port `18080` is reused safely.
- Improve autoinstall boot/network setup and use SSH-agent authentication.
- Refresh APT metadata on cloned guests.

## Validation

- `packer init packer/ubuntu-26.04-base`
- `packer fmt -check -recursive packer/ubuntu-26.04-base`
- `packer validate packer/ubuntu-26.04-base`
- `bash -n packer/ubuntu-26.04-base/build.sh packer/scripts/build-ubuntu-template.sh packer/scripts/setup-ubuntu-base.sh`
- `pre-commit run --files packer/scripts/setup-ubuntu-base.sh packer/ubuntu-26.04-base/build.sh packer/ubuntu-26.04-base/http/user-data.template packer/ubuntu-26.04-base/ubuntu-26.04.pkr.hcl packer/ubuntu-26.04-base/variables.pkr.hcl`