### PR TITLE
feat(hermes): add cluster access

### DIFF
--- a/kubernetes/apps/apps/external-proxy/hermes.yaml
+++ b/kubernetes/apps/apps/external-proxy/hermes.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes
+  namespace: external-proxy
+spec:
+  ports:
+    - name: http
+      port: 9119
+      targetPort: 9119
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: hermes
+  namespace: external-proxy
+subsets:
+  - addresses:
+      - ip: 192.168.10.100
+    ports:
+      - name: http
+        port: 9119
+        protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hermes
+  namespace: external-proxy
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    external-dns.alpha.kubernetes.io/hostname: hermes.lan.${CLUSTER_DOMAIN}
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: hermes.lan.${CLUSTER_DOMAIN}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hermes
+                port:
+                  name: http

--- a/kubernetes/apps/apps/external-proxy/hermes.yaml
+++ b/kubernetes/apps/apps/external-proxy/hermes.yaml
@@ -17,7 +17,7 @@ metadata:
   namespace: external-proxy
 subsets:
   - addresses:
-      - ip: 192.168.10.100
+      - ip: ${HERMES_IP}
     ports:
       - name: http
         port: 9119

--- a/kubernetes/apps/apps/external-proxy/kustomization.yaml
+++ b/kubernetes/apps/apps/external-proxy/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - garage-s3.yaml
+  - hermes.yaml
   - home-assistant.yaml
   - kvm.yaml
   - opnsense.yaml

--- a/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
@@ -171,6 +171,10 @@ spec:
                 icon: emqx.png
                 description: "MQTT broker"
                 href: https://emqx.lan.${CLUSTER_DOMAIN}
+            - Hermes:
+                icon: https://assets.web.${CLUSTER_DOMAIN}/icons/hermes.svg
+                description: "Hermes dashboard"
+                href: https://hermes.lan.${CLUSTER_DOMAIN}
             - Home Assistant:
                 icon: home-assistant.png
                 description: "Home automation server"

--- a/kubernetes/clusters/production/identity/cluster-identity.sops.yaml
+++ b/kubernetes/clusters/production/identity/cluster-identity.sops.yaml
@@ -28,6 +28,7 @@ data:
     GARAGE_S3_IP: ENC[AES256_GCM,data:iqv9LTSyB6FlXG9tsQ==,iv:MblBb7RReTD+4Xvv8CMwqIRYnlT+ITg849coTKXuBxk=,tag:fo8WFLPcrUowcubtXAWv0A==,type:str]
     PHOTON_IP: ENC[AES256_GCM,data:4Oui5lf1Yx5s/NhXWQ==,iv:ZF9oR7dfhI3NdC8F99NcteET24qF+FTc6UU9GvqUp1k=,tag:DXOpK1DupIIntjnp7RsqPg==,type:str]
     LDAP_LB_IP: ENC[AES256_GCM,data:fDBQ+3e/0UOT4gvGtxc=,iv:yxEHOTPOiucrcK9dVVZPPTYSb08I1LjvGGZnOvmlC7s=,tag:mNeGLabbOE30KuUffz+HRw==,type:str]
+    HERMES_IP: ENC[AES256_GCM,data:KSTYCaAqfHb3+n1fZhY=,iv:yJfP0hA3eORWpr9jtyhtUsb599nekW1dA9fAerF15b4=,tag:rbayjLrha3nvO3wd0G2qig==,type:str]
 sops:
     age:
         - enc: |
@@ -40,6 +41,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-09T14:50:46Z"
-    mac: ENC[AES256_GCM,data:PxRBWSgznN75/cQKHaiq7eJ1Ewb82f+o9U4blpw7tPQBZV9ayFDGxsGUUuE5z2UBg75ahauQ7TuyA6HiKpu6OVL0yG+8ZElyOHAK3iD5fe9t5UBqSyEAnt70Ax2rql0w7/W9p9yq2fl3kxqF9mjmmkD9u0Kk72rmGXqlAwfK1Yk=,iv:dWo5E+3jolQ4mFX3rxw2iUFGYdGug7MiavWeTN9klMk=,tag:HnFyJTA2/bE07BtwXldKMw==,type:str]
-    version: 3.13.1
+    lastmodified: "2026-08-12T20:37:24Z"
+    mac: ENC[AES256_GCM,data:JpbV0/sple0V4/nThe/iQK7V6qeuLG3sij13S/5xvYDOx96VRvSQYBn2opJzOhevwAdCt/bAzyhLAgWCzhnggv24Krw3KO7fIE9Vn0KquivslmVHfyesA6kkEDyFEv/c1AdMior2BKisNKvUaPDImcP9631tZhKBnfXQ7a7q5N0=,iv:6kFCN8GN5B936L7sbEEyAdsoiG5QMpJOere+TguKg9A=,tag:FL+Eb357WdbhJ3L28JKJZQ==,type:str]
+    version: 3.13.3

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1879,6 +1879,17 @@ data:
       labels:
         blueprints.goauthentik.io/instantiate: "true"
     entries:
+      # Hermes Users group
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Hermes Users"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
       # OAuth2/OIDC Provider for Hermes Remote
       - model: authentik_providers_oauth2.oauth2provider
         id: hermes-provider
@@ -1913,6 +1924,14 @@ data:
           icon: https://assets.web.${CLUSTER_DOMAIN}/icons/hermes.svg
           provider: !KeyOf hermes-provider
           group: "Local Services"
+
+      # Restrict access to Hermes Users
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "hermes"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Hermes Users"]]
 
   900-ldap.yaml: |
     version: 1

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1872,6 +1872,48 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "Tautulli users"]]
 
+  550-hermes.yaml: |
+    version: 1
+    metadata:
+      name: hermes-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # OAuth2/OIDC Provider for Hermes Remote
+      - model: authentik_providers_oauth2.oauth2provider
+        id: hermes-provider
+        identifiers:
+          name: "Hermes Remote"
+        attrs:
+          client_id: !Env HERMES_CLIENT_ID
+          client_secret: !Env HERMES_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_post
+          include_claims_in_id_token: true
+          redirect_uris:
+            - url: "https://hermes.lan.${CLUSTER_DOMAIN}/auth/callback"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+
+      # Hermes Remote Application
+      - model: authentik_core.application
+        identifiers:
+          slug: "hermes"
+        attrs:
+          name: "Hermes"
+          icon: https://assets.web.${CLUSTER_DOMAIN}/icons/hermes.svg
+          provider: !KeyOf hermes-provider
+          group: "Local Services"
+
   900-ldap.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -232,6 +232,16 @@ spec:
             secretKeyRef:
               name: home-assistant-sso-secret
               key: CLIENT_SECRET
+        - name: HERMES_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: hermes-sso-secret
+              key: CLIENT_ID
+        - name: HERMES_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: hermes-sso-secret
+              key: CLIENT_SECRET
         - name: DISCORD_BASIC_AUTH
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/hermes-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/hermes-sso-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hermes-sso-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:Wx8+VmPicyiC/C4huqYixtqaIqPIE3vOARMgZFiMRlZTWbISHPVf,iv:LcCmsT/FWd+kPW3XvvsFI96W7dfT/1HlKUK9RcPlc3U=,tag:T5ZPsgueMyznHkF/LkcYtw==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:/ydpWIf7Z4Bk6AxVO7hwPDXyKpoT7SsUAfFyZGMgFDNpbu48QiLASMRFWWAw9rt7t6vA7sLyTOzbdO5dsORVNQ==,iv:enuAv9+FNTWFGRn2PBCijI6o0RatpqsNiRAhDftSB7g=,tag:w3I+aQgYTGuP3dyds8rWMg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaam5ldEE3SGMvSE5RNEtS
+            OFA0UVlYWkl5Z1NpT201c2xSMVB1ZTdxeFd3CmhMWnEraWd0dk5GWHJhR3JucVhY
+            MnI0MnBrN3JFSExIUk1mOVpBbTVrVDgKLS0tIDMxZ0hWWGVaN1liZVhnOHR6dlIw
+            bmQ4OEgxU3ZqbUozN3M4VkRNTnVnNDQKf8j/pdgGNW25akjy8UPBcPSLdVQuo/XO
+            Gy6iXObeH5TcfpoGFCgb12bm9dIm8b0RjsXB3hTfbqyvKmt8Dkgy2A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-12T20:26:01Z"
+    mac: ENC[AES256_GCM,data:PijBcaGN5d0vc6EHtxG/ZTReXJfs37jZjtk5LR3UquyP1oObXbfqHM8Wc2gYts3z0uDVPyMDGq/hoz2VHs7EVeUmKBAtiZBsuDCaJ+3RRa6AGZHe6G5JYfyii3bsEkB4TwuqeZDafSmQYTEDqJNYAPeH2BbFVgJS3c7l2Cbhuio=,iv:7meaC3PKseIvUyXi1bh6/MfF5pyJ2qXykgkMNGNYsfw=,tag:wT4VCB09mbLFScQ0I5meVg==,type:str]
+    version: 3.13.3

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - proxmox-sso-secret.sops.yaml
   - proxmox-backup-sso-secret.sops.yaml
   - home-assistant-sso-secret.sops.yaml
+  - hermes-sso-secret.sops.yaml
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml
   - llama-auth-secret.sops.yaml


### PR DESCRIPTION
Adds an Authentik OIDC client with SOPS-encrypted credentials, Traefik routing for Hermes, and a Homepage entry. Validated with Kustomize renders, SOPS decryption, pre-commit, kubeconform, and Checkov.