### PR TITLE
feat(ai): add hindsight memory service

### DIFF
--- a/kubernetes/apps/apps/ai/hindsight/cnpg-cluster.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/cnpg-cluster.yaml
@@ -1,0 +1,74 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: hindsight-pg
+  namespace: ai
+  labels:
+    release: observability-kube-prometheus-stack
+spec:
+  inheritedMetadata:
+    labels:
+      recurring-job.longhorn.io/backup-daily: enabled
+      recurring-job.longhorn.io/backup-weekly: enabled
+  instances: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 384Mi
+  monitoring:
+    enablePodMonitor: true
+  storage:
+    size: 10Gi
+    storageClass: longhorn-r2
+
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:14.18-0.3.0
+
+  postgresql:
+    parameters:
+      wal_level: "replica"
+      archive_timeout: "21600"
+      archive_mode: "on"
+    shared_preload_libraries:
+      - "vchord.so"
+
+  bootstrap:
+    initdb:
+      database: hindsight
+      owner: hindsight
+      secret:
+        name: hindsight-db-secrets
+      postInitApplicationSQL:
+        - CREATE EXTENSION vchord CASCADE;
+
+  backup:
+    barmanObjectStore:
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-backup-s3
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-backup-s3
+          key: ACCESS_SECRET_KEY
+        region:
+          name: cnpg-backup-s3
+          key: AWS_DEFAULT_REGION
+      destinationPath: "s3://cloudnative-pg/hindsight"
+      endpointURL: "https://s3.${CLUSTER_DOMAIN}"
+      serverName: "hindsight-pg-v1"
+    retentionPolicy: "14d"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: hindsight-pg-backup
+  namespace: ai
+spec:
+  schedule: "0 0 0 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: hindsight-pg
+  method: barmanObjectStore

--- a/kubernetes/apps/apps/ai/hindsight/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/helmrelease.yaml
@@ -48,18 +48,18 @@ spec:
               HINDSIGHT_API_LLM_API_KEY:
                 valueFrom:
                   secretKeyRef:
-                    name: litellm-secrets
-                    key: LITELLM_MASTER_KEY
+                    name: hindsight-secrets
+                    key: LITELLM_API_KEY
               HINDSIGHT_API_EMBEDDINGS_LITELLM_API_KEY:
                 valueFrom:
                   secretKeyRef:
-                    name: litellm-secrets
-                    key: LITELLM_MASTER_KEY
+                    name: hindsight-secrets
+                    key: LITELLM_API_KEY
               HINDSIGHT_API_RERANKER_LITELLM_API_KEY:
                 valueFrom:
                   secretKeyRef:
-                    name: litellm-secrets
-                    key: LITELLM_MASTER_KEY
+                    name: hindsight-secrets
+                    key: LITELLM_API_KEY
             ports:
               - name: http
                 containerPort: 8888
@@ -147,18 +147,18 @@ spec:
               HINDSIGHT_API_LLM_API_KEY:
                 valueFrom:
                   secretKeyRef:
-                    name: litellm-secrets
-                    key: LITELLM_MASTER_KEY
+                    name: hindsight-secrets
+                    key: LITELLM_API_KEY
               HINDSIGHT_API_EMBEDDINGS_LITELLM_API_KEY:
                 valueFrom:
                   secretKeyRef:
-                    name: litellm-secrets
-                    key: LITELLM_MASTER_KEY
+                    name: hindsight-secrets
+                    key: LITELLM_API_KEY
               HINDSIGHT_API_RERANKER_LITELLM_API_KEY:
                 valueFrom:
                   secretKeyRef:
-                    name: litellm-secrets
-                    key: LITELLM_MASTER_KEY
+                    name: hindsight-secrets
+                    key: LITELLM_API_KEY
             ports:
               - name: http
                 containerPort: 8889
@@ -281,11 +281,6 @@ spec:
       control-plane:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: hindsight.lan.${CLUSTER_DOMAIN}
-          gethomepage.dev/enabled: "true"
-          gethomepage.dev/name: Hindsight
-          gethomepage.dev/description: Agent memory dashboard
-          gethomepage.dev/group: AI
-          gethomepage.dev/icon: hindsight.png
         hosts:
           - host: hindsight.lan.${CLUSTER_DOMAIN}
             paths:

--- a/kubernetes/apps/apps/ai/hindsight/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/helmrelease.yaml
@@ -269,6 +269,8 @@ spec:
 
     ingress:
       api:
+        enabled: true
+        className: traefik
         annotations:
           external-dns.alpha.kubernetes.io/hostname: hindsight-api.lan.${CLUSTER_DOMAIN}
         hosts:
@@ -279,6 +281,8 @@ spec:
                   identifier: api
                   port: api
       control-plane:
+        enabled: true
+        className: traefik
         annotations:
           external-dns.alpha.kubernetes.io/hostname: hindsight.lan.${CLUSTER_DOMAIN}
         hosts:

--- a/kubernetes/apps/apps/ai/hindsight/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/helmrelease.yaml
@@ -1,0 +1,295 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hindsight
+  namespace: ai
+spec:
+  chart:
+    spec:
+      chart: app-template
+  values:
+    controllers:
+      api:
+        containers:
+          api:
+            image:
+              # renovate: datasource=docker depName=vectorize-io/hindsight-api registryUrl=https://ghcr.io
+              repository: ghcr.io/vectorize-io/hindsight-api
+              tag: 0.9.0-slim
+            env:
+              TZ: Europe/Berlin
+              HINDSIGHT_ENABLE_API: "true"
+              HINDSIGHT_ENABLE_CP: "false"
+              HINDSIGHT_API_DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: hindsight-db-secrets
+                    key: DATABASE_URL
+              HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP: "true"
+              HINDSIGHT_API_DATABASE_BACKEND: postgresql
+              HINDSIGHT_API_VECTOR_EXTENSION: vchord
+              HINDSIGHT_API_LLM_PROVIDER: openai
+              HINDSIGHT_API_LLM_BASE_URL: http://litellm-main.ai.svc.cluster.local:4000/v1
+              HINDSIGHT_API_LLM_MODEL: zai-coding/glm-5-turbo
+              HINDSIGHT_API_LLM_STRICT_SCHEMA: "false"
+              HINDSIGHT_API_LLM_EXTRA_BODY: '{"allowed_openai_params":["response_format","tools","tool_choice"]}'
+              HINDSIGHT_API_LLM_MAX_CONCURRENT: "1"
+              HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT: "1"
+              HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT: "1"
+              HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT: "1"
+              HINDSIGHT_API_EMBEDDINGS_PROVIDER: litellm
+              HINDSIGHT_API_EMBEDDINGS_LITELLM_API_BASE: http://litellm-main.ai.svc.cluster.local:4000
+              HINDSIGHT_API_EMBEDDINGS_LITELLM_MODEL: local/embedding
+              HINDSIGHT_API_RERANKER_PROVIDER: litellm
+              HINDSIGHT_API_RERANKER_LITELLM_API_BASE: http://litellm-main.ai.svc.cluster.local:4000
+              HINDSIGHT_API_RERANKER_LITELLM_MODEL: local/rerank
+              HINDSIGHT_API_RERANKER_LITELLM_MAX_TOKENS_PER_DOC: "8192"
+              HINDSIGHT_API_RERANKER_LITELLM_TIMEOUT: "60"
+              HINDSIGHT_API_LLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secrets
+                    key: LITELLM_MASTER_KEY
+              HINDSIGHT_API_EMBEDDINGS_LITELLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secrets
+                    key: LITELLM_MASTER_KEY
+              HINDSIGHT_API_RERANKER_LITELLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secrets
+                    key: LITELLM_MASTER_KEY
+            ports:
+              - name: http
+                containerPort: 8888
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/live
+                    port: 8888
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8888
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/live
+                    port: 8888
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+
+      worker:
+        replicas: 1
+        containers:
+          worker:
+            image:
+              # renovate: datasource=docker depName=vectorize-io/hindsight-api registryUrl=https://ghcr.io
+              repository: ghcr.io/vectorize-io/hindsight-api
+              tag: 0.9.0-slim
+            command:
+              - hindsight-worker
+            env:
+              TZ: Europe/Berlin
+              HINDSIGHT_API_DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: hindsight-db-secrets
+                    key: DATABASE_URL
+              HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP: "false"
+              HINDSIGHT_API_DATABASE_BACKEND: postgresql
+              HINDSIGHT_API_VECTOR_EXTENSION: vchord
+              HINDSIGHT_API_LLM_PROVIDER: openai
+              HINDSIGHT_API_LLM_BASE_URL: http://litellm-main.ai.svc.cluster.local:4000/v1
+              HINDSIGHT_API_LLM_MODEL: zai-coding/glm-5-turbo
+              HINDSIGHT_API_LLM_STRICT_SCHEMA: "false"
+              HINDSIGHT_API_LLM_EXTRA_BODY: '{"allowed_openai_params":["response_format","tools","tool_choice"]}'
+              HINDSIGHT_API_LLM_MAX_CONCURRENT: "1"
+              HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT: "1"
+              HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT: "1"
+              HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT: "1"
+              HINDSIGHT_API_EMBEDDINGS_PROVIDER: litellm
+              HINDSIGHT_API_EMBEDDINGS_LITELLM_API_BASE: http://litellm-main.ai.svc.cluster.local:4000
+              HINDSIGHT_API_EMBEDDINGS_LITELLM_MODEL: local/embedding
+              HINDSIGHT_API_RERANKER_PROVIDER: litellm
+              HINDSIGHT_API_RERANKER_LITELLM_API_BASE: http://litellm-main.ai.svc.cluster.local:4000
+              HINDSIGHT_API_RERANKER_LITELLM_MODEL: local/rerank
+              HINDSIGHT_API_RERANKER_LITELLM_MAX_TOKENS_PER_DOC: "8192"
+              HINDSIGHT_API_RERANKER_LITELLM_TIMEOUT: "60"
+              HINDSIGHT_API_WORKER_ID: hindsight-worker-1
+              HINDSIGHT_API_WORKER_MAX_SLOTS: "1"
+              HINDSIGHT_API_WORKER_POLL_INTERVAL_MS: "500"
+              HINDSIGHT_API_WORKER_MAX_RETRIES: "3"
+              HINDSIGHT_API_LLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secrets
+                    key: LITELLM_MASTER_KEY
+              HINDSIGHT_API_EMBEDDINGS_LITELLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secrets
+                    key: LITELLM_MASTER_KEY
+              HINDSIGHT_API_RERANKER_LITELLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secrets
+                    key: LITELLM_MASTER_KEY
+            ports:
+              - name: http
+                containerPort: 8889
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8889
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8889
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8889
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+
+      control-plane:
+        containers:
+          control-plane:
+            image:
+              # renovate: datasource=docker depName=vectorize-io/hindsight-control-plane registryUrl=https://ghcr.io
+              repository: ghcr.io/vectorize-io/hindsight-control-plane
+              tag: 0.9.0
+            env:
+              TZ: Europe/Berlin
+              HINDSIGHT_ENABLE_API: "false"
+              HINDSIGHT_ENABLE_CP: "true"
+              HINDSIGHT_CP_PORT: "9999"
+              HINDSIGHT_CP_DATAPLANE_API_URL: http://hindsight-api:8888
+            ports:
+              - name: http
+                containerPort: 9999
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 9999
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 9999
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 9999
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      api:
+        controller: api
+        ports:
+          api:
+            port: 8888
+      control-plane:
+        controller: control-plane
+        ports:
+          http:
+            port: 9999
+
+    ingress:
+      api:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: hindsight-api.lan.${CLUSTER_DOMAIN}
+        hosts:
+          - host: hindsight-api.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: api
+                  port: api
+      control-plane:
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: hindsight.lan.${CLUSTER_DOMAIN}
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Hindsight
+          gethomepage.dev/description: Agent memory dashboard
+          gethomepage.dev/group: AI
+          gethomepage.dev/icon: hindsight.png
+        hosts:
+          - host: hindsight.lan.${CLUSTER_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: control-plane
+                  port: http

--- a/kubernetes/apps/apps/ai/hindsight/helmrelease.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/helmrelease.yaml
@@ -280,9 +280,7 @@ spec:
                 service:
                   identifier: api
                   port: api
-      control-plane:
-        enabled: true
-        className: traefik
+      main:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: hindsight.lan.${CLUSTER_DOMAIN}
         hosts:

--- a/kubernetes/apps/apps/ai/hindsight/hindsight-db-secrets.sops.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/hindsight-db-secrets.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hindsight-db-secrets
+    namespace: ai
+type: Opaque
+stringData:
+    username: ENC[AES256_GCM,data:J4OepGA1plWO,iv:qzRusIuLRKQ2yDmhgfpBX/tbNDBS1iZVRGvBi8ka8YU=,tag:22B0t0syix89pxdElL50fA==,type:str]
+    password: ENC[AES256_GCM,data:a/p4CGSpa9W0VA/8xvA+H0BiRbhAzuvGPzEXsGOKIcHHYI75QsJg07Tc/Fk/HTPUIAKBTwrE574WfzQ+9NA/5Q==,iv:40hGVJT8MoZpoAFOSTZwIFyDHvcotsrGpZUh16iGV4M=,tag:uHpBvb6v/oz8Gh5hp19QXQ==,type:str]
+    DATABASE_URL: ENC[AES256_GCM,data:2G3ZZz7/ergRwVz4MNDTJA3TFuhlDQKtQbPvIgHbH16+ifhhuCrmhXG4vYKX8bWwFNeAr/XwYWB51RytWLri+kdrklRgeeKT82sgq+AKcCtkXPrz9ZTldOsMm2RrtvUx8wF9YzQmUcgl/q6aVcg/011+oANGwg==,iv:fwKJewar+JEM061OQ2l5Dj/p1c8lBMCvTm/zQT6VM88=,tag:1PrdIv2rPw0SQzP6QiGWpg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3OGtHdW5wcXNpK3lLWm5F
+            bHdvaDlQTTlSYzFFWUdqajB6M0NKQW5zMlgwCmVVaFhSUmdTSGZ2c2tCZmZjMDFR
+            Z2F4SHgxRU4vZkZqRW5LaVpjZGo4dm8KLS0tIDhMZlFlbEsrbFA0OEFnY0kzdzdE
+            cUxxM09hTWJyQUxFY3EvZ0prM3V2c2cKh+EYwM19He8wt4sTsqa4tkUO792oanLv
+            M4LEUOM5Uodsg7VWaJndphMCgrcIMf4hBEAgSAXoS/EhAtMfNMQ39w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-13T21:29:09Z"
+    mac: ENC[AES256_GCM,data:7RvE8K42V9ciI9aMKTBMcUqe7YHfuOUvZiS0UNmkpVyfYQ1Ja1WeeC1/EMLHSXEdB6HseZ/xsOkzmcsHoX7IHQ+3V5Ca9CzDn3HuJnUvZ/cr+Rj478P044csj5IzbXfNYyIUXk/mcYohRCIeOhqOeCnT38pT89BkyURviRZas4I=,iv:jLfvacnmICYQkw/4pCXUT+c5L4Ebrh4nNrH3raLpFGc=,tag:Lwa5WmnfDyTiN82BD96mXA==,type:str]
+    version: 3.13.3

--- a/kubernetes/apps/apps/ai/hindsight/hindsight-secrets.sops.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/hindsight-secrets.sops.yaml
@@ -5,19 +5,19 @@ metadata:
     namespace: ai
 type: Opaque
 stringData:
-    LITELLM_API_KEY: ENC[AES256_GCM,data:A293Z/REFN2tDuw0o9XCJ5FnxVxaaRMi+OmhITHWIw==,iv:cp1BVKZRI2VKCVI7oL6hwKuwj+27WcdLGqBTNRigSi0=,tag:vUH/sloIiZ3bm66+kf8MOw==,type:str]
+    LITELLM_API_KEY: ENC[AES256_GCM,data:lmPovKVkk6qEjIbL1UYY2jIVxAuFrFaliQ==,iv:AEExbxZlJNLzMjZSmbO2pHlcoEh69hCu4nghPutpct8=,tag:tQR6ERsvorUQAtbbGBEZQg==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTbzBDTGlyUWJlNVl4bW8v
-            dWF0M29ESkV0SklnY3U0cUVvVWpabjRVRDJnCkNwU2tSNFZoaXhWblEzQXhCdkFO
-            d25yRjlEc0tMNEdwQ0Z0OHdjNEFrVG8KLS0tIFpSaDdCdWpxcHNpMTlQMG5SY3BU
-            TFNnbFZWNDJEaWpSWWhwNmw0OHRTNmMKd+ExQ3EUdnSkUNPbejCpRYJiLWfv3OXl
-            FqqawgTd5+y2B7rNiXT0iym6cs7pUbrZ2hubYJu2hEwov5cvQb3qow==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2aEhmRXJzditWOW43bzY2
+            Zng3aDNnR0oxM1krVzBDWFROV25RRVZXTWdRCkg1RFVzemxRazBLVGRPR0tSdDVR
+            OEh4bERzdHBZYmFnSlNMemFKQXVTQW8KLS0tIEZ5OTVjTmtiTjYxR2NnWUkxN3d5
+            VzVvMzlKT09kaHYvOVVyNlVwZkdDeWsKa7C3uc8NIs4ighFdPPB/VhxrJGgUiwP8
+            xz4DE5wmP0kCzCmiUekZnDkocCS79sa/79Y56bcQURxrj4UFmXYwmQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-13T21:58:45Z"
-    mac: ENC[AES256_GCM,data:uCYLVjWmwK1meU8RwgZLAEpXoaQzvdXxp4Vp7arWAiUIRIbdKXiQE13YLa3Yl6xAVno7qdr2EN4k92B+0zjVfHwuzOO6MQK0pA1jUzmYvC859Cvu5JaI1FtQQlaySaZYc/yJJFFKfgp4TKdxEcu9EYCK9DpFSpw5p1T8ANOxdgA=,iv:Myly3Ku5+W+JGgIORNyOnuAqfmVJVLRcHbClxvxC0Ok=,tag:PjprfK0eV2my7DB/LCe4/w==,type:str]
+    lastmodified: "2026-08-13T22:02:48Z"
+    mac: ENC[AES256_GCM,data:ydq4pSgAyrpkysRbY7mNu8kWbho+lxrQHOLVWXy6z3p705IkOx7NMMg3QYYouua/wdTwjb1qbbWIOHq/4bkQmAMOjEwH4WMQ3yD5KY/zBDWiiunqvSPeaX3zSl1L/WUbkwu9DYbBrmM6bna6vuJZl2AfegxoQvZy3qIWkrBMd7o=,iv:mOkqaaUg9K0w6IojitZekx9o+ORwEb8r+xDHRoQfnsU=,tag:rE0eDIFaP340tiqYPhBunA==,type:str]
     version: 3.13.3

--- a/kubernetes/apps/apps/ai/hindsight/hindsight-secrets.sops.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/hindsight-secrets.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hindsight-secrets
+    namespace: ai
+type: Opaque
+stringData:
+    LITELLM_API_KEY: ENC[AES256_GCM,data:A293Z/REFN2tDuw0o9XCJ5FnxVxaaRMi+OmhITHWIw==,iv:cp1BVKZRI2VKCVI7oL6hwKuwj+27WcdLGqBTNRigSi0=,tag:vUH/sloIiZ3bm66+kf8MOw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTbzBDTGlyUWJlNVl4bW8v
+            dWF0M29ESkV0SklnY3U0cUVvVWpabjRVRDJnCkNwU2tSNFZoaXhWblEzQXhCdkFO
+            d25yRjlEc0tMNEdwQ0Z0OHdjNEFrVG8KLS0tIFpSaDdCdWpxcHNpMTlQMG5SY3BU
+            TFNnbFZWNDJEaWpSWWhwNmw0OHRTNmMKd+ExQ3EUdnSkUNPbejCpRYJiLWfv3OXl
+            FqqawgTd5+y2B7rNiXT0iym6cs7pUbrZ2hubYJu2hEwov5cvQb3qow==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-13T21:58:45Z"
+    mac: ENC[AES256_GCM,data:uCYLVjWmwK1meU8RwgZLAEpXoaQzvdXxp4Vp7arWAiUIRIbdKXiQE13YLa3Yl6xAVno7qdr2EN4k92B+0zjVfHwuzOO6MQK0pA1jUzmYvC859Cvu5JaI1FtQQlaySaZYc/yJJFFKfgp4TKdxEcu9EYCK9DpFSpw5p1T8ANOxdgA=,iv:Myly3Ku5+W+JGgIORNyOnuAqfmVJVLRcHbClxvxC0Ok=,tag:PjprfK0eV2my7DB/LCe4/w==,type:str]
+    version: 3.13.3

--- a/kubernetes/apps/apps/ai/hindsight/kustomization.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/kustomization.yaml
@@ -6,4 +6,5 @@ components:
 resources:
   - cnpg-cluster.yaml
   - hindsight-db-secrets.sops.yaml
+  - hindsight-secrets.sops.yaml
   - helmrelease.yaml

--- a/kubernetes/apps/apps/ai/hindsight/kustomization.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:
   - ../../../../components/bjw-s-defaults
+  - ../../../../components/ingress/traefik-base
 resources:
   - cnpg-cluster.yaml
   - hindsight-db-secrets.sops.yaml

--- a/kubernetes/apps/apps/ai/hindsight/kustomization.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:
   - ../../../../components/bjw-s-defaults
-  - ../../../../components/ingress/traefik-base
 resources:
   - cnpg-cluster.yaml
   - hindsight-db-secrets.sops.yaml

--- a/kubernetes/apps/apps/ai/hindsight/kustomization.yaml
+++ b/kubernetes/apps/apps/ai/hindsight/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/bjw-s-defaults
+  - ../../../../components/ingress/traefik-base
+resources:
+  - cnpg-cluster.yaml
+  - hindsight-db-secrets.sops.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
@@ -299,6 +299,10 @@ spec:
                 icon: grafana.png
                 description: "Dashboards"
                 href: https://grafana.lan.${CLUSTER_DOMAIN}
+            - Hindsight:
+                icon: hindsight.png
+                description: "Agent memory dashboard"
+                href: https://hindsight.lan.${CLUSTER_DOMAIN}
             - Immich:
                 icon: immich.png
                 description: "Photo management and backup"

--- a/kubernetes/apps/production/kustomization.yaml
+++ b/kubernetes/apps/production/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
   - ../apps/media/prowlarr
   - ../apps/development/gitea
   - ../apps/ai/sillytavern
+  - ../apps/ai/hindsight
   - ../apps/ai/vane
   - ../apps/ai/litellm
   - ../apps/security/frigate


### PR DESCRIPTION
## Summary
- deploy Hindsight API, worker, and Control Plane with the existing app-template pattern
- add a VectorChord-backed CNPG database with encrypted credentials and backups
- route LLM, embeddings, and reranking through LiteLLM; add private-LAN UI/API ingresses and Homepage entry

## Validation
- kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/apps/ai/hindsight
- kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/production
- kubectl apply --dry-run=client for rendered manifests
- pre-commit run --files <changed files>
- scripts/kubeconform.sh