### PR TITLE
feat(homepage): enable native authentik oidc

### DIFF
--- a/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
@@ -61,7 +61,6 @@ spec:
       main:
         enabled: true
         annotations:
-          traefik.ingress.kubernetes.io/router.middlewares: traefik-gatekeeper-auth-chain@kubernetescrd
           external-dns.alpha.kubernetes.io/hostname: start.lan.${CLUSTER_DOMAIN}
         ingressClassName: traefik
         hosts:
@@ -508,6 +507,14 @@ spec:
     # F) - name: TZ
     #      value: '{{ .Release.Name }}'
     env:
+      - name: HOMEPAGE_AUTH_ENABLED
+        value: "true"
+      - name: HOMEPAGE_EXTERNAL_URL
+        value: "https://start.lan.${CLUSTER_DOMAIN}"
+      - name: HOMEPAGE_OIDC_ISSUER
+        value: "https://sso.${CLUSTER_DOMAIN}/application/o/homepage/"
+      - name: HOMEPAGE_OIDC_NAME
+        value: "Authentik"
       - name: HOMEPAGE_ALLOWED_HOSTS
         # This value must be set
         # ref: https://gethomepage.dev/installation/#homepage_allowed_hosts

--- a/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
+++ b/kubernetes/apps/apps/utils/homepage/helmrelease.yaml
@@ -515,6 +515,16 @@ spec:
         value: "https://sso.${CLUSTER_DOMAIN}/application/o/homepage/"
       - name: HOMEPAGE_OIDC_NAME
         value: "Authentik"
+      - name: HOMEPAGE_OIDC_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: homepage-sso-secret
+            key: CLIENT_ID
+      - name: HOMEPAGE_OIDC_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: homepage-sso-secret
+            key: CLIENT_SECRET
       - name: HOMEPAGE_ALLOWED_HOSTS
         # This value must be set
         # ref: https://gethomepage.dev/installation/#homepage_allowed_hosts

--- a/kubernetes/apps/apps/utils/homepage/homepage-secrets.sops.yaml
+++ b/kubernetes/apps/apps/utils/homepage/homepage-secrets.sops.yaml
@@ -5,23 +5,21 @@ metadata:
     namespace: utils
 type: Opaque
 stringData:
-    HOMEPAGE_VAR_WEATHER_LATITUDE: ENC[AES256_GCM,data:dr9oS97AMlUztiG4vYXVpgU=,iv:yu1zc4068OAhqpgwcxqDv/TMl/KATzdLlppD/C6dexo=,tag:cevhn7LGJ7hmn8gjYO6o9g==,type:str]
-    HOMEPAGE_VAR_WEATHER_LONGITUDE: ENC[AES256_GCM,data:lajmOASyW3a56s54lA4BJytg,iv:dPcWKvZsATxLBrpvlvX0Hm2drCACF76dwuAWHb6XqfQ=,tag:aGqG3ngKMSrowvSmJFTHSA==,type:str]
-    HOMEPAGE_AUTH_SECRET: ENC[AES256_GCM,data:KMJJvvm5yNJsMTFqiX6dIt0XEAx/2k7K4VPpNu9TuaDKWmZWKqKJweMUHp5O7LAPjJ/026QdEqnu5y+hf2B40g==,iv:AfVGLw0KXKUdAHjkCqLjFYr1ruI6oZiF3oNdTcfiyuk=,tag:Gq0869lMtbTFp45wlAI5bA==,type:str]
-    HOMEPAGE_OIDC_CLIENT_ID: ENC[AES256_GCM,data:SdLgZMpLrKqno5nxf5nkhHI0+SnnYwvUFiwX0ErLwxEz/4fuVCiAp/UA9kcDxW2z,iv:tuWYiJZer87j2oa1YJuF95ZWQdxXdsUNH+UfFof8vkc=,tag:VdoetTQDg5gY/46bfU2UDw==,type:str]
-    HOMEPAGE_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:h5oy+ZyUuoh2N5wPA0pJj78N4GHBfQZzmMrMK/VhHY2kh6MnYCTZcwIWnxNmOzSHsuEuo7za/8dJIRfnkTROcA==,iv:sNR2k8zcgQGccvgrOBBvBdjK9SNjH1h9G+pWJJ3eI1g=,tag:aMYKC9TshDMKjBOTf2YPug==,type:str]
+    HOMEPAGE_VAR_WEATHER_LATITUDE: ENC[AES256_GCM,data:DjfCY9dG3mckfnoBvKDot80=,iv:S3B9B2qAUKXv5NX6k2t3xAAEGaYmft7gXoWrGsRzWVI=,tag:AJA8oColg6fRXF/r2PkqrA==,type:str]
+    HOMEPAGE_VAR_WEATHER_LONGITUDE: ENC[AES256_GCM,data:22LGcEJyI7u7trxqzjpzEPc2,iv:YXS9/tfidb+iMfjF+wPD+7EpgrQJ+5QDKn5F2lViTfE=,tag:Gv9mlRpzno2NSMGjf4L/uw==,type:str]
+    HOMEPAGE_AUTH_SECRET: ENC[AES256_GCM,data:hNeCNKyCWspznz/X/PaN1Umfpu5eXK3xe6otxniQOTGmXN8mglRmU8sQ+ePXduux66MhuYuLuw6xg98tje43Zg==,iv:5CobJrdpLdrNCMuE8Jxkl+pE2eoHZkJxfYPfvfy1txg=,tag:ZoN/mooY7bG9+MAXjDgVjw==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlZHRRbnBkNjM1VjNYcEZn
-            SmVhU2NyRWFaYUxRQytWV3A0WTdZRGd4dTMwCkNEalY2Q25jVnlOUVJrZk0zQVJP
-            RkhpeEV1OTQyVVRQdkozY1dGSXRrVmMKLS0tIFZVNHVkQVZEYytDWTM3ZTNlS3lo
-            QWMrSHR1UzJIUUtFbFovWS9uWkxKNzQKuClJqk/UtCuanL7dI800lzGYxLXalXgA
-            OlhEIyykUwWZI+n/77TqvbmbjLTuaat96h+Rrro1IC0xMqeqjGi3tA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxSGFkbU5EdWJvYkQ4bkJx
+            aGRPSEl2b2JqeVZWMVlPZkx4UWFCZjFYZmhvCjNrYi95NXBLU3JCa3oxd1ZRSVlu
+            N3E0S1o4d05rU2x0bEsrVDFadnFOYVEKLS0tIC9sR2FmL0RONXcrQnk3dGNIemVP
+            aHgrOWFqaHJta25abE1HZEVmWWsyb3MKaRQek0suuiXL4wgXVQYQ6k0AFqCPa8wn
+            Ae+UdyjvKiJMpOnHd5zulpziziizjEuy9nTR3nCDuDLm+uIR16BNhg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-15T13:31:37Z"
-    mac: ENC[AES256_GCM,data:S+CLhtx0fShbyVhv5mALtdDh/G3WGVDHdOhQmtsB3kDRd+u395A55hquAm3TVcF3aVbdFW2eZzvszqbesCc6PfEk44Y+4xXGxdNBNWOxSGDzEIePJyjXLbx5SQN4KD9YVqFpGSXlwD6+rsmEU/uJWEr9os65BRC0hzkPxcXfs0A=,iv:iBNNREe7OszqSuVRuBNSz26AaM/U7oSxnP7KoInJTkI=,tag:+ZFZhEDWBSaM+o7o1thcPA==,type:str]
+    lastmodified: "2026-08-15T13:42:54Z"
+    mac: ENC[AES256_GCM,data:T7eJzhIz1wMA2YMZImgkvjZXlArUBzvtKmNIr2Jj3aOz9Ue2B9uSc/J8mk4S3LPS1o60+uMOBh+vN9orvpFFYVs2RhNbRWoqdArc4rsuevoihGWWTJq8QbCnvbG6OTHPd/ajsCjRCxI6N6eljbkq8CgVg93hst1rSZn+tC4lt/w=,iv:pgdMH05DhnOP5Ximn613ZMdbzmFesU9dfugjenmUO4A=,tag:3gQPXK466xKbND4GkYWf3w==,type:str]
     version: 3.13.3

--- a/kubernetes/apps/apps/utils/homepage/homepage-secrets.sops.yaml
+++ b/kubernetes/apps/apps/utils/homepage/homepage-secrets.sops.yaml
@@ -5,20 +5,23 @@ metadata:
     namespace: utils
 type: Opaque
 stringData:
-    HOMEPAGE_VAR_WEATHER_LATITUDE: ENC[AES256_GCM,data:X+me4v5Q4HEwKYCA+Ln7Zhc=,iv:ws7qTXiv4feJMWWg3QjGrc1M7NnUNS0BgBA8VlZUUdg=,tag:5w4jn10KCOSiiaenPN52zg==,type:str]
-    HOMEPAGE_VAR_WEATHER_LONGITUDE: ENC[AES256_GCM,data:0VdFJ9X0umfJRW9C48rVUHfS,iv:9d9FI9vaFtI31x0WW6KLyJ/YzqPxtQgJWm+5RkNLd3I=,tag:Wjk3RP0i4XBWcoFd+H6cQg==,type:str]
+    HOMEPAGE_VAR_WEATHER_LATITUDE: ENC[AES256_GCM,data:dr9oS97AMlUztiG4vYXVpgU=,iv:yu1zc4068OAhqpgwcxqDv/TMl/KATzdLlppD/C6dexo=,tag:cevhn7LGJ7hmn8gjYO6o9g==,type:str]
+    HOMEPAGE_VAR_WEATHER_LONGITUDE: ENC[AES256_GCM,data:lajmOASyW3a56s54lA4BJytg,iv:dPcWKvZsATxLBrpvlvX0Hm2drCACF76dwuAWHb6XqfQ=,tag:aGqG3ngKMSrowvSmJFTHSA==,type:str]
+    HOMEPAGE_AUTH_SECRET: ENC[AES256_GCM,data:KMJJvvm5yNJsMTFqiX6dIt0XEAx/2k7K4VPpNu9TuaDKWmZWKqKJweMUHp5O7LAPjJ/026QdEqnu5y+hf2B40g==,iv:AfVGLw0KXKUdAHjkCqLjFYr1ruI6oZiF3oNdTcfiyuk=,tag:Gq0869lMtbTFp45wlAI5bA==,type:str]
+    HOMEPAGE_OIDC_CLIENT_ID: ENC[AES256_GCM,data:SdLgZMpLrKqno5nxf5nkhHI0+SnnYwvUFiwX0ErLwxEz/4fuVCiAp/UA9kcDxW2z,iv:tuWYiJZer87j2oa1YJuF95ZWQdxXdsUNH+UfFof8vkc=,tag:VdoetTQDg5gY/46bfU2UDw==,type:str]
+    HOMEPAGE_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:h5oy+ZyUuoh2N5wPA0pJj78N4GHBfQZzmMrMK/VhHY2kh6MnYCTZcwIWnxNmOzSHsuEuo7za/8dJIRfnkTROcA==,iv:sNR2k8zcgQGccvgrOBBvBdjK9SNjH1h9G+pWJJ3eI1g=,tag:aMYKC9TshDMKjBOTf2YPug==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNW9QUEUwL1BDWUROWWVW
-            S1dHR3pkN0VhWU9relI0TWFYOVhnSVhmbGxBCmNPQzNHaC85ZnNrdm9iWHRTQkF0
-            NkJnSk1RaFVuck5kZ1FXaTU4aWhiRjAKLS0tIENTVFVZVmlTWmgxenBvMEVnTlFT
-            aFFHZzdNTjV5d3ZsUlM0ZDh5ZGlPbHMKHSIfwkjH0/LB9pDrDm58pqCwft1zQJGE
-            +YtIjRbOkMh8FCGnsm2xb3utkcZKr6HOr8Ah7LApkgPoW0KaAoYaZw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlZHRRbnBkNjM1VjNYcEZn
+            SmVhU2NyRWFaYUxRQytWV3A0WTdZRGd4dTMwCkNEalY2Q25jVnlOUVJrZk0zQVJP
+            RkhpeEV1OTQyVVRQdkozY1dGSXRrVmMKLS0tIFZVNHVkQVZEYytDWTM3ZTNlS3lo
+            QWMrSHR1UzJIUUtFbFovWS9uWkxKNzQKuClJqk/UtCuanL7dI800lzGYxLXalXgA
+            OlhEIyykUwWZI+n/77TqvbmbjLTuaat96h+Rrro1IC0xMqeqjGi3tA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-07T12:22:18Z"
-    mac: ENC[AES256_GCM,data:Ip/JEx80HS7jCoDlh0kVEnsDItQApqOyQyyBq1F9xllF4UX61BDIG00kRNrHFapV1i52zbYRxmmcXi3VZ4RvN4AeVz5hyVWH67nAgwEfuzQsogk0yFVovI7+WvneTTH0mfEcLP7W3V0i6PHYg5QXqu4yHrGrEzsFPi8F1cuzQa4=,iv:cP6VanOknXKfFcxKy+7qJhzPMz0Ey3e7G0LRH+f97LU=,tag:tpeIE7yE/vNsHRl38693Dw==,type:str]
+    lastmodified: "2026-08-15T13:31:37Z"
+    mac: ENC[AES256_GCM,data:S+CLhtx0fShbyVhv5mALtdDh/G3WGVDHdOhQmtsB3kDRd+u395A55hquAm3TVcF3aVbdFW2eZzvszqbesCc6PfEk44Y+4xXGxdNBNWOxSGDzEIePJyjXLbx5SQN4KD9YVqFpGSXlwD6+rsmEU/uJWEr9os65BRC0hzkPxcXfs0A=,iv:iBNNREe7OszqSuVRuBNSz26AaM/U7oSxnP7KoInJTkI=,tag:+ZFZhEDWBSaM+o7o1thcPA==,type:str]
     version: 3.13.3

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -963,7 +963,7 @@ data:
           slug: "homepage"
         attrs:
           name: "Homepage"
-          icon: "https://assets.web.lainternetdelpantano.${CLUSTER_DOMAIN}/icons/homepage.svg"
+          icon: "https://assets.web.${CLUSTER_DOMAIN}/icons/homepage.svg"
           provider: !KeyOf homepage-provider
           group: "Kubernetes"
 

--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -914,6 +914,67 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, "Karakeep Users"]]
 
+  257-homepage.yaml: |
+    version: 1
+    metadata:
+      name: homepage-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      # Homepage Users group
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: "Homepage Users"
+        attrs:
+          is_superuser: false
+          parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_BLUEPRINT_USERNAME]]
+
+      # OAuth2 Provider for Homepage
+      - model: authentik_providers_oauth2.oauth2provider
+        id: homepage-provider
+        identifiers:
+          name: "Homepage"
+        attrs:
+          client_id: !Env HOMEPAGE_CLIENT_ID
+          client_secret: !Env HOMEPAGE_CLIENT_SECRET
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          jwt_algorithm: RS256
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          encryption_key: null
+          client_type: confidential
+          grant_types:
+            - authorization_code
+          client_authentication_method: client_secret_basic
+          redirect_uris:
+            - url: "https://start.lan.${CLUSTER_DOMAIN}/api/auth/callback/homepage-oidc"
+              matching_mode: strict
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+
+      # Homepage Application
+      - model: authentik_core.application
+        identifiers:
+          slug: "homepage"
+        attrs:
+          name: "Homepage"
+          icon: "https://assets.web.lainternetdelpantano.${CLUSTER_DOMAIN}/icons/homepage.svg"
+          provider: !KeyOf homepage-provider
+          group: "Kubernetes"
+
+      # Restrict access to Homepage Users
+      - model: authentik_policies.policybinding
+        identifiers:
+          target: !Find [authentik_core.application, [slug, "homepage"]]
+          order: 0
+        attrs:
+          group: !Find [authentik_core.group, [name, "Homepage Users"]]
+
   257-scrob.yaml: |
     version: 1
     metadata:

--- a/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/helmrelease.yaml
@@ -142,6 +142,16 @@ spec:
             secretKeyRef:
               name: karakeep-sso-secret
               key: CLIENT_SECRET
+        - name: HOMEPAGE_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: homepage-sso-secret
+              key: CLIENT_ID
+        - name: HOMEPAGE_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: homepage-sso-secret
+              key: CLIENT_SECRET
         - name: NEXTCLOUD_CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/kubernetes/infrastructure/security/authentik/install/homepage-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/homepage-sso-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: homepage-sso-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    CLIENT_ID: ENC[AES256_GCM,data:fYud9X+ezuwV6s3ALRH05tAQrnLcoWfph5RlASaHRemAZrEnSUz05B4cBJXggXZg,iv:H0En6JtvgYQlENgKhGYoJWnR6PoskBfqINKni3KVbpA=,tag:/DfRLpTZu5Ou3lxHc65jew==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:g1V/sCYi4SyZDY9//D659niKjtPvBK2lM0VY6sgBp6yeQUzNABbsvNLJJniLNhWFShsl8+bThIWke3NqzUP3tQ==,iv:w3s7aRFC05419NbQ1hP9SrzqvoUkNO7oiKjygMjfvt4=,tag:EfDSCiaUNA3TxcA85WpJFA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmQlBmZHI4cUdZcmpWWnpH
+            bGU2S1k4VFNkK3VxK1FtdVI5TlZOV1ZJekNrCkhEV3RMQmlkUGhycjB2c2RzckhN
+            WHo1dWxseGRrWEcvRStXVU1OQTArYjgKLS0tIGtyTHhRYXFOTjVESFNBUVk4L1hU
+            Qm5MM0U1bk41T1U3bm9CdmxHV1VYdVEKh5Zx6DyjFPsT+mcrM7Y6vn3s8DTsCVas
+            FygOwTLcZdfLVF3D5BiV67q1r4ElBcdy+imRrIzVWD6+RfjxluhaYw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-15T13:31:37Z"
+    mac: ENC[AES256_GCM,data:Vl2V81ZI4lD2lOlhbaltxAN9zGUyFICqU07TL0aftj1pbtWCqJIiNu7OZNggK+2FNI+gL2/OxPHWceQYMn6HEbQOL8+oLwabSMF61rKYIfukBm1EyMmyNHF8IRMJ7JzIAqCVoyP48/6ijITsbrCmUkfMCKdPx2XuryJ9z5G23uU=,iv:UQfvlA7n4up+HNiGz5nTSZGhZYGGO1tc4cGNSQrsepI=,tag:4B1Ru/VvQDR8RxZFAwmZjQ==,type:str]
+    version: 3.13.3

--- a/kubernetes/infrastructure/security/authentik/install/homepage-sso-secret.sops.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/homepage-sso-secret.sops.yaml
@@ -3,22 +3,24 @@ kind: Secret
 metadata:
     name: homepage-sso-secret
     namespace: authentik
+    annotations:
+        replicator.v1.mittwald.de/replicate-to: utils
 type: Opaque
 stringData:
-    CLIENT_ID: ENC[AES256_GCM,data:fYud9X+ezuwV6s3ALRH05tAQrnLcoWfph5RlASaHRemAZrEnSUz05B4cBJXggXZg,iv:H0En6JtvgYQlENgKhGYoJWnR6PoskBfqINKni3KVbpA=,tag:/DfRLpTZu5Ou3lxHc65jew==,type:str]
-    CLIENT_SECRET: ENC[AES256_GCM,data:g1V/sCYi4SyZDY9//D659niKjtPvBK2lM0VY6sgBp6yeQUzNABbsvNLJJniLNhWFShsl8+bThIWke3NqzUP3tQ==,iv:w3s7aRFC05419NbQ1hP9SrzqvoUkNO7oiKjygMjfvt4=,tag:EfDSCiaUNA3TxcA85WpJFA==,type:str]
+    CLIENT_ID: ENC[AES256_GCM,data:a1DAH+MYkfcNj2c7icEY2OaT67RASKxn4uepV7W+m5X15Yr1FLW+/yct4Eb4hJ4M,iv:Ol7C5fu10j/ZHqeDlRZfCW3fbkfNismYgU/cGbnKUro=,tag:2wiS48hekaZsLyEQetknsg==,type:str]
+    CLIENT_SECRET: ENC[AES256_GCM,data:b0xYrxIBuSy2C8/oWPIQ9AQnADUfiBYwV1W3O1aN8rZa1vlGLzDJeDsknH992FvJc+zkDX/+MQlqhCxUUlEtHg==,iv:NWpALWdUJbPEFGM0hLmZnTKJYUOWB+K35Rp81EYlgeU=,tag:8qTgGPdaOzl31o/lzRMNaw==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmQlBmZHI4cUdZcmpWWnpH
-            bGU2S1k4VFNkK3VxK1FtdVI5TlZOV1ZJekNrCkhEV3RMQmlkUGhycjB2c2RzckhN
-            WHo1dWxseGRrWEcvRStXVU1OQTArYjgKLS0tIGtyTHhRYXFOTjVESFNBUVk4L1hU
-            Qm5MM0U1bk41T1U3bm9CdmxHV1VYdVEKh5Zx6DyjFPsT+mcrM7Y6vn3s8DTsCVas
-            FygOwTLcZdfLVF3D5BiV67q1r4ElBcdy+imRrIzVWD6+RfjxluhaYw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSRDY3THhSUWVvKzhyNmRH
+            MzB2NVNscXhlQmJUSkFHWjhBdXdiWnU1UUdzClRWNU5DbzU2Q3lURm9Wd04zcVE5
+            dVJVM2tCajI3QnJDdW1pY0pENVpBZzgKLS0tIHBzYi82eFIzN2xWaFZtWUQwd2Nw
+            MlFTWnZRN0hyV2FJcGhBRS9seXNyV3MKHG68/V+1f6NZ2zuF1Ol0aLLxCm4ainPe
+            feFNl/NJAnCeRp/JMUZ0UpPa1CE2MRXupmcnQVacZBhHSPh3qQVyOA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ejjf4e7dnkc0tmwmyuyr9k5cl8sz9g0rpj4gnywk26x56jut6ygqph0x4h
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-15T13:31:37Z"
-    mac: ENC[AES256_GCM,data:Vl2V81ZI4lD2lOlhbaltxAN9zGUyFICqU07TL0aftj1pbtWCqJIiNu7OZNggK+2FNI+gL2/OxPHWceQYMn6HEbQOL8+oLwabSMF61rKYIfukBm1EyMmyNHF8IRMJ7JzIAqCVoyP48/6ijITsbrCmUkfMCKdPx2XuryJ9z5G23uU=,iv:UQfvlA7n4up+HNiGz5nTSZGhZYGGO1tc4cGNSQrsepI=,tag:4B1Ru/VvQDR8RxZFAwmZjQ==,type:str]
+    lastmodified: "2026-08-15T13:43:39Z"
+    mac: ENC[AES256_GCM,data:Kbas2WJSGQ9GcAQ87B1yoRn6rfjYYl2zBQzwqT2e0Dez0vHRqezr7KJFOIR9Dk31r/mw4+eWZySjqAyRTIl2ZdPkdd8dnmRp+QpBJCpmqPsoyJTNTs9hs3XhnRwaPwDgTrPRhaYESM9ij1bZzaZB/0VkOQSGXlEqAau6M6E9bfU=,iv:/P6oe05xPWA9tUbioe9SWhrJiNPGY874NdyopgrQ6zw=,tag:SV7Kn/QhSmcVO0jrr1PNKQ==,type:str]
     version: 3.13.3

--- a/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
   - proxmox-backup-sso-secret.sops.yaml
   - home-assistant-sso-secret.sops.yaml
   - hermes-sso-secret.sops.yaml
+  - homepage-sso-secret.sops.yaml
   - discord-auth-secret.sops.yaml
   - kopia-auth-secret.sops.yaml
   - llama-auth-secret.sops.yaml


### PR DESCRIPTION
## Summary
- enable Homepage built-in OIDC against Authentik
- restrict the Homepage Authentik application to Homepage Users
- remove Homepage from the generic Traefik gatekeeper chain

## Validation
- kubectl kustomize for Homepage and Authentik infrastructure
- pre-commit run --files (including kubeconform and Checkov)
- verified encrypted OIDC credentials match between Homepage and Authentik