### PR TITLE
feat(authentik): add second user to Jellyfin Users group

### DIFF
--- a/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
+++ b/kubernetes/infrastructure/security/authentik/install/blueprint-bootstrap-cm.yaml
@@ -1169,6 +1169,8 @@ data:
         attrs:
           is_superuser: false
           parent: null
+          users:
+            - !Find [authentik_core.user, [username, !Env AK_USER2_USERNAME]]
 
   261-proxmox.yaml: |
     version: 1


### PR DESCRIPTION
## What
Adds `AK_USER2_USERNAME` to the **Jellyfin Users** group in the `260-jellyfin.yaml` Authentik blueprint (`blueprint-bootstrap-cm.yaml`).

## Why
The second user (created via `AK_USER2_*` env vars in `authentik-env.sops.yaml`, PR #988) already has access to Home Assistant via `home-assistant-users`. This grants the same user Jellyfin access, mirroring the established pattern.

## Notes
- No SOPS changes needed — `AK_USER2_USERNAME` env var already exists and is already consumed by the blueprint user-creation entry.
- `Jellyfin Users` previously had no `users:` key; first apply sets membership to `[AK_USER2]` (replace semantics, no existing members affected).
- Validated: `kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/infrastructure/security/authentik/install` ✅, YAML parse ✅, pattern matched to `home-assistant-users` group.

🤖 Generated with OpenCode (gpt-5.6-terra) + [Hermes Agent](https://hermes-agent.nousresearch.com)