### PR TITLE
feat(ansible): manage Hermes profile gateway services

### DIFF
--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -38,6 +38,18 @@ hermes_service_name: hermes-gateway
 hermes_service_enabled: true
 hermes_service_state: started
 
+# Reusable gateway unit template inputs; named-profile units override these
+# per profile with the profile HERMES_HOME, no environment file, and the
+# profile name. The default unit renders the values above.
+hermes_gateway_home: "{{ hermes_native_home }}"
+hermes_gateway_environment_file: "{{ hermes_environment_file }}"
+hermes_gateway_profile_name: ""
+
+# Named gateway profiles: one per direct child directory of this path, each
+# rendered as a disabled hermes-gateway-<profile>.service unit.
+hermes_profiles_path: "{{ hermes_native_home }}/profiles"
+hermes_profile_gateway_service_prefix: "{{ hermes_service_name }}-"
+
 # System-level Hermes dashboard service.
 hermes_dashboard_service_name: hermes-dashboard
 hermes_dashboard_service_enabled: true

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -135,6 +135,96 @@
     daemon_reload: true
   when: not ansible_check_mode
 
+- name: Inspect named Hermes profiles directory
+  ansible.builtin.stat:
+    path: "{{ hermes_profiles_path }}"
+  register: hermes_profiles_directory
+
+- name: Find named Hermes profiles
+  ansible.builtin.find:
+    paths: "{{ hermes_profiles_path }}"
+    file_type: directory
+    recurse: false
+  register: hermes_profile_directories
+  when: hermes_profiles_directory.stat.isdir | default(false)
+
+- name: Install named Hermes gateway systemd units
+  ansible.builtin.template:
+    src: hermes-gateway.service.j2
+    dest: >-
+      /etc/systemd/system/{{ hermes_profile_gateway_service_prefix }}{{ item.path | basename }}.service
+    owner: root
+    group: root
+    mode: "0644"
+  vars:
+    hermes_gateway_home: "{{ item.path }}"
+    hermes_gateway_environment_file: ""
+    hermes_gateway_profile_name: "{{ item.path | basename }}"
+  loop: "{{ hermes_profile_directories.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  when: hermes_profiles_directory.stat.isdir | default(false)
+
+- name: Disable named Hermes gateway services at boot
+  ansible.builtin.systemd_service:
+    name: "{{ hermes_profile_gateway_service_prefix }}{{ item.path | basename }}"
+    enabled: false
+    daemon_reload: true
+  loop: "{{ hermes_profile_directories.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  when:
+    - not ansible_check_mode
+    - hermes_profiles_directory.stat.isdir | default(false)
+
+- name: Find installed named Hermes gateway systemd units
+  ansible.builtin.find:
+    paths: /etc/systemd/system
+    patterns: "{{ hermes_profile_gateway_service_prefix }}*.service"
+    file_type: file
+    recurse: false
+  register: hermes_profile_gateway_unit_files
+
+- name: Record active Hermes profile names
+  ansible.builtin.set_fact:
+    hermes_profile_names: >-
+      {{ hermes_profile_directories.files | default([]) | map(attribute='path') | map('basename') | list }}
+
+- name: Stop and disable stale named Hermes gateway services
+  ansible.builtin.systemd_service:
+    name: "{{ item.path | basename }}"
+    state: stopped
+    enabled: false
+  loop: "{{ hermes_profile_gateway_unit_files.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  when:
+    - not ansible_check_mode
+    - >-
+      (item.path | basename
+      | regex_replace('^' ~ hermes_profile_gateway_service_prefix, '')
+      | regex_replace('\.service$', '')) not in hermes_profile_names
+
+- name: Remove stale named Hermes gateway systemd units
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ hermes_profile_gateway_unit_files.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  register: hermes_stale_profile_gateway_unit_removal
+  when: >-
+    (item.path | basename
+    | regex_replace('^' ~ hermes_profile_gateway_service_prefix, '')
+    | regex_replace('\.service$', '')) not in hermes_profile_names
+
+- name: Reload systemd after pruning stale named Hermes gateway units
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  when:
+    - not ansible_check_mode
+    - hermes_stale_profile_gateway_unit_removal is changed
+
 - name: Inspect legacy Hermes serve systemd unit
   ansible.builtin.stat:
     path: /etc/systemd/system/hermes-serve.service

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -148,6 +148,10 @@
   register: hermes_profile_directories
   when: hermes_profiles_directory.stat.isdir | default(false)
 
+- name: Gather named Hermes gateway service facts
+  ansible.builtin.service_facts:
+  when: hermes_profiles_directory.stat.isdir | default(false)
+
 - name: Install named Hermes gateway systemd units
   ansible.builtin.template:
     src: hermes-gateway.service.j2
@@ -161,6 +165,7 @@
     hermes_gateway_environment_file: ""
     hermes_gateway_profile_name: "{{ item.path | basename }}"
   loop: "{{ hermes_profile_directories.files | default([]) }}"
+  register: hermes_profile_gateway_units
   loop_control:
     label: "{{ item.path | basename }}"
   when: hermes_profiles_directory.stat.isdir | default(false)
@@ -176,6 +181,22 @@
   when:
     - not ansible_check_mode
     - hermes_profiles_directory.stat.isdir | default(false)
+
+- name: Restart changed running named Hermes gateway services
+  ansible.builtin.systemd_service:
+    name: "{{ hermes_profile_gateway_service_prefix }}{{ item.item.path | basename }}"
+    state: restarted
+    daemon_reload: true
+  loop: "{{ hermes_profile_gateway_units.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.path | basename }}"
+  when:
+    - not ansible_check_mode
+    - item.changed
+    - >-
+      (ansible_facts.services | default({})).get(
+      hermes_profile_gateway_service_prefix ~ (item.item.path | basename) ~ '.service', {}
+      ).state | default('stopped') == 'running'
 
 - name: Find installed named Hermes gateway systemd units
   ansible.builtin.find:

--- a/ansible/roles/hermes/templates/hermes-gateway.service.j2
+++ b/ansible/roles/hermes/templates/hermes-gateway.service.j2
@@ -8,9 +8,11 @@ Type=simple
 User={{ hermes_user_name }}
 Group={{ hermes_user_name }}
 Environment=HOME={{ hermes_user_home }}
-Environment=HERMES_HOME={{ hermes_native_home }}
-EnvironmentFile=-{{ hermes_environment_file }}
-ExecStart={{ hermes_binary_path }} gateway run
+Environment=HERMES_HOME={{ hermes_gateway_home }}
+{% if hermes_gateway_environment_file -%}
+EnvironmentFile=-{{ hermes_gateway_environment_file }}
+{% endif -%}
+ExecStart={{ hermes_binary_path }}{% if hermes_gateway_profile_name %} --profile {{ hermes_gateway_profile_name }}{% endif %} gateway run
 Restart=on-failure
 RestartSec=5s
 


### PR DESCRIPTION
## Summary
- install disabled gateway units for each direct Hermes profile home
- isolate profile runtime configuration from the default environment file
- prune stale profile gateway units

## Validation
- `pre-commit run --files ansible/roles/hermes/defaults/main.yml ansible/roles/hermes/tasks/main.yml ansible/roles/hermes/templates/hermes-gateway.service.j2`
- `ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook ansible/playbooks/hermes.yml --syntax-check`